### PR TITLE
feat: 兼容GSE Agent 历史版本 #2008

### DIFF
--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/constants/GseConstants.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/constants/GseConstants.java
@@ -34,4 +34,9 @@ public interface GseConstants {
      * GSE API 度量指标名称前缀
      */
     String GSE_API_METRICS_NAME_PREFIX = "job.client.gse.api";
+
+    /**
+     * GSE 获取文件任务执行结果协议版本V2 - 解除valuekey依赖版本
+     */
+    int GSE_FILE_PROTOCOL_VERSION_V2 = 2;
 }


### PR DESCRIPTION
由于GSE2.0 删除了protocolVersion，会导致Job解析协议版本出问题。需要Job兼容
