### PR TITLE
bugfix: 去除k8s负载中重复定义的环境变量 #1828

### DIFF
--- a/support-files/kubernetes/charts/bk-job/templates/job-file-worker/statefulset.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-file-worker/statefulset.yaml
@@ -80,10 +80,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
-            - name: BK_JOB_POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
             - name: BK_JOB_FILE_WORKER_SERVICE_NAME
               value: "job-file-worker-headless"
             - name: JOB_APPLICATION_CONFIGMAP_NAME


### PR DESCRIPTION
已检查所有负载，就job-file-worker statefulset中存在，已处理。