### PR TITLE
perf: 作业包含大量主机，执行作业请求响应时间过长 #1697

### DIFF
--- a/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/CollectionUtil.java
+++ b/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/CollectionUtil.java
@@ -80,11 +80,9 @@ public class CollectionUtil {
         int limit = (collection.size() + size - 1) / size;
         return Stream.iterate(0, n -> n + 1)
             .limit(limit)
-            .parallel()
             .map(a -> collection.stream()
                 .skip(a * size)
                 .limit(size)
-                .parallel()
                 .collect(Collectors.toList()))
             .collect(Collectors.toList());
     }

--- a/src/backend/commons/common-utils/src/test/java/com/tencent/bk/job/common/util/CollectionUtilTest.java
+++ b/src/backend/commons/common-utils/src/test/java/com/tencent/bk/job/common/util/CollectionUtilTest.java
@@ -104,7 +104,8 @@ class CollectionUtilTest {
             assertThat(partitionLists.get(1004)).hasSize(1);
             assertThat(partitionLists.get(1004).get(0)).isEqualTo("test2009");
 
-            List<String> mergedElements = partitionLists.stream().flatMap(Collection::stream).distinct().collect(Collectors.toList());
+            List<String> mergedElements =
+                partitionLists.stream().flatMap(Collection::stream).distinct().collect(Collectors.toList());
             // 测试分区之后与原始的在数量上一致
             assertThat(mergedElements).hasSize(2009);
         }
@@ -167,7 +168,8 @@ class CollectionUtilTest {
             assertThat(partitionLists.get(1)).hasSize(2);
             assertThat(partitionLists.get(1004)).hasSize(1);
 
-            List<String> mergedElements = partitionLists.stream().flatMap(Collection::stream).distinct().collect(Collectors.toList());
+            List<String> mergedElements =
+                partitionLists.stream().flatMap(Collection::stream).distinct().collect(Collectors.toList());
             // 测试分区之后与原始的在数量上一致
             assertThat(mergedElements).hasSize(2009);
         }

--- a/src/backend/commons/common-utils/src/test/java/com/tencent/bk/job/common/util/CollectionUtilTest.java
+++ b/src/backend/commons/common-utils/src/test/java/com/tencent/bk/job/common/util/CollectionUtilTest.java
@@ -28,9 +28,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
@@ -87,6 +89,24 @@ class CollectionUtilTest {
             assertThat(partitionLists).hasSize(2);
             assertThat(partitionLists.get(0)).hasSize(2);
             assertThat(partitionLists.get(1)).hasSize(2);
+
+            // 测试分区较多的场景
+            list = new ArrayList<>();
+            for (int i = 1; i <= 2009; i++) {
+                list.add("test" + i);
+            }
+            partitionLists = CollectionUtil.partitionCollection(list, 2);
+            assertThat(partitionLists).hasSize(1005);
+            assertThat(partitionLists.get(0)).hasSize(2);
+            assertThat(partitionLists.get(0).get(0)).isEqualTo("test1");
+            assertThat(partitionLists.get(0).get(1)).isEqualTo("test2");
+            assertThat(partitionLists.get(1)).hasSize(2);
+            assertThat(partitionLists.get(1004)).hasSize(1);
+            assertThat(partitionLists.get(1004).get(0)).isEqualTo("test2009");
+
+            List<String> mergedElements = partitionLists.stream().flatMap(Collection::stream).distinct().collect(Collectors.toList());
+            // 测试分区之后与原始的在数量上一致
+            assertThat(mergedElements).hasSize(2009);
         }
 
         @Test
@@ -135,6 +155,21 @@ class CollectionUtilTest {
             assertThat(partitionLists.get(0)).hasSize(3);
             assertThat(partitionLists.get(1)).hasSize(3);
             assertThat(partitionLists.get(2)).hasSize(1);
+
+            // 测试分区较多的场景
+            Set<String> set6 = new HashSet<>();
+            for (int i = 1; i <= 2009; i++) {
+                set6.add("test" + i);
+            }
+            partitionLists = CollectionUtil.partitionCollection(set6, 2);
+            assertThat(partitionLists).hasSize(1005);
+            assertThat(partitionLists.get(0)).hasSize(2);
+            assertThat(partitionLists.get(1)).hasSize(2);
+            assertThat(partitionLists.get(1004)).hasSize(1);
+
+            List<String> mergedElements = partitionLists.stream().flatMap(Collection::stream).distinct().collect(Collectors.toList());
+            // 测试分区之后与原始的在数量上一致
+            assertThat(mergedElements).hasSize(2009);
         }
 
     }


### PR DESCRIPTION
 1. 修复并行流导致的分区数据不准确的问题(Collection. partitionCollection())