### PR TITLE
fix: 创建作业时源文件/目标文件路径填写变量时校验不通过 #2019

### DIFF
--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/vo/task/TaskFileSourceInfoVO.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/vo/task/TaskFileSourceInfoVO.java
@@ -25,11 +25,11 @@
 package com.tencent.bk.job.manage.model.web.vo.task;
 
 import com.tencent.bk.job.common.model.vo.TaskTargetVO;
-import com.tencent.bk.job.common.util.FilePathValidateUtil;
 import com.tencent.bk.job.common.util.JobContextUtil;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.CollectionUtils;
 
 import java.util.List;
@@ -80,8 +80,8 @@ public class TaskFileSourceInfoVO {
                     return false;
                 }
                 for (String file : fileLocation) {
-                    if (!FilePathValidateUtil.validateFileSystemAbsolutePath(file)) {
-                        JobContextUtil.addDebugMessage("fileLocation is null or illegal!");
+                    if (StringUtils.isBlank(file)) {
+                        JobContextUtil.addDebugMessage("fileLocation is null or blank!");
                         return false;
                     }
                 }

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/vo/task/TaskFileStepVO.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/vo/task/TaskFileStepVO.java
@@ -29,11 +29,11 @@ import com.tencent.bk.job.common.constant.DuplicateHandlerEnum;
 import com.tencent.bk.job.common.constant.ErrorCode;
 import com.tencent.bk.job.common.constant.NotExistPathHandlerEnum;
 import com.tencent.bk.job.common.exception.InvalidParamException;
-import com.tencent.bk.job.common.util.FilePathValidateUtil;
 import com.tencent.bk.job.common.util.JobContextUtil;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.CollectionUtils;
 
 import java.util.List;
@@ -115,8 +115,8 @@ public class TaskFileStepVO {
             JobContextUtil.addDebugMessage("Empty destination info!");
             return false;
         }
-        if (!FilePathValidateUtil.validateFileSystemAbsolutePath(fileDestination.getPath())) {
-            JobContextUtil.addDebugMessage("fileDestinationPath is null or illegal!");
+        if (StringUtils.isBlank(fileDestination.getPath())) {
+            JobContextUtil.addDebugMessage("fileDestinationPath is null or blank!");
             return false;
         }
         if (fileDestination.getAccount() == null || fileDestination.getAccount() <= 0) {

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/inner/impl/ServiceTaskTemplateResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/inner/impl/ServiceTaskTemplateResourceImpl.java
@@ -36,6 +36,7 @@ import com.tencent.bk.job.common.model.InternalResponse;
 import com.tencent.bk.job.common.model.PageData;
 import com.tencent.bk.job.common.model.dto.AppResourceScope;
 import com.tencent.bk.job.common.util.JobContextUtil;
+import com.tencent.bk.job.common.util.StringUtil;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import com.tencent.bk.job.manage.api.inner.ServiceTaskTemplateResource;
 import com.tencent.bk.job.manage.auth.TemplateAuthService;
@@ -180,7 +181,10 @@ public class ServiceTaskTemplateResourceImpl implements ServiceTaskTemplateResou
                 finalTemplateId, taskTemplateCreateUpdateReq.getName(), username);
             return InternalResponse.buildSuccessResp(finalTemplateId);
         } else {
-            throw new InvalidParamException(ErrorCode.ILLEGAL_PARAM);
+            throw new InvalidParamException(ErrorCode.ILLEGAL_PARAM_WITH_PARAM_NAME_AND_REASON, new String[]{
+                "body",
+                StringUtil.concatCollection(JobContextUtil.getDebugMessage())
+            });
         }
     }
 


### PR DESCRIPTION
1. 作业场景校验改为判空校验；
2. Service接口返回参数校验失败信息。