### PR TITLE
bugfix: 文件任务分发，页面上执行成功，但是实际上文件并没有分发到目标机器 #1867

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/FileGseTaskStartCommand.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/FileGseTaskStartCommand.java
@@ -165,10 +165,10 @@ public class FileGseTaskStartCommand extends AbstractGseTaskStartCommand {
         resolveFileSource();
         // 解析文件传输的源文件, 得到List<JobFile>
         parseSrcFiles();
-        // 解析源<->目标文件映射
-        parseSrcDestFileMap();
         // 解析目标路径中的变量
         resolvedTargetPathWithVariable();
+        // 解析源<->目标文件映射
+        parseSrcDestFileMap();
         // 初始化agent任务
         initFileSourceGseAgentTasks();
         // 保存文件子任务的初始状态


### PR DESCRIPTION
缺陷原因，定位见 #1867 