### PR TITLE
perf: 升级spring + springboot + spring cloud 框架版本 #1701

### DIFF
--- a/src/backend/build.gradle
+++ b/src/backend/build.gradle
@@ -115,8 +115,10 @@ ext {
     set('cronUtilsVersion', "9.1.6")
     set('otelJdbcVersion', "1.22.0-alpha")
     set('commonsValidatorVersion', "1.6")
-    set('okHttpVersion', "4.9.0")
+    set('okHttpVersion', "4.9.1")
     set('jcommanderVersion', "1.71")
+    set('kubernetesJavaClientVersion', "11.0.4")
+    set('springCloudKubernetesVersion', "2.0.6")
     if (System.getProperty("bkjobVersion")) {
         set('bkjobVersion', System.getProperty("bkjobVersion"))
         println "bkjobVersion:" + bkjobVersion
@@ -216,6 +218,19 @@ subprojects {
                 mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
                 mavenBom "org.springframework.cloud:spring-cloud-sleuth-otel-dependencies:${springCloudOtelVersion}"
             }
+            // 由于spring cloud (2021.0.5)的 kubernetes 组件在特性版本jdk(8u252）下会出现不兼容（http2协议)，并且由于历史原因jdk版本无法升级，所以把spring cloud kubernetes 降低版本
+            dependency "org.springframework.cloud:spring-cloud-kubernetes-client-autoconfig:$springCloudKubernetesVersion"
+            dependency "org.springframework.cloud:spring-cloud-kubernetes-client-config:$springCloudKubernetesVersion"
+            dependency "org.springframework.cloud:spring-cloud-kubernetes-client-discovery:$springCloudKubernetesVersion"
+            dependency "org.springframework.cloud:spring-cloud-kubernetes-client-loadbalancer:$springCloudKubernetesVersion"
+            dependency "org.springframework.cloud:spring-cloud-kubernetes-commons:$springCloudKubernetesVersion"
+            dependency "io.kubernetes:client-java:$kubernetesJavaClientVersion"
+            dependency "io.kubernetes:client-java-api:$kubernetesJavaClientVersion"
+            dependency "io.kubernetes:client-java-api-fluent:$kubernetesJavaClientVersion"
+            dependency "io.kubernetes:client-java-extended:$kubernetesJavaClientVersion"
+            dependency "io.kubernetes:client-java-proto:$kubernetesJavaClientVersion"
+            dependency "io.kubernetes:client-java-spring-integration:$kubernetesJavaClientVersion"
+
             dependency "org.junit.jupiter:junit-jupiter:$junitVersion"
             dependency "org.springframework.boot:spring-boot-starter-web:$springBootVersion"
             dependency "org.springframework.boot:spring-boot-starter-jdbc:$springBootVersion"

--- a/src/backend/commons/common-k8s/build.gradle
+++ b/src/backend/commons/common-k8s/build.gradle
@@ -25,6 +25,5 @@
 dependencies {
     api project(':commons:common-discovery')
     api 'org.apache.httpcomponents:httpcore'
-    api 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-all'
-    api 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-loadbalancer'
+    api "org.springframework.cloud:spring-cloud-starter-kubernetes-client-all"
 }

--- a/src/backend/commons/common-service/build.gradle
+++ b/src/backend/commons/common-service/build.gradle
@@ -42,7 +42,6 @@ dependencies {
         println("Compile with kubernetes mode")
         api project(":commons:common-k8s")
         api 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-all'
-        api 'org.springframework.cloud:spring-cloud-starter-kubernetes-client-loadbalancer'
     } else {
         api project(":commons:common-consul")
         api 'org.springframework.cloud:spring-cloud-starter-config'

--- a/support-files/kubernetes/charts/bk-job/templates/config-watch/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/config-watch/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             - name: spring.profiles.active
               value: bus-amqp
             - name: logging.level.org.springframework.cloud.kubernetes
-              value: DEBUG
+              value: INFO
             - name: spring.rabbitmq.host
               value: {{ include "job.rabbitmq.host" . }}
             - name: spring.rabbitmq.port

--- a/support-files/kubernetes/images/backend/backend.Dockerfile
+++ b/support-files/kubernetes/images/backend/backend.Dockerfile
@@ -1,4 +1,4 @@
-FROM bkjob/jdk:0.0.1
+FROM bkjob/jdk:0.0.2
 
 LABEL maintainer="Tencent BlueKing Job"
 

--- a/support-files/kubernetes/images/backend/jdk.Dockerfile
+++ b/support-files/kubernetes/images/backend/jdk.Dockerfile
@@ -5,9 +5,9 @@ LABEL maintainer="Tencent BlueKing Job"
 ## 安装JDK
 RUN mkdir -p /data && \
     cd /data/ &&\
-    curl -OL https://github.com/Tencent/TencentKona-8/releases/download/8.0.13-GA/TencentKona8.0.13.b1_jdk_linux-x86_64_8u362.tar.gz &&\
-    tar -xzf TencentKona8.0.13.b1_jdk_linux-x86_64_8u362.tar.gz &&\
-    rm -f TencentKona8.0.13.b1_jdk_linux-x86_64_8u362.tar.gz
-ENV JAVA_HOME=/data/TencentKona-8.0.13-362
+    curl -OL https://github.com/Tencent/TencentKona-8/releases/download/8.0.3-GA/TencentKona8.0.3.b2_jdk_linux-x86_64_8u262.tar.gz &&\
+    tar -xzf TencentKona8.0.3.b2_jdk_linux-x86_64_8u262.tar.gz &&\
+    rm -f TencentKona8.0.3.b2_jdk_linux-x86_64_8u262.tar.gz
+ENV JAVA_HOME=/data/TencentKona-8.0.3-262
 ENV PATH=${JAVA_HOME}/bin:$PATH
 ENV CLASSPATH=.:${JAVA_HOME}/lib


### PR DESCRIPTION
1. 问题: https://github.com/kubernetes-client/java/issues/2306
2. 解决方案：由于konajdk因为历史原因无法升级（跟GSE依赖), 所以只能临时降低spring cloud kubernetes 的版本，其他组件维持不变。