### PR TITLE
feat: 兼容GSE Agent 历史版本 #2008

### DIFF
--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/feature/FeatureIdConstants.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/feature/FeatureIdConstants.java
@@ -16,4 +16,9 @@ public interface FeatureIdConstants {
      * 特性-第三方文件源
      */
     String FEATURE_FILE_MANAGE = "fileManage";
+
+    /**
+     * 特性-是否支持GSE 获取文件分发任务结果的API协议(2.0版本之前)
+     */
+    String GSE_FILE_PROTOCOL_BEFORE_V2 = "gseFileProtocolBeforeV2";
 }

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v1/GseV1ApiClient.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v1/GseV1ApiClient.java
@@ -463,6 +463,7 @@ public class GseV1ApiClient implements IGseClient {
             content.setStatusInfo(fileTaskResult.getStatusDesc());
             content.setTaskId(fileTaskResult.getTaskId());
             content.setTaskType(fileTaskResult.getTaskType());
+            content.setProtocolVersion(fileTaskResult.getProtocolVersion());
             atomicFileTaskResult.setContent(content);
             atomicFileTaskResults.add(atomicFileTaskResult);
         }

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v1/model/GSEFileTaskResult.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v1/model/GSEFileTaskResult.java
@@ -228,7 +228,7 @@ public class GSEFileTaskResult {
     }
 
     public String buildTaskId(Integer mode, String sourceAgentId, String sourceFilePath, String destAgentId,
-                                     String destFilePath) {
+                              String destFilePath) {
         String taskId;
         if (FileDistModeEnum.getFileDistMode(mode) == FileDistModeEnum.DOWNLOAD) {
             taskId = concat(mode.toString(), sourceAgentId, FilePathUtils.standardizedGSEFilePath(sourceFilePath),
@@ -270,4 +270,5 @@ public class GSEFileTaskResult {
         }
         return null;
     }
+
 }

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/AtomicFileTaskResultContent.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/AtomicFileTaskResultContent.java
@@ -195,7 +195,7 @@ public class AtomicFileTaskResultContent {
     /**
      * 判断是否是协议2.0之前的版本。（该版本文件分发协议存在问题，需要兼容)
      */
-    public boolean isBeforeV2() {
+    public boolean isApiProtocolBeforeV2() {
         return this.protocolVersion == null || this.protocolVersion < 2;
     }
 }

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/AtomicFileTaskResultContent.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/model/AtomicFileTaskResultContent.java
@@ -102,6 +102,12 @@ public class AtomicFileTaskResultContent {
     @JsonProperty("end_time")
     private Long endTime;
 
+    /**
+     * GSE 协议版本(0 - 未知版本；1 - 初始版本 ; 2 - 解除valuekey依赖版本)
+     */
+    @JsonProperty("protover")
+    private Integer protocolVersion;
+
     // ------------------ 非协议字段 ----------------------
     /**
      * 用来表示文件任务ID
@@ -185,4 +191,11 @@ public class AtomicFileTaskResultContent {
         return sj.toString();
     }
 
+
+    /**
+     * 判断是否是协议2.0之前的版本。（该版本文件分发协议存在问题，需要兼容)
+     */
+    public boolean isBeforeV2() {
+        return this.protocolVersion == null || this.protocolVersion < 2;
+    }
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/FileResultHandleTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/FileResultHandleTask.java
@@ -350,27 +350,27 @@ public class FileResultHandleTask extends AbstractResultHandleTask<FileTaskResul
                     });
                 });
                 log.info("[CompatibleProtocolBeforeV2] Init destSrcMap: {}", destSrcMap);
-                String destPath = content.getStandardDestFilePath();
-                Map<String, JobFile> srcIpAndSrcFile = destSrcMap.get(destPath);
-                if (srcIpAndSrcFile == null) {
-                    log.error("[CompatibleProtocolBeforeV2] Can not get srcFile by destPath: {}. ", destPath);
-                    return;
-                }
-                String srcAgentId = content.getSourceAgentId();
-                String srcIp = IpUtils.extractIp(srcAgentId);
-                JobFile srcFile = srcIpAndSrcFile.get(srcIp);
-                if (srcFile == null) {
-                    log.error("[CompatibleProtocolBeforeV2] Can not get srcFile by destPath: {} and srcIp: {}. ",
-                        destPath, srcIp);
-                    return;
-                }
-                content.setSourceAgentId(srcFile.getHost().toCloudIp());
-                content.setSourceFileDir(srcFile.getDir());
-                content.setSourceFileName(srcFile.getFileName());
-                // 重置
-                content.setStandardSourceFilePath(null);
-                content.setTaskId(null);
             }
+            String destPath = content.getStandardDestFilePath();
+            Map<String, JobFile> srcIpAndSrcFile = destSrcMap.get(destPath);
+            if (srcIpAndSrcFile == null) {
+                log.error("[CompatibleProtocolBeforeV2] Can not get srcFile by destPath: {}. ", destPath);
+                return;
+            }
+            String srcAgentId = content.getSourceAgentId();
+            String srcIp = IpUtils.extractIp(srcAgentId);
+            JobFile srcFile = srcIpAndSrcFile.get(srcIp);
+            if (srcFile == null) {
+                log.error("[CompatibleProtocolBeforeV2] Can not get srcFile by destPath: {} and srcIp: {}. ",
+                    destPath, srcIp);
+                return;
+            }
+            content.setSourceAgentId(srcFile.getHost().toCloudIp());
+            content.setSourceFileDir(srcFile.getDir());
+            content.setSourceFileName(srcFile.getFileName());
+            // 重置
+            content.setStandardSourceFilePath(null);
+            content.setTaskId(null);
         }
     }
 

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/AppScopeMappingServiceImpl.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/AppScopeMappingServiceImpl.java
@@ -43,6 +43,7 @@ public class AppScopeMappingServiceImpl extends AbstractLocalCacheAppScopeMappin
 
     public AppScopeMappingServiceImpl(ServiceApplicationResource applicationResource) {
         this.applicationResource = applicationResource;
+        GlobalAppScopeMappingService.register(this);
     }
 
     @Override

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/GlobalAppScopeMappingService.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/GlobalAppScopeMappingService.java
@@ -1,0 +1,64 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage;
+
+import com.tencent.bk.job.common.service.AppScopeMappingService;
+import com.tencent.bk.job.common.util.ApplicationContextRegister;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class GlobalAppScopeMappingService {
+    private static AppScopeMappingService globalAppScopeMappingService;
+
+    private static final Object lock = new Object();
+
+    private GlobalAppScopeMappingService() {
+
+    }
+
+    public static AppScopeMappingService get() {
+        AppScopeMappingService service = globalAppScopeMappingService;
+        if (service == null) {
+            synchronized (lock) {
+                service = globalAppScopeMappingService;
+                if (service == null) {
+                    service =
+                        ApplicationContextRegister.getBean(AppScopeMappingService.class);
+                }
+            }
+        }
+        return service;
+    }
+
+    public static void register(AppScopeMappingService appScopeMappingService) {
+        synchronized (lock) {
+            if (globalAppScopeMappingService != null) {
+                log.info("AppScopeMappingService is alreay register");
+                return;
+            }
+            globalAppScopeMappingService = appScopeMappingService;
+        }
+    }
+}

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/GlobalAppScopeMappingService.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/GlobalAppScopeMappingService.java
@@ -30,7 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class GlobalAppScopeMappingService {
-    private static AppScopeMappingService globalAppScopeMappingService;
+    private static volatile AppScopeMappingService globalAppScopeMappingService;
 
     private static final Object lock = new Object();
 
@@ -55,7 +55,7 @@ public class GlobalAppScopeMappingService {
     public static void register(AppScopeMappingService appScopeMappingService) {
         synchronized (lock) {
             if (globalAppScopeMappingService != null) {
-                log.info("AppScopeMappingService is alreay register");
+                log.info("AppScopeMappingService is already register");
                 return;
             }
             globalAppScopeMappingService = appScopeMappingService;

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/AppScopeMappingServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/AppScopeMappingServiceImpl.java
@@ -28,6 +28,7 @@ import com.tencent.bk.job.common.constant.ErrorCode;
 import com.tencent.bk.job.common.exception.NotFoundException;
 import com.tencent.bk.job.common.model.dto.ResourceScope;
 import com.tencent.bk.job.manage.AbstractLocalCacheAppScopeMappingService;
+import com.tencent.bk.job.manage.GlobalAppScopeMappingService;
 import com.tencent.bk.job.manage.service.ApplicationService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +43,7 @@ public class AppScopeMappingServiceImpl extends AbstractLocalCacheAppScopeMappin
     @Autowired
     public AppScopeMappingServiceImpl(ApplicationService applicationService) {
         this.applicationService = applicationService;
+        GlobalAppScopeMappingService.register(this);
     }
 
     @Override


### PR DESCRIPTION
1. 兼容GSE Agent 历史版本（< 1.7.2)的文件任务结果协议
2. 支持灰度
3. 灰度功能不对外开放，仅内部使用（对外版本统一不兼容)