### PR TITLE
perf: 打印API请求的日志，占用大量内存，导致OOM #1084

### DIFF
--- a/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/interceptor/EsbApiLogInterceptor.java
+++ b/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/interceptor/EsbApiLogInterceptor.java
@@ -27,6 +27,7 @@ package com.tencent.bk.job.common.web.interceptor;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.tencent.bk.job.common.constant.JobCommonHeaders;
+import com.tencent.bk.job.common.util.StringUtil;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import com.tencent.bk.job.common.web.model.RepeatableReadHttpServletResponse;
 import com.tencent.bk.job.common.web.model.RepeatableReadWriteHttpServletRequest;
@@ -142,8 +143,15 @@ public class EsbApiLogInterceptor extends HandlerInterceptorAdapter {
             String requestId = request.getHeader(JobCommonHeaders.BK_GATEWAY_REQUEST_ID);
             int respStatus = response.getStatus();
             long cost = System.currentTimeMillis() - startTimeInMills;
-            log.info("request-id:{}|API:{}|uri:{}|appCode:{}|username:{}|status:{}|resp:{}|cost:{}", requestId, apiName,
-                request.getRequestURI(), appCode, username, respStatus, wrapperResponse.getBodyAsText(), cost);
+            log.info("request-id:{}|API:{}|uri:{}|appCode:{}|username:{}|status:{}|resp:{}|cost:{}",
+                requestId,
+                apiName,
+                request.getRequestURI(),
+                appCode,
+                username,
+                respStatus,
+                StringUtil.substring(wrapperResponse.getBodyAsText(), 10000),
+                cost);
         } catch (Throwable e) {
             log.warn("Handle after completion fail", e);
         } finally {

--- a/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/model/RepeatableReadHttpServletResponse.java
+++ b/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/model/RepeatableReadHttpServletResponse.java
@@ -42,8 +42,8 @@ import java.nio.charset.StandardCharsets;
  * 由于HttpServletRequest的InputStream只允许读取一次，为了能够重复读取body，需要用装饰模式来包装
  */
 public class RepeatableReadHttpServletResponse extends HttpServletResponseWrapper {
-    private ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-    private HttpServletResponse response;
+    private final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    private final HttpServletResponse response;
 
     public RepeatableReadHttpServletResponse(HttpServletResponse response) {
         super(response);
@@ -71,9 +71,7 @@ public class RepeatableReadHttpServletResponse extends HttpServletResponseWrappe
 
     @Override
     public void flushBuffer() throws IOException {
-        if (byteArrayOutputStream != null) {
-            byteArrayOutputStream.flush();
-        }
+        byteArrayOutputStream.flush();
     }
 
     @Data


### PR DESCRIPTION
#1084 
response body 截断，最多支持10000字符长度