### PR TITLE
perf: 优化对 GSE任务查询结果为空的处理 #2132

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/GseStepEventHandler.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/GseStepEventHandler.java
@@ -227,8 +227,8 @@ public class GseStepEventHandler implements StepEventHandler {
      * @return GSE 任务ID
      */
     private Long saveInitialGseTask(StepInstanceDTO stepInstance) {
-        GseTaskDTO gseTask = new GseTaskDTO(stepInstance.getId(), stepInstance.getExecuteCount(),
-            stepInstance.getBatch());
+        GseTaskDTO gseTask = new GseTaskDTO(stepInstance.getTaskInstanceId(), stepInstance.getId(),
+            stepInstance.getExecuteCount(), stepInstance.getBatch());
         gseTask.setStatus(RunStatusEnum.WAITING_USER.getValue());
 
         return gseTaskService.saveGseTask(gseTask);

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/model/FileGseTaskResult.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/model/FileGseTaskResult.java
@@ -38,7 +38,7 @@ public class FileGseTaskResult extends GseTaskResult<FileTaskResult> {
     }
 
     @Override
-    public boolean isNullResult() {
+    public boolean isEmptyResult() {
         return getResult() == null || CollectionUtils.isEmpty(getResult().getAtomicFileTaskResults());
     }
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/model/GseTaskResult.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/model/GseTaskResult.java
@@ -47,7 +47,7 @@ public abstract class GseTaskResult<T> {
     /**
      * 任务执行结果是否为空
      */
-    public boolean isNullResult() {
+    public boolean isEmptyResult() {
         return false;
     }
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/model/ScriptGseTaskResult.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/model/ScriptGseTaskResult.java
@@ -38,7 +38,7 @@ public class ScriptGseTaskResult extends GseTaskResult<ScriptTaskResult> {
     }
 
     @Override
-    public boolean isNullResult() {
+    public boolean isEmptyResult() {
         return getResult() == null || CollectionUtils.isEmpty(getResult().getResult());
     }
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/AbstractResultHandleTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/AbstractResultHandleTask.java
@@ -80,9 +80,9 @@ import static com.tencent.bk.job.common.util.function.LambdasUtil.not;
 @Slf4j
 public abstract class AbstractResultHandleTask<T> implements ContinuousScheduledTask {
     /**
-     * GSE任务执行结果为空,Job最大容忍时间,5min.用于异常情况下的任务自动终止，防止长时间占用系统资源
+     * GSE任务执行结果为空,Job最大容忍时间1min.用于异常情况下的任务自动终止，防止长时间占用系统资源
      */
-    private static final int GSE_TASK_EMPTY_RESULT_MAX_TOLERATION_MILLS = 300_000;
+    private static final int GSE_TASK_EMPTY_RESULT_MAX_TOLERATION_MILLS = 60_000;
     /**
      * GSE任务超时未结束,Job最大容忍时间。5min.用于异常情况下的任务自动终止，防止长时间占用系统资源
      */
@@ -210,7 +210,6 @@ public abstract class AbstractResultHandleTask<T> implements ContinuousScheduled
      * 是否包含非法主机
      */
     protected boolean hasInvalidHost;
-
 
 
     protected AbstractResultHandleTask(TaskInstanceService taskInstanceService,
@@ -480,9 +479,9 @@ public abstract class AbstractResultHandleTask<T> implements ContinuousScheduled
             latestPullGseLogSuccessTimeMillis = System.currentTimeMillis();
         }
         boolean isAbnormal = false;
-        if (null == gseTaskResult || gseTaskResult.isNullResult()) {
+        if (null == gseTaskResult || gseTaskResult.isEmptyResult()) {
             long currentTimeMillis = System.currentTimeMillis();
-            // 执行结果持续为空
+            // 执行结果持续为空,并且超出 Job 最大容忍时间，需要终止调度任务
             if (currentTimeMillis - latestPullGseLogSuccessTimeMillis >= GSE_TASK_EMPTY_RESULT_MAX_TOLERATION_MILLS) {
                 log.warn("[{}]: Execution result log always empty!", gseTask.getTaskUniqueName());
                 this.executeResult = GseTaskExecuteResult.FAILED;

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/FileResultHandleTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/FileResultHandleTask.java
@@ -274,7 +274,7 @@ public class FileResultHandleTask extends AbstractResultHandleTask<FileTaskResul
 
     @Override
     GseTaskExecuteResult analyseGseTaskResult(GseTaskResult<FileTaskResult> taskDetail) {
-        if (taskDetail == null || taskDetail.getResult() == null) {
+        if (taskDetail == null || taskDetail.isEmptyResult()) {
             log.info("Analyse gse task result, result is empty!");
             return analyseExecuteResult();
         }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/ScriptResultHandleTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/ScriptResultHandleTask.java
@@ -275,7 +275,7 @@ public class ScriptResultHandleTask extends AbstractResultHandleTask<ScriptTaskR
 
     @Override
     GseTaskExecuteResult analyseGseTaskResult(GseTaskResult<ScriptTaskResult> taskDetail) {
-        if (taskDetail == null || taskDetail.getResult() == null) {
+        if (taskDetail == null || taskDetail.isEmptyResult()) {
             log.info("[{}] Analyse gse task result, result is empty!", gseTask.getTaskUniqueName());
             return analyseExecuteResult();
         }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/GseTaskDTO.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/model/GseTaskDTO.java
@@ -38,6 +38,10 @@ public class GseTaskDTO {
      */
     private Long id;
     /**
+     * 作业实例ID
+     */
+    private Long jobInstanceId;
+    /**
      * 步骤实例ID
      */
     private Long stepInstanceId;
@@ -74,7 +78,8 @@ public class GseTaskDTO {
      */
     private String taskUniqueName;
 
-    public GseTaskDTO(Long stepInstanceId, Integer executeCount, int batch) {
+    public GseTaskDTO(Long jobInstanceId, Long stepInstanceId, Integer executeCount, int batch) {
+        this.jobInstanceId = jobInstanceId;
         this.stepInstanceId = stepInstanceId;
         this.executeCount = executeCount;
         this.batch = batch;
@@ -84,7 +89,8 @@ public class GseTaskDTO {
         if (taskUniqueName != null) {
             return taskUniqueName;
         } else {
-            String taskName = "GseTask:" + id + ":" + stepInstanceId + ":" + executeCount;
+            String taskName = "GseTask:" + id + ":" + jobInstanceId + ":" + stepInstanceId
+                + ":" + executeCount;
             if (batch > 0) {
                 taskName = taskName + ":" + batch;
             }


### PR DESCRIPTION
问题分析见 #2132

## 解决方案
1. 对于 GSE 返回的 result 为空的场景，进行容错处理。只有到 result 持续为空一段时间之后，才会判定为任务失效，才会终止调度，并设置任务为状态异常
2. 容错时间由 5min 调整为 1min，尽可能减少GSE 故障等特殊情况导致 Job 执行引擎任务堆积
3. GseTask 日志优化，增加 jobInstanceId 信息，方便定位的时候获取任务上下文