### PR TITLE
fix: get_job_instance_ip_log 返回的 bk_host_id 字段为 null #2129

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v3/EsbGetJobInstanceIpLogV3ResourceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v3/EsbGetJobInstanceIpLogV3ResourceImpl.java
@@ -209,8 +209,8 @@ public class EsbGetJobInstanceIpLogV3ResourceImpl extends JobQueryCommonProcesso
             if (StringUtils.isNotBlank(fileTaskLog.getDestIp())) {
                 EsbIpDTO destIp = EsbIpDTO.fromCloudIp(fileTaskLog.getDestIp());
                 if (destIp != null) {
-                    srcHost.setBkCloudId(destIp.getBkCloudId());
-                    srcHost.setIp(destIp.getIp());
+                    destHost.setBkCloudId(destIp.getBkCloudId());
+                    destHost.setIp(destIp.getIp());
                 }
             }
             fileLog.setDestIp(destHost);

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/ScriptHostLogContent.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/ScriptHostLogContent.java
@@ -55,10 +55,6 @@ public class ScriptHostLogContent {
      */
     private String cloudIpv6;
     /**
-     * 主机IPv6
-     */
-    private String ipv6;
-    /**
      * 日志内容
      */
     private String content;


### PR DESCRIPTION
问题分析见 #2129 

## 修改内容
1. 如果查询参数中没有 hostId,返回的结果也需要补全 bk_host_id 参数
2. 修复文件结果获取中，目标主机的 bk_cloud_id 和 ip 设置不正确的问题