### PR TITLE
fix: db 账号没有 super 权限，导致 job-backup 微服务启动失败 #2213

### DIFF
--- a/support-files/kubernetes/charts/bk-job/Chart.yaml
+++ b/support-files/kubernetes/charts/bk-job/Chart.yaml
@@ -2,7 +2,9 @@ apiVersion: v2
 name: "bk-job"
 description: The BK-JOB is a ops script management and execution system with the capability of dealing with multiple tasks simultaneously.
 type: application
+# release 的时候需要改为实际的版本号
 version: {{CHART_VERSION}}
+# release 的时候需要改为实际的版本号
 appVersion: "{{APP_VERSION}}"
 
 dependencies:

--- a/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
+++ b/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
@@ -221,6 +221,17 @@ Return the JDBC MySQL Driver Class
 {{- end -}}
 
 {{/*
+Return the MariaDB jdbc connection url properties
+*/}}
+{{- define "job.mariadb.connection.properties" -}}
+{{- if .Values.mariadb.enabled }}
+    {{- printf "%s" .Values.mariadb.connection.properties -}}
+{{- else -}}
+    {{- printf "%s" .Values.externalMariaDB.connection.properties -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the JDBC MySQL scheme
 */}}
 {{- define "job.jdbcMysqlScheme" -}}

--- a/support-files/kubernetes/charts/bk-job/templates/job-analysis/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-analysis/configmap.yaml
@@ -35,7 +35,7 @@ data:
         job-analysis:
           driver-class-name: {{ include "job.jdbcMysqlDriverClass" . }}
           type: com.zaxxer.hikari.HikariDataSource
-          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_analysis?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
+          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_analysis{{ include "job.mariadb.connection.properties" . }}
           username: {{ include "job.mariadb.username" . }}
           {{ if .Values.externalMariaDB.existingPasswordSecret }}
           password: {{ .Values.externalMariaDB.existingPasswordKey | default "mariadb-password" | printf "${%s}" }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-backup/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-backup/configmap.yaml
@@ -35,7 +35,7 @@ data:
         job-backup:
           driver-class-name: {{ include "job.jdbcMysqlDriverClass" . }}
           type: com.zaxxer.hikari.HikariDataSource
-          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_backup?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
+          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_backup{{ include "job.mariadb.connection.properties" . }}
           username: {{ include "job.mariadb.username" . }}
           {{ if .Values.externalMariaDB.existingPasswordSecret }}
           password: {{ .Values.externalMariaDB.existingPasswordKey | default "mariadb-password" | printf "${%s}" }}
@@ -50,7 +50,7 @@ data:
         job-execute-db:
           driver-class-name: {{ include "job.jdbcMysqlDriverClass" . }}
           type: com.zaxxer.hikari.HikariDataSource
-          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_execute?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&sessionVariables=binlog_format=statement
+          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_execute{{ include "job.mariadb.connection.properties" . }}
           username: {{ include "job.mariadb.username" . }}
           {{ if .Values.externalMariaDB.existingPasswordSecret }}
           password: {{ .Values.externalMariaDB.existingPasswordKey | default "mariadb-password" | printf "${%s}" }}
@@ -65,7 +65,7 @@ data:
         job-execute-archive:
           driver-class-name: {{ include "job.jdbcMysqlDriverClass" . }}
           type: com.zaxxer.hikari.HikariDataSource
-          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_execute?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
+          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_execute{{ include "job.mariadb.connection.properties" . }}
           username: {{ include "job.mariadb.username" . }}
           {{ if .Values.externalMariaDB.existingPasswordSecret }}
           password: {{ .Values.externalMariaDB.existingPasswordKey | default "mariadb-password" | printf "${%s}" }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-crontab/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-crontab/configmap.yaml
@@ -35,7 +35,7 @@ data:
         job-crontab:
           driver-class-name: {{ include "job.jdbcMysqlDriverClass" . }}
           type: com.zaxxer.hikari.HikariDataSource
-          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_crontab?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
+          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_crontab{{ include "job.mariadb.connection.properties" . }}
           username: {{ include "job.mariadb.username" . }}
           {{ if .Values.externalMariaDB.existingPasswordSecret }}
           password: {{ .Values.externalMariaDB.existingPasswordKey | default "mariadb-password" | printf "${%s}" }}
@@ -116,7 +116,7 @@ data:
     job:
       crontab:
         db:
-          url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_crontab?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
+          url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_crontab{{ include "job.mariadb.connection.properties" . }}
           username: {{ include "job.mariadb.username" . }}
           {{ if .Values.externalMariaDB.existingPasswordSecret }}
           password: {{ .Values.externalMariaDB.existingPasswordKey | default "mariadb-password" | printf "${%s}" }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-execute/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-execute/configmap.yaml
@@ -163,7 +163,7 @@ data:
         job-execute:
           driver-class-name: {{ include "job.jdbcMysqlDriverClass" . }}
           type: com.zaxxer.hikari.HikariDataSource
-          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_execute?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true
+          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_execute{{ include "job.mariadb.connection.properties" . }}
           username: {{ include "job.mariadb.username" . }}
           {{ if .Values.externalMariaDB.existingPasswordSecret }}
           password: {{ .Values.externalMariaDB.existingPasswordKey | default "mariadb-password" | printf "${%s}" }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-file-gateway/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-file-gateway/configmap.yaml
@@ -35,7 +35,7 @@ data:
         job-file-gateway:
           driver-class-name: {{ include "job.jdbcMysqlDriverClass" . }}
           type: com.zaxxer.hikari.HikariDataSource
-          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_file_gateway?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
+          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_file_gateway{{ include "job.mariadb.connection.properties" . }}
           username: {{ include "job.mariadb.username" . }}
           {{ if .Values.externalMariaDB.existingPasswordSecret }}
           password: {{ .Values.externalMariaDB.existingPasswordKey | default "mariadb-password" | printf "${%s}" }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-manage/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-manage/configmap.yaml
@@ -35,7 +35,7 @@ data:
         job-manage:
           driver-class-name: {{ include "job.jdbcMysqlDriverClass" . }}
           type: com.zaxxer.hikari.HikariDataSource
-          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_manage?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
+          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_manage{{ include "job.mariadb.connection.properties" . }}
           username: {{ include "job.mariadb.username" . }}
           {{ if .Values.externalMariaDB.existingPasswordSecret }}
           password: {{ .Values.externalMariaDB.existingPasswordKey | default "mariadb-password" | printf "${%s}" }}

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -117,6 +117,9 @@ mariadb:
       grant all privileges on *.* to 'root'@'%' identified by 'job';
       grant all privileges on *.* to 'job'@'%' identified by 'job';
       flush privileges;
+  ## JDBC Connection properties
+  connection:
+    properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
 
 ## External MariaDB configuration
 ##
@@ -142,6 +145,9 @@ externalMariaDB:
   ## @param externalMariaDB.rootPassword Password for the MariaDB `root` user
   ##
   rootPassword: ""
+  ## JDBC Connection properties
+  connection:
+    properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
 
 
 ## Redis chart configuration

--- a/support-files/templates/#etc#job#job-backup#job-backup.yml
+++ b/support-files/templates/#etc#job#job-backup#job-backup.yml
@@ -30,7 +30,7 @@ spring:
     job-execute-db:
       driver-class-name: io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver
       type: com.zaxxer.hikari.HikariDataSource
-      jdbc-url: jdbc:otel:mysql://__BK_JOB_EXECUTE_MYSQL_HOST__:__BK_JOB_EXECUTE_MYSQL_PORT__/job_execute?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&serverTimezone=Asia/Shanghai&sessionVariables=binlog_format=statement
+      jdbc-url: jdbc:otel:mysql://__BK_JOB_EXECUTE_MYSQL_HOST__:__BK_JOB_EXECUTE_MYSQL_PORT__/job_execute?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
       username: __BK_JOB_EXECUTE_MYSQL_USERNAME__
       password: __BK_JOB_EXECUTE_MYSQL_PASSWORD__
       maximum-pool-size: 10
@@ -42,7 +42,7 @@ spring:
     #job-execute-archive:
       #driver-class-name: io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver
       #type: com.zaxxer.hikari.HikariDataSource
-      #jdbc-url: jdbc:otel:mysql://__BK_JOB_EXECUTE_ARCHIVE_MYSQL_HOST__:__BK_JOB_EXECUTE_ARCHIVE_MYSQL_PORT__/job_execute?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&serverTimezone=Asia/Shanghai
+      #jdbc-url: jdbc:otel:mysql://__BK_JOB_EXECUTE_ARCHIVE_MYSQL_HOST__:__BK_JOB_EXECUTE_ARCHIVE_MYSQL_PORT__/job_execute?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
       #username: __BK_JOB_EXECUTE_ARCHIVE_MYSQL_USERNAME__
       #password: __BK_JOB_EXECUTE_ARCHIVE_MYSQL_PASSWORD__
       #maximum-pool-size: 10


### PR DESCRIPTION
### 修改内容
1. 容器化版本，ConfigMap 中的 MySQL jdbc URL 配置的 properties 参数支持在 values.yml 中配置；默认不添加sessionVariables=binlog_format=statement，防止 db 账号权限不足导致微服务无法启动。用户如果需要，按需配置开启即可
2. 二进制版本，template 中删除sessionVariables=binlog_format=statement，用户按需配置