### PR TITLE
bugfix: 全局设置Linux账号默认命名规则正则表达式与描述不匹配 #1932 

### DIFF
--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/api/inner/impl/ServiceCronJobResourceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/api/inner/impl/ServiceCronJobResourceImpl.java
@@ -43,6 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.HashMap;
@@ -115,6 +116,7 @@ public class ServiceCronJobResourceImpl implements ServiceCronJobResource {
     }
 
     @Override
+    @Transactional(rollbackFor = {Throwable.class})
     public InternalResponse<Long> saveCronJobWithId(String username, Long appId, Long cronJobId, Long createTime,
                                                     Long lastModifyTime, String lastModifyUser,
                                                     CronJobCreateUpdateReq cronJobCreateUpdateReq) {

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/inner/impl/ServiceAccountResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/inner/impl/ServiceAccountResourceImpl.java
@@ -45,6 +45,7 @@ import com.tencent.bk.job.manage.service.AccountService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
@@ -134,6 +135,7 @@ public class ServiceAccountResourceImpl implements ServiceAccountResource {
     }
 
     @Override
+    @Transactional(rollbackFor = {Throwable.class})
     public InternalResponse<ServiceAccountDTO> saveOrGetAccount(String username, Long createTime, Long lastModifyTime,
                                                                 String lastModifyUser, Long appId,
                                                                 AccountCreateUpdateReq accountCreateUpdateReq) {

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/inner/impl/ServiceScriptResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/inner/impl/ServiceScriptResourceImpl.java
@@ -41,6 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -98,10 +99,11 @@ public class ServiceScriptResourceImpl implements ServiceScriptResource {
     }
 
     @Override
+    @Transactional(rollbackFor = {Throwable.class})
     public InternalResponse<Pair<String, Long>> createScriptWithVersionId(String username, Long createTime,
-                                                                     Long lastModifyTime, String lastModifyUser,
-                                                                     Integer scriptStatus, Long appId,
-                                                                     ScriptCreateUpdateReq scriptCreateUpdateReq) {
+                                                                          Long lastModifyTime, String lastModifyUser,
+                                                                          Integer scriptStatus, Long appId,
+                                                                          ScriptCreateUpdateReq scriptCreateUpdateReq) {
         if (log.isDebugEnabled()) {
             log.debug("createScriptWithVersionId,operator={},appId={},script={},status={}", username, appId,
                 scriptCreateUpdateReq, scriptStatus);

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/inner/impl/ServiceTaskPlanResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/inner/impl/ServiceTaskPlanResourceImpl.java
@@ -67,6 +67,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
@@ -206,6 +207,7 @@ public class ServiceTaskPlanResourceImpl implements ServiceTaskPlanResource {
     }
 
     @Override
+    @Transactional(rollbackFor = {Throwable.class})
     public InternalResponse<Long> createPlanWithIdForMigration(
         String username,
         Long appId,
@@ -221,7 +223,7 @@ public class ServiceTaskPlanResourceImpl implements ServiceTaskPlanResource {
 
     @Override
     public InternalResponse<ServiceIdNameCheckDTO> checkIdAndName(Long appId, Long templateId, Long planId,
-                                                             String name) {
+                                                                  String name) {
         boolean idResult = taskPlanService.checkPlanId(planId);
         boolean nameResult = taskPlanService.checkPlanName(appId, templateId, 0L, name);
 
@@ -233,7 +235,7 @@ public class ServiceTaskPlanResourceImpl implements ServiceTaskPlanResource {
 
     @Override
     public InternalResponse<Long> savePlanForImport(String username, Long appId, Long templateId,
-                                               Long createTime, TaskPlanVO planInfo) {
+                                                    Long createTime, TaskPlanVO planInfo) {
         if (planInfo.validateForImport()) {
             TaskPlanInfoDTO taskPlanInfo = TaskPlanInfoDTO.fromVO(username, appId, planInfo);
             if (createTime != null && createTime > 0) {
@@ -248,7 +250,7 @@ public class ServiceTaskPlanResourceImpl implements ServiceTaskPlanResource {
 
     @Override
     public InternalResponse<List<ServiceTaskVariableDTO>> getPlanVariable(String username, Long appId, Long templateId,
-                                                                     Long planId) {
+                                                                          Long planId) {
         List<TaskVariableDTO> taskVariableList = taskVariableService.listVariablesByParentId(planId);
         if (CollectionUtils.isNotEmpty(taskVariableList)) {
             List<ServiceTaskVariableDTO> variableList =

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/inner/impl/ServiceTaskTemplateResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/inner/impl/ServiceTaskTemplateResourceImpl.java
@@ -54,6 +54,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Collections;
@@ -123,6 +124,7 @@ public class ServiceTaskTemplateResourceImpl implements ServiceTaskTemplateResou
     }
 
     @Override
+    @Transactional(rollbackFor = {Throwable.class})
     public InternalResponse<Long> saveTemplateForMigration(
         String username,
         Long appId,

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/GlobalSettingsServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/GlobalSettingsServiceImpl.java
@@ -298,69 +298,42 @@ public class GlobalSettingsServiceImpl implements GlobalSettingsService {
         return null;
     }
 
+    // 默认账号命名规则：Linux
+    private static final String DEFAULT_ACCOUNT_NAME_RULE_LINUX = "^[a-z_][a-z0-9_-]{1,31}$";
+    // 默认账号命名规则：Windows
+    private static final String DEFAULT_ACCOUNT_NAME_RULE_WINDOWS = "^[a-æA-Æ0-9-]{1,32}$";
+    // 默认账号命名规则：Database
+    private static final String DEFAULT_ACCOUNT_NAME_RULE_DATABASE = "^[a-zA-Z0-9\\.\\-\\_]{1,16}$";
+
+    private List<AccountNameRule> getDefaultNameRules(Locale locale) {
+        List<AccountNameRule> defaultNameRules = new ArrayList<>();
+        defaultNameRules.add(new AccountNameRule(OSTypeEnum.LINUX, DEFAULT_ACCOUNT_NAME_RULE_LINUX,
+            i18nService.getI18n("job.manage.globalsettings.defaultNameRules.description.linux",
+                locale)));
+        defaultNameRules.add(new AccountNameRule(OSTypeEnum.WINDOWS, DEFAULT_ACCOUNT_NAME_RULE_WINDOWS,
+            i18nService.getI18n("job.manage.globalsettings.defaultNameRules.description.windows",
+                locale)));
+        defaultNameRules.add(new AccountNameRule(OSTypeEnum.DATABASE, DEFAULT_ACCOUNT_NAME_RULE_DATABASE,
+            i18nService.getI18n("job.manage.globalsettings.defaultNameRules.description.database",
+                locale)));
+        return defaultNameRules;
+    }
+
     @Override
     public AccountNameRulesWithDefaultVO getAccountNameRules() {
         String normalLang = LocaleUtils.getNormalLang(JobContextUtil.getUserLang());
-        List<AccountNameRule> defaultNameRules = new ArrayList<>();
+        List<AccountNameRule> defaultNameRules;
         GlobalSettingDTO currentNameRulesDTO;
         if (normalLang.equals(LocaleUtils.LANG_EN) || normalLang.equals(LocaleUtils.LANG_EN_US)) {
             //英文环境
-            GlobalSettingDTO defaultNameRulesDTO = globalSettingDAO.getGlobalSetting(dslContext,
-                GlobalSettingKeys.KEY_DEFAULT_NAME_RULES_EN);
-            if (defaultNameRulesDTO == null) {
-                defaultNameRules.add(new AccountNameRule(OSTypeEnum.LINUX, "^[a-z_][a-z0-9_-]{2,31}$",
-                    i18nService.getI18n("job.manage.globalsettings.defaultNameRules.description.linux",
-                        Locale.ENGLISH)));
-                defaultNameRules.add(new AccountNameRule(OSTypeEnum.WINDOWS, "^[a-æA-Æ0-9-]{1,32}$",
-                    i18nService.getI18n("job.manage.globalsettings.defaultNameRules.description.windows",
-                        Locale.ENGLISH)));
-                defaultNameRules.add(new AccountNameRule(OSTypeEnum.DATABASE, "^[a-zA-Z0-9\\.\\-\\_]{1,16}$",
-                    i18nService.getI18n("job.manage.globalsettings.defaultNameRules.description.database",
-                        Locale.ENGLISH)));
-                defaultNameRulesDTO = new GlobalSettingDTO(GlobalSettingKeys.KEY_DEFAULT_NAME_RULES_EN,
-                    JsonUtils.toJson(defaultNameRules),
-                    "默认命名规则JSON串(default json-serialized name rules)");
-                currentNameRulesDTO = new GlobalSettingDTO(GlobalSettingKeys.KEY_CURRENT_NAME_RULES_EN,
-                    JsonUtils.toJson(defaultNameRules),
-                    "默认命名规则JSON串(default json-serialized name rules)");
-                globalSettingDAO.insertGlobalSetting(dslContext, defaultNameRulesDTO);
-                globalSettingDAO.insertGlobalSetting(dslContext, currentNameRulesDTO);
-            } else {
-                defaultNameRules = JsonUtils.fromJson(defaultNameRulesDTO.getValue(),
-                    new TypeReference<List<AccountNameRule>>() {
-                    });
-                currentNameRulesDTO = globalSettingDAO.getGlobalSetting(dslContext,
-                    GlobalSettingKeys.KEY_CURRENT_NAME_RULES_EN);
-            }
+            defaultNameRules = getDefaultNameRules(Locale.ENGLISH);
+            currentNameRulesDTO = globalSettingDAO.getGlobalSetting(dslContext,
+                GlobalSettingKeys.KEY_CURRENT_NAME_RULES_EN);
         } else {
             //中文环境
-            GlobalSettingDTO defaultNameRulesDTO = globalSettingDAO.getGlobalSetting(dslContext,
-                GlobalSettingKeys.KEY_DEFAULT_NAME_RULES);
-            if (defaultNameRulesDTO == null) {
-                defaultNameRules.add(new AccountNameRule(OSTypeEnum.LINUX, "^[a-z_][a-z0-9_-]{2,31}$",
-                    i18nService.getI18n("job.manage.globalsettings.defaultNameRules.description.linux",
-                        Locale.CHINA)));
-                defaultNameRules.add(new AccountNameRule(OSTypeEnum.WINDOWS, "^[a-æA-Æ0-9-]{1,32}$",
-                    i18nService.getI18n("job.manage.globalsettings.defaultNameRules.description.windows",
-                        Locale.CHINA)));
-                defaultNameRules.add(new AccountNameRule(OSTypeEnum.DATABASE, "^[a-zA-Z0-9\\.\\-\\_]{1,16}$",
-                    i18nService.getI18n("job.manage.globalsettings.defaultNameRules.description.database",
-                        Locale.CHINA)));
-                defaultNameRulesDTO = new GlobalSettingDTO(GlobalSettingKeys.KEY_DEFAULT_NAME_RULES,
-                    JsonUtils.toJson(defaultNameRules),
-                    "默认命名规则JSON串(default json-serialized name rules)");
-                currentNameRulesDTO = new GlobalSettingDTO(GlobalSettingKeys.KEY_CURRENT_NAME_RULES,
-                    JsonUtils.toJson(defaultNameRules),
-                    "默认命名规则JSON串(default json-serialized name rules)");
-                globalSettingDAO.insertGlobalSetting(dslContext, defaultNameRulesDTO);
-                globalSettingDAO.insertGlobalSetting(dslContext, currentNameRulesDTO);
-            } else {
-                defaultNameRules = JsonUtils.fromJson(defaultNameRulesDTO.getValue(),
-                    new TypeReference<List<AccountNameRule>>() {
-                    });
-                currentNameRulesDTO = globalSettingDAO.getGlobalSetting(dslContext,
-                    GlobalSettingKeys.KEY_CURRENT_NAME_RULES);
-            }
+            defaultNameRules = getDefaultNameRules(Locale.CHINA);
+            currentNameRulesDTO = globalSettingDAO.getGlobalSetting(dslContext,
+                GlobalSettingKeys.KEY_CURRENT_NAME_RULES);
         }
         List<AccountNameRule> currentNameRules;
         if (currentNameRulesDTO != null) {

--- a/support-files/sql/job-manage/0027_job_manage_20230411-1000_V3.6.3_mysql.sql
+++ b/support-files/sql/job-manage/0027_job_manage_20230411-1000_V3.6.3_mysql.sql
@@ -1,0 +1,10 @@
+USE job_manage;
+
+SET NAMES utf8mb4;
+
+BEGIN;
+
+DELETE FROM `job_manage`.`global_setting` WHERE `key`='DEFAULT_NAME_RULES';
+DELETE FROM `job_manage`.`global_setting` WHERE `key`='DEFAULT_NAME_RULES_EN';
+
+COMMIT;


### PR DESCRIPTION
[bugfix: 全局设置Linux账号默认命名规则正则表达式与描述不匹配](https://github.com/TencentBlueKing/bk-job/commit/4a3b0c885810baba45f022295c3c54e2902854cc) https://github.com/TencentBlueKing/bk-job/issues/1932
[perf: 迁移数据资源创建接口支持事务](https://github.com/TencentBlueKing/bk-job/commit/9f659bfa61deedf20ae88e93b1aa435ae7789c02) https://github.com/TencentBlueKing/bk-job/issues/1937