### PR TITLE
perf: 增加GSE任务结果响应中的agentId(ip)不正确的错误日志 #2165

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/FileResultHandleTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/FileResultHandleTask.java
@@ -552,25 +552,33 @@ public class FileResultHandleTask extends AbstractResultHandleTask<FileTaskResul
         boolean isDownloadMode = content.isDownloadMode();
         String agentId = isDownloadMode ?
             content.getDestAgentId() : content.getSourceAgentId();
-        boolean shouldAnalyse = true;
         if (isDownloadMode) {
-            if (this.analyseFinishedTargetAgentIds.contains(agentId) // 该ip已经日志分析结束，不要再分析
+            if (this.analyseFinishedTargetAgentIds.contains(agentId) // 该Agent已经分析结束，不需要再分析
                 // 该文件下载任务已结束
                 || (this.finishedDownloadFileMap.get(agentId) != null
-                && this.finishedDownloadFileMap.get(agentId).contains(content.getTaskId()))
-                // 非目标IP
-                || !this.fileDownloadTaskNumMap.containsKey(agentId)) {
-                shouldAnalyse = false;
+                && this.finishedDownloadFileMap.get(agentId).contains(content.getTaskId()))) {
+                return false;
+            }
+            // 不属于当前任务的目标Agent
+            if (!this.fileDownloadTaskNumMap.containsKey(agentId)) {
+                log.warn("[{}] Unexpected target agentId {}. result: {}", gseTaskInfo, agentId,
+                    JsonUtils.toJson(result));
+                return false;
             }
         } else {
-            if ((this.finishedUploadFileMap.get(agentId) != null
-                && this.finishedUploadFileMap.get(agentId).contains(content.getTaskId()))
-                // 非源IP
-                || !this.fileUploadTaskNumMap.containsKey(agentId)) {
-                shouldAnalyse = false;
+            if (this.analyseFinishedSourceAgentIds.contains(agentId) // 该Agent已经分析结束，不需要再分析
+                || (this.finishedUploadFileMap.get(agentId) != null
+                && this.finishedUploadFileMap.get(agentId).contains(content.getTaskId()))) {
+                return false;
+            }
+            // 不属于当前任务的源Agent
+            if (!this.fileUploadTaskNumMap.containsKey(agentId)) {
+                log.warn("[{}] Unexpected source agentId {}. result: {}", gseTaskInfo, agentId,
+                    JsonUtils.toJson(result));
+                return false;
             }
         }
-        return shouldAnalyse;
+        return true;
     }
 
     private void analyseFailedFileResult(JobAtomicFileTaskResult result,

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/ScriptResultHandleTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/ScriptResultHandleTask.java
@@ -286,7 +286,7 @@ public class ScriptResultHandleTask extends AbstractResultHandleTask<ScriptTaskR
         watch.start("analyse");
         for (ScriptAgentTaskResult agentTaskResult : taskDetail.getResult().getResult()) {
             String agentId = agentTaskResult.getAgentId();
-            if (shouldAnalyse(agentTaskResult)) {
+            if (!shouldAnalyse(agentTaskResult)) {
                 continue;
             }
 

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/ScriptResultHandleTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/ScriptResultHandleTask.java
@@ -299,7 +299,7 @@ public class ScriptResultHandleTask extends AbstractResultHandleTask<ScriptTaskR
 
             log.info("[{}]: Analyse agent task result, result: {}", gseTaskInfo, agentTaskResult);
 
-            /*为了解决shell上下文传参的问题，在下发用户脚本的时候，实际上下下发两个脚本。第一个脚本是用户脚本，第二个脚本
+            /*为了解决shell上下文传参的问题，在下发用户脚本的时候，实际上下发两个脚本。第一个脚本是用户脚本，第二个脚本
              *是获取上下文参数的脚本。所以m_id=0的是用户脚本的执行日志，需要分析记录；m_id=1的，则是获取上下文参数
              *输出的日志内容，不需要记录，仅需要从日志分析提取上下文参数*/
             boolean isUserScriptResult = agentTaskResult.getAtomicTaskId() == 0;


### PR DESCRIPTION
#2165 

1. 日志优化：如果 GSE 返回结果中的 agentId(ip) 不存在，会打印 WARN 日志
2. 相关代码位置调整，更符合逻辑