### PR TITLE
fix: 错误信息超长导致定时任务启动失败时不通知 #1739

### DIFF
--- a/src/backend/build.gradle
+++ b/src/backend/build.gradle
@@ -69,7 +69,7 @@ ext {
     set("springBootVersion", "2.6.13")
     // https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-dependencies
     set('springCloudVersion', "2021.0.5")
-    set('springCloudOtelVersion', "1.1.1")
+    set('springCloudOtelVersion', "1.1.3")
     set('swaggerVersion', "3.0.0")
     set('junitVersion', "5.5.2")
     // https://mvnrepository.com/artifact/org.projectlombok/lombok
@@ -113,7 +113,7 @@ ext {
     set('bcprovVersion', "1.64")
     set('reflectionsVersion', "0.9.12")
     set('cronUtilsVersion', "9.1.6")
-    set('otelJdbcVersion', "1.22.0-alpha")
+    set('otelJdbcVersion', "1.24.0-alpha")
     set('commonsValidatorVersion', "1.6")
     set('okHttpVersion', "4.9.1")
     set('jcommanderVersion', "1.71")

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/dao/impl/CronJobHistoryDAOImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/dao/impl/CronJobHistoryDAOImpl.java
@@ -26,12 +26,17 @@ package com.tencent.bk.job.crontab.dao.impl;
 
 import com.tencent.bk.job.common.model.BaseSearchCondition;
 import com.tencent.bk.job.common.model.PageData;
+import com.tencent.bk.job.common.util.StringUtil;
 import com.tencent.bk.job.crontab.constant.ExecuteStatusEnum;
 import com.tencent.bk.job.crontab.dao.CronJobHistoryDAO;
 import com.tencent.bk.job.crontab.model.dto.CronJobHistoryDTO;
 import com.tencent.bk.job.crontab.util.DbRecordMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.jooq.*;
+import org.jooq.Condition;
+import org.jooq.DSLContext;
+import org.jooq.Record10;
+import org.jooq.Result;
+import org.jooq.SelectSeekStep1;
 import org.jooq.generated.tables.CronJobHistory;
 import org.jooq.generated.tables.records.CronJobHistoryRecord;
 import org.jooq.types.UByte;
@@ -95,8 +100,12 @@ public class CronJobHistoryDAOImpl implements CronJobHistoryDAO {
     public boolean fillErrorInfo(long historyId, long errorCode, String errorMsg) {
         List<Condition> conditions = new ArrayList<>();
         conditions.add(TABLE.ID.eq(ULong.valueOf(historyId)));
-        return 1 == context.update(TABLE).set(TABLE.ERROR_CODE, ULong.valueOf(errorCode)).set(TABLE.ERROR_MESSAGE,
-            errorMsg).where(conditions).limit(1).execute();
+        return 1 == context.update(TABLE)
+            .set(TABLE.ERROR_CODE, ULong.valueOf(errorCode))
+            .set(TABLE.ERROR_MESSAGE, StringUtil.substring(errorMsg, 255))
+            .where(conditions)
+            .limit(1)
+            .execute();
     }
 
     @Override
@@ -115,8 +124,8 @@ public class CronJobHistoryDAOImpl implements CronJobHistoryDAO {
         int length = baseSearchCondition.getLengthOrDefault(10);
         Result<Record10<ULong, ULong, ULong, UByte, ULong, ULong, ULong, String, ULong, String>> result =
             context.select(TABLE.ID, TABLE.APP_ID, TABLE.CRON_JOB_ID, TABLE.STATUS, TABLE.SCHEDULED_TIME,
-            TABLE.START_TIME, TABLE.FINISH_TIME, TABLE.EXECUTOR, TABLE.ERROR_CODE, TABLE.ERROR_MESSAGE)
-            .from(TABLE).where(conditions).orderBy(TABLE.START_TIME.desc()).limit(start, length).fetch();
+                TABLE.START_TIME, TABLE.FINISH_TIME, TABLE.EXECUTOR, TABLE.ERROR_CODE, TABLE.ERROR_MESSAGE)
+                .from(TABLE).where(conditions).orderBy(TABLE.START_TIME.desc()).limit(start, length).fetch();
 
         List<CronJobHistoryDTO> cronJobHistoryList = new ArrayList<>();
 

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/timer/executor/SimpleJobExecutor.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/timer/executor/SimpleJobExecutor.java
@@ -145,7 +145,7 @@ public class SimpleJobExecutor extends AbstractQuartzJobBean {
             cronJobHistoryService.updateStatusByIdAndTime(appId, cronJobId, scheduledFireTime,
                 ExecuteStatusEnum.RUNNING);
         } else {
-            log.error("Execute task failed!|{}|{}|{}|{}", appId, cronJobId, scheduledFireTime, executeResult);
+            log.warn("Execute task failed!|{}|{}|{}|{}", appId, cronJobId, scheduledFireTime, executeResult);
             cronJobHistoryService.updateStatusByIdAndTime(appId, cronJobId, scheduledFireTime, ExecuteStatusEnum.FAIL);
             executeFailed = true;
             if (executeResult != null) {
@@ -167,7 +167,8 @@ public class SimpleJobExecutor extends AbstractQuartzJobBean {
         if (executeFailed && isNotify(cronJobErrorInfo)) {
             notifyService.sendCronJobFailedNotification(errorCode, errorMessage, cronJobInfo);
             if (log.isDebugEnabled()) {
-                log.debug("Send cronjob failed notification, execute error count is {}", cronJobErrorInfo.getLastExecuteErrorCount());
+                log.debug("Send cronjob failed notification, execute error count is {}",
+                    cronJobErrorInfo.getLastExecuteErrorCount());
             }
         }
     }


### PR DESCRIPTION
1. 错误信息超长后截断后存储；
2. 更改错误日志级别为WARN；
3. 升级otel版本，修复其空指针问题掩盖真实异常信息。