### PR TITLE
fix: 主机Agent状态不准确 #2103

### DIFF
--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/HostSimpleDTO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/HostSimpleDTO.java
@@ -54,9 +54,9 @@ public class HostSimpleDTO {
      */
     private Long bizId;
     /**
-     * 主机Agent状态
+     * 主机Agent状态，取值参考AgentStatusEnum
      */
-    private Integer gseAgentAlive;
+    private Integer agentAliveStatus;
     /**
      * 云区域+ip
      */
@@ -113,7 +113,7 @@ public class HostSimpleDTO {
     public static List<String> buildAgentIdList(List<HostSimpleDTO> hosts) {
         List<String> agentIdList = new ArrayList<>();
         for (HostSimpleDTO host : hosts) {
-            if(StringUtils.isBlank(host.getIp()) && StringUtils.isBlank(host.getAgentId())){
+            if (StringUtils.isBlank(host.getIp()) && StringUtils.isBlank(host.getAgentId())) {
                 log.warn("buildAgentIdList, ip and agentId is blank, {}", host);
                 continue;
             }
@@ -122,13 +122,12 @@ public class HostSimpleDTO {
         return agentIdList;
     }
 
-    public ApplicationHostDTO convertToHostDTO(){
+    public ApplicationHostDTO convertToHostDTO() {
         ApplicationHostDTO hostDTO = new ApplicationHostDTO();
         hostDTO.setIp(this.getIp());
         hostDTO.setCloudAreaId(this.getCloudAreaId());
         hostDTO.setCloudIp(this.getCloudIp());
-        hostDTO.setGseAgentAlive(this.getGseAgentAlive().intValue() == 1);
-        hostDTO.setGseAgentStatus(this.getGseAgentAlive());
+        hostDTO.setGseAgentAlive(this.getAgentAliveStatus() == 1);
         hostDTO.setBizId(this.getBizId());
         hostDTO.setHostId(this.getHostId());
         hostDTO.setAgentId(this.getAgentId());

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/constants/AgentAliveStatusEnum.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/constants/AgentAliveStatusEnum.java
@@ -29,9 +29,9 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.tencent.bk.job.common.gse.v2.model.resp.AgentState;
 
 /**
- * Agent 状态
+ * Agent 正常状态
  */
-public enum AgentStatusEnum {
+public enum AgentAliveStatusEnum {
     /**
      * 异常
      */
@@ -47,21 +47,21 @@ public enum AgentStatusEnum {
     @JsonValue
     private final int status;
 
-    AgentStatusEnum(int status) {
+    AgentAliveStatusEnum(int status) {
         this.status = status;
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static AgentStatusEnum valOf(int status) {
-        for (AgentStatusEnum agentStatus : values()) {
-            if (agentStatus.status == status) {
-                return agentStatus;
+    public static AgentAliveStatusEnum valOf(int status) {
+        for (AgentAliveStatusEnum agentAliveStatus : values()) {
+            if (agentAliveStatus.status == status) {
+                return agentAliveStatus;
             }
         }
         return null;
     }
 
-    public static AgentStatusEnum fromAgentState(AgentState agentState) {
+    public static AgentAliveStatusEnum fromAgentState(AgentState agentState) {
         if (agentState == null || agentState.getStatusCode() == null) {
             return UNKNOWN;
         } else if (agentState.getStatusCode().equals(AgentStateStatusEnum.RUNNING.getValue())) {
@@ -71,11 +71,7 @@ public enum AgentStatusEnum {
         }
     }
 
-    public static boolean isAgentAlive(AgentState agentState) {
-        return fromAgentState(agentState) == ALIVE;
-    }
-
-    public int getValue() {
+    public int getStatusValue() {
         return status;
     }
 }

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/service/AgentStateClientImpl.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/service/AgentStateClientImpl.java
@@ -28,7 +28,7 @@ import com.tencent.bk.job.common.constant.ErrorCode;
 import com.tencent.bk.job.common.exception.InternalException;
 import com.tencent.bk.job.common.gse.GseClient;
 import com.tencent.bk.job.common.gse.config.AgentStateQueryConfig;
-import com.tencent.bk.job.common.gse.constants.AgentStatusEnum;
+import com.tencent.bk.job.common.gse.constants.AgentAliveStatusEnum;
 import com.tencent.bk.job.common.gse.util.AgentUtils;
 import com.tencent.bk.job.common.gse.v2.model.req.ListAgentStateReq;
 import com.tencent.bk.job.common.gse.v2.model.resp.AgentState;
@@ -156,7 +156,8 @@ public class AgentStateClientImpl implements AgentStateClient {
         for (Map.Entry<String, AgentState> entry : agentStateMap.entrySet()) {
             String agentId = entry.getKey();
             AgentState agentState = entry.getValue();
-            agentAliveStatusMap.put(agentId, AgentStatusEnum.fromAgentState(agentState) == AgentStatusEnum.ALIVE);
+            agentAliveStatusMap.put(agentId,
+                AgentAliveStatusEnum.fromAgentState(agentState) == AgentAliveStatusEnum.ALIVE);
         }
         return agentAliveStatusMap;
     }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/ApplicationHostDAO.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/ApplicationHostDAO.java
@@ -24,7 +24,6 @@
 
 package com.tencent.bk.job.manage.dao;
 
-import com.tencent.bk.job.common.gse.constants.AgentStatusEnum;
 import com.tencent.bk.job.common.model.BaseSearchCondition;
 import com.tencent.bk.job.common.model.PageData;
 import com.tencent.bk.job.common.model.dto.ApplicationHostDTO;
@@ -46,8 +45,6 @@ public interface ApplicationHostDAO {
     boolean existAppHostInfoByHostId(Long hostId);
 
     ApplicationHostDTO getHostById(Long hostId);
-
-    ApplicationHostDTO getLatestHost(long bizId, long cloudAreaId, String ip);
 
     List<ApplicationHostDTO> listHostInfoByIps(Collection<String> ips);
 
@@ -138,15 +135,6 @@ public interface ApplicationHostDAO {
                                   Collection<String> hostNameKeys,
                                   Collection<String> osNameKeys,
                                   Integer agentAlive);
-
-    /**
-     * 根据ID与Agent状态查询主机数量
-     *
-     * @param hostIds     主机Id集合
-     * @param agentStatus Agent状态
-     * @return 主机数量
-     */
-    Long countHostByIdAndStatus(Collection<Long> hostIds, AgentStatusEnum agentStatus);
 
     long countHostsByBizIds(Collection<Long> bizIds);
 

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/IndexServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/IndexServiceImpl.java
@@ -27,7 +27,7 @@ package com.tencent.bk.job.manage.service.impl;
 import com.tencent.bk.job.common.constant.ErrorCode;
 import com.tencent.bk.job.common.constant.ResourceScopeTypeEnum;
 import com.tencent.bk.job.common.exception.InternalException;
-import com.tencent.bk.job.common.gse.constants.AgentStatusEnum;
+import com.tencent.bk.job.common.gse.constants.AgentAliveStatusEnum;
 import com.tencent.bk.job.common.i18n.locale.LocaleUtils;
 import com.tencent.bk.job.common.model.PageData;
 import com.tencent.bk.job.common.model.dto.AppResourceScope;
@@ -41,7 +41,6 @@ import com.tencent.bk.job.common.util.TimeUtil;
 import com.tencent.bk.job.manage.common.TopologyHelper;
 import com.tencent.bk.job.manage.dao.ApplicationDAO;
 import com.tencent.bk.job.manage.dao.ApplicationHostDAO;
-import com.tencent.bk.job.manage.dao.HostTopoDAO;
 import com.tencent.bk.job.manage.dao.ScriptDAO;
 import com.tencent.bk.job.manage.dao.index.IndexGreetingDAO;
 import com.tencent.bk.job.manage.dao.template.TaskTemplateDAO;
@@ -73,7 +72,6 @@ public class IndexServiceImpl implements IndexService {
     private final IndexGreetingDAO indexGreetingDAO;
     private final ApplicationDAO applicationDAO;
     private final ApplicationHostDAO applicationHostDAO;
-    private final HostTopoDAO hostTopoDAO;
     private final TopologyHelper topologyHelper;
     private final TaskTemplateService taskTemplateService;
     private final TaskTemplateDAO taskTemplateDAO;
@@ -84,7 +82,6 @@ public class IndexServiceImpl implements IndexService {
                             IndexGreetingDAO indexGreetingDAO,
                             ApplicationDAO applicationDAO,
                             ApplicationHostDAO applicationHostDAO,
-                            HostTopoDAO hostTopoDAO,
                             TopologyHelper topologyHelper,
                             TaskTemplateService taskTemplateService,
                             TaskTemplateDAO taskTemplateDAO,
@@ -93,7 +90,6 @@ public class IndexServiceImpl implements IndexService {
         this.indexGreetingDAO = indexGreetingDAO;
         this.applicationDAO = applicationDAO;
         this.applicationHostDAO = applicationHostDAO;
-        this.hostTopoDAO = hostTopoDAO;
         this.topologyHelper = topologyHelper;
         this.taskTemplateService = taskTemplateService;
         this.taskTemplateDAO = taskTemplateDAO;
@@ -116,7 +112,7 @@ public class IndexServiceImpl implements IndexService {
                 content = it.getContent();
             }
             return new GreetingVO(it.getId(), content.replace("${time}",
-                TimeUtil.getCurrentTimeStrWithDescription("HH:mm"))
+                    TimeUtil.getCurrentTimeStrWithDescription("HH:mm"))
                 .replace("${username}", username), it.getPriority());
         }).collect(Collectors.toList());
     }
@@ -125,8 +121,8 @@ public class IndexServiceImpl implements IndexService {
     public AgentStatistics getAgentStatistics(String username, AppResourceScope appResourceScope) {
         // 查出业务
         ApplicationDTO appInfo = applicationDAO.getAppById(appResourceScope.getAppId());
-        Long normalNum = 0L;
-        Long abnormalNum = 0L;
+        long normalNum = 0L;
+        long abnormalNum = 0L;
         List<Long> bizIds;
         if (appInfo.isBiz()) {
             // 普通业务
@@ -144,13 +140,13 @@ public class IndexServiceImpl implements IndexService {
         }
         List<HostStatusNumStatisticsDTO> statisticsDTOS = applicationHostDAO.countHostStatusNumByBizIds(bizIds);
         for (HostStatusNumStatisticsDTO statisticsDTO : statisticsDTOS) {
-            if (statisticsDTO.getGseAgentAlive() == AgentStatusEnum.ALIVE.getValue()) {
+            if (statisticsDTO.getGseAgentAlive() == AgentAliveStatusEnum.ALIVE.getStatusValue()) {
                 normalNum += statisticsDTO.getHostNum();
             } else {
                 abnormalNum += statisticsDTO.getHostNum();
             }
         }
-        return new AgentStatistics(normalNum.intValue(), abnormalNum.intValue());
+        return new AgentStatistics((int) normalNum, (int) abnormalNum);
     }
 
     /**

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/task/ScheduledTasks.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/task/ScheduledTasks.java
@@ -115,9 +115,9 @@ public class ScheduledTasks {
     }
 
     /**
-     * Agent状态同步：3min/次
+     * Agent状态同步：1min/次
      */
-    @Scheduled(cron = "0 0/3 * * * ?")
+    @Scheduled(cron = "0 * * * * ?")
     public void agentStatusSyncTask() {
         log.info(Thread.currentThread().getId() + ":agentStatusSyncTask start");
         try {


### PR DESCRIPTION
1. 明确区分Agent状态与Agent存活状态两个概念，当前持久层与展示层均只支持存活状态；
2. 清理部分无用代码，消除告警，优化日志；
3. 调整Agent状态刷新周期为1min/次。