### PR TITLE
fix: 当业务下有大量的执行作业，加载 web 页面首页的时候会触发DB慢查询 #2228

### DIFF
--- a/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/date/DateUtils.java
+++ b/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/date/DateUtils.java
@@ -361,7 +361,7 @@ public class DateUtils {
      * @return 当天（UTC 时区)的截止时间戳，单位毫秒
      */
     public static long getUTCCurrentDayEndTimestamp() {
-        return 1000 * getUTCDayEndTimestamp(LocalDate.now(ZoneId.of("UTC")));
+        return getUTCDayEndTimestamp(LocalDate.now(ZoneId.of("UTC")));
     }
 
     /**

--- a/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/date/DateUtils.java
+++ b/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/date/DateUtils.java
@@ -34,6 +34,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -352,5 +353,24 @@ public class DateUtils {
             log.error(msg, e);
             return null;
         }
+    }
+
+    /**
+     * 计算当天（UTC 时区)的截止时间戳
+     *
+     * @return 当天（UTC 时区)的截止时间戳，单位毫秒
+     */
+    public static long getUTCCurrentDayEndTimestamp() {
+        return 1000 * getUTCDayEndTimestamp(LocalDate.now(ZoneId.of("UTC")));
+    }
+
+    /**
+     * 根据日期（UTC 时区)计算这一天的截止时间戳
+     *
+     * @return 日期（UTC 时区)对应当天截止时间戳，单位毫秒
+     */
+    public static long getUTCDayEndTimestamp(LocalDate localDateUTC) {
+
+        return 1000 * (localDateUTC.atStartOfDay().toEpochSecond(ZoneOffset.UTC) + 86400);
     }
 }

--- a/src/backend/commons/common-utils/src/test/java/com/tencent/bk/job/common/util/date/DateUtilsTest.java
+++ b/src/backend/commons/common-utils/src/test/java/com/tencent/bk/job/common/util/date/DateUtilsTest.java
@@ -26,6 +26,10 @@ package com.tencent.bk.job.common.util.date;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class DateUtilsTest {
@@ -41,5 +45,33 @@ public class DateUtilsTest {
         assertThat(DateUtils.calcDaysBetween("2020-12-31", "2021-1-1")).isEqualTo(1);
         assertThat(DateUtils.calcDaysBetween("2021-2-28", "2021-3-1")).isEqualTo(1);
         assertThat(DateUtils.calcDaysBetween("2020-2-28", "2020-3-1")).isEqualTo(2);
+    }
+
+    @Test
+    void getUTCDayEndTimestamp() {
+        ZonedDateTime dateTime = LocalDateTime.of(2023, 7, 14, 15, 14, 23, 12312)
+            .atZone(ZoneId.of("UTC"));
+        long endTime = DateUtils.getUTCDayEndTimestamp(dateTime.toLocalDate());
+        // 2023-07-15 00:00:00 UTC
+        assertThat(endTime).isEqualTo(1689379200000L);
+
+
+        ZonedDateTime dateTime2 = LocalDateTime.of(2023, 7, 14, 7, 15, 22, 123)
+            .atZone(ZoneId.of("UTC"));
+        long endTime2 = DateUtils.getUTCDayEndTimestamp(dateTime2.toLocalDate());
+        // 2023-07-15 00:00:00 UTC
+        assertThat(endTime2).isEqualTo(1689379200000L);
+
+        ZonedDateTime dateTime3 = LocalDateTime.of(2023, 7, 13, 0, 0, 0, 0)
+            .atZone(ZoneId.of("UTC"));
+        long endTime3 = DateUtils.getUTCDayEndTimestamp(dateTime3.toLocalDate());
+        // 2023-07-14 00:00:00 UTC
+        assertThat(endTime3).isEqualTo(1689292800000L);
+
+        ZonedDateTime dateTime4 = LocalDateTime.of(2023, 7, 13, 23, 59, 59, 99999999)
+            .atZone(ZoneId.of("UTC"));
+        long endTime4 = DateUtils.getUTCDayEndTimestamp(dateTime4.toLocalDate());
+        // 2023-07-14 00:00:00 UTC
+        assertThat(endTime4).isEqualTo(1689292800000L);
     }
 }

--- a/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/interceptor/EsbApiLogInterceptor.java
+++ b/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/interceptor/EsbApiLogInterceptor.java
@@ -92,7 +92,7 @@ public class EsbApiLogInterceptor extends HandlerInterceptorAdapter {
         } catch (Throwable e) {
             return true;
         } finally {
-            log.info("request-id: {}|lang:{}|API:{}|uri:{}|appCode:{}|username:{}|body:{}|queryParams:{}", requestId,
+            log.info("request-id: {}|lang: {}|API: {}|uri: {}|appCode: {}|username: {}|body: {}|queryParams: {}", requestId,
                 lang, apiName,
                 request.getRequestURI(), appCode, username, desensitizedBody, desensitizedQueryParams);
         }
@@ -142,7 +142,7 @@ public class EsbApiLogInterceptor extends HandlerInterceptorAdapter {
             String requestId = request.getHeader(JobCommonHeaders.BK_GATEWAY_REQUEST_ID);
             int respStatus = response.getStatus();
             long cost = System.currentTimeMillis() - startTimeInMills;
-            log.info("request-id:{}|API:{}|uri:{}|appCode:{}|username:{}|status:{}|resp:{}|cost:{}",
+            log.info("request-id: {}|API: {}|uri: {}|appCode: {}|username: {}|status: {}|resp: {}|cost: {}",
                 requestId,
                 apiName,
                 request.getRequestURI(),

--- a/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/interceptor/EsbApiLogInterceptor.java
+++ b/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/interceptor/EsbApiLogInterceptor.java
@@ -68,6 +68,7 @@ public class EsbApiLogInterceptor extends HandlerInterceptorAdapter {
             request.setAttribute(ATTR_REQUEST_START, System.currentTimeMillis());
             apiName = getAPIName(wrapperRequest.getRequestURI());
             request.setAttribute(ATTR_API_NAME, apiName);
+            desensitizedQueryParams = desensitizeQueryParams(request.getQueryString());
             if (request.getMethod().equals(HttpMethod.POST.name())
                 || request.getMethod().equals(HttpMethod.PUT.name())) {
                 if (StringUtils.isNotBlank(wrapperRequest.getBody())) {
@@ -85,15 +86,13 @@ public class EsbApiLogInterceptor extends HandlerInterceptorAdapter {
             } else if (request.getMethod().equals(HttpMethod.GET.name())) {
                 username = request.getParameter("bk_username");
                 appCode = request.getParameter("bk_app_code");
-                desensitizedQueryParams = desensitizeQueryParams(request.getQueryString());
-
                 request.setAttribute(ATTR_USERNAME, username);
                 request.setAttribute(ATTR_APP_CODE, appCode);
             }
         } catch (Throwable e) {
             return true;
         } finally {
-            log.info("request-id:{}|lang:{}|API:{}|uri:{}|appCode:{}|username:{}|body:{}|queryParams:{}", requestId,
+            log.info("request-id: {}|lang:{}|API:{}|uri:{}|appCode:{}|username:{}|body:{}|queryParams:{}", requestId,
                 lang, apiName,
                 request.getRequestURI(), appCode, username, desensitizedBody, desensitizedQueryParams);
         }

--- a/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/interceptor/EsbApiLogInterceptor.java
+++ b/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/interceptor/EsbApiLogInterceptor.java
@@ -92,9 +92,9 @@ public class EsbApiLogInterceptor extends HandlerInterceptorAdapter {
         } catch (Throwable e) {
             return true;
         } finally {
-            log.info("request-id: {}|lang: {}|API: {}|uri: {}|appCode: {}|username: {}|body: {}|queryParams: {}", requestId,
-                lang, apiName,
-                request.getRequestURI(), appCode, username, desensitizedBody, desensitizedQueryParams);
+            log.info("request-id: {}|lang: {}|API: {}|uri: {}|appCode: {}|username: {}|body: {}|queryParams: {}",
+                requestId, lang, apiName, request.getRequestURI(), appCode, username, desensitizedBody,
+                desensitizedQueryParams);
         }
         return true;
     }

--- a/src/backend/job-execute/api-job-execute/src/main/java/com/tencent/bk/job/execute/api/inner/ServiceMetricsResource.java
+++ b/src/backend/job-execute/api-job-execute/src/main/java/com/tencent/bk/job/execute/api/inner/ServiceMetricsResource.java
@@ -27,17 +27,10 @@ package com.tencent.bk.job.execute.api.inner;
 import com.tencent.bk.job.common.annotation.InternalAPI;
 import com.tencent.bk.job.common.model.InternalResponse;
 import com.tencent.bk.job.common.statistics.model.dto.StatisticsDTO;
-import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
-import com.tencent.bk.job.execute.common.constants.StepExecuteTypeEnum;
-import com.tencent.bk.job.execute.common.constants.TaskStartupModeEnum;
-import com.tencent.bk.job.execute.common.constants.TaskTypeEnum;
-import com.tencent.bk.job.execute.model.inner.request.ServiceTriggerStatisticsRequest;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -65,75 +58,6 @@ public interface ServiceMetricsResource {
         @RequestParam(value = "toTime", required = false) Long toTime
     );
 
-    /**
-     * 大数据量下容易导致慢查询影响全局，非特殊情况不使用
-     */
-    @Deprecated
-    @ApiOperation(value = "快速文件分发统计", produces = "application/json")
-    @GetMapping("/service/metrics/fastPushFile/count")
-    InternalResponse<Integer> countFastPushFile(
-        @ApiParam(value = "业务Id", required = false)
-        @RequestParam(value = "appId", required = false) Long appId,
-        @ApiParam(value = "传输模式", required = false)
-        @RequestParam(value = "transferMode", required = false) Integer transferMode,
-        @ApiParam(value = "文件源是否为本地文件", required = false)
-        @RequestParam(value = "localUpload", required = false) Boolean localUpload,
-        @ApiParam(value = "步骤状态", required = false)
-        @RequestParam(value = "runStatus", required = false) RunStatusEnum runStatus,
-        @ApiParam(value = "统计的起始时间", required = false)
-        @RequestParam(value = "fromTime", required = false) Long fromTime,
-        @ApiParam(value = "统计的截止时间", required = false)
-        @RequestParam(value = "toTime", required = false) Long toTime
-    );
-
-    /**
-     * 大数据量下容易导致慢查询影响全局，非特殊情况不使用
-     */
-    @Deprecated
-    @ApiOperation(value = "步骤执行统计", produces = "application/json")
-    @GetMapping("/service/metrics/stepInstances/count")
-    InternalResponse<Integer> countStepInstances(
-        @ApiParam(value = "业务Id", required = false)
-        @RequestParam(value = "appId", required = false) Long appId,
-        @ApiParam(value = "步骤对应的StepId列表", required = false)
-        @RequestParam(value = "stepIdList", required = false) List<Long> stepIdList,
-        @ApiParam(value = "步骤类型", required = false)
-        @RequestParam(value = "stepExecuteType", required = false) StepExecuteTypeEnum stepExecuteType,
-        @ApiParam(value = "脚本类型", required = false)
-        @RequestParam(value = "scriptType", required = false) Integer scriptType,
-        @ApiParam(value = "步骤状态", required = false)
-        @RequestParam(value = "runStatus", required = false) RunStatusEnum runStatus,
-        @ApiParam(value = "统计的起始时间", required = false)
-        @RequestParam(value = "fromTime", required = false) Long fromTime,
-        @ApiParam(value = "统计的截止时间", required = false)
-        @RequestParam(value = "toTime", required = false) Long toTime
-    );
-
-    /**
-     * 大数据量下容易导致慢查询影响全局，非特殊情况不使用
-     */
-    @Deprecated
-    @ApiOperation(value = "任务（含快速/作业）执行统计", produces = "application/json")
-    @GetMapping("/service/metrics/taskInstances/count")
-    InternalResponse<Integer> countTaskInstances(
-        @ApiParam(value = "业务Id", required = false)
-        @RequestParam(value = "appId", required = false) Long appId,
-        @ApiParam(value = "最小执行用时(单位：秒)", required = false)
-        @RequestParam(value = "minTotalTime", required = false) Long minTotalTime,
-        @ApiParam(value = "最大执行用时(单位：秒)", required = false)
-        @RequestParam(value = "maxTotalTime", required = false) Long maxTotalTime,
-        @ApiParam(value = "触发方式", required = false)
-        @RequestParam(value = "taskStartupMode", required = false) TaskStartupModeEnum taskStartupMode,
-        @ApiParam(value = "任务类型", required = false)
-        @RequestParam(value = "taskType", required = false) TaskTypeEnum taskType,
-        @ApiParam(value = "任务状态列表", required = false)
-        @RequestParam(value = "runStatusList", required = false) List<Byte> runStatusList,
-        @ApiParam(value = "统计的起始时间(ms)", required = false)
-        @RequestParam(value = "fromTime", required = false) Long fromTime,
-        @ApiParam(value = "统计的截止时间(ms)", required = false)
-        @RequestParam(value = "toTime", required = false) Long toTime
-    );
-
     @ApiOperation(value = "获取统计数据", produces = "application/json")
     @GetMapping("/service/metrics/statistics")
     InternalResponse<StatisticsDTO> getStatistics(
@@ -148,27 +72,4 @@ public interface ServiceMetricsResource {
         @ApiParam(value = "统计日期(yyyy-MM-dd)", required = true)
         @RequestParam(value = "dateStr", required = true) String dateStr
     );
-
-    @ApiOperation(value = "获取统计数据", produces = "application/json")
-    @GetMapping("/service/metrics/statistics/list")
-    InternalResponse<List<StatisticsDTO>> listStatistics(
-        @ApiParam(value = "业务Id", required = false)
-        @RequestParam(value = "appId", required = false) Long appId,
-        @ApiParam(value = "资源类型", required = false)
-        @RequestParam(value = "resource", required = false) String resource,
-        @ApiParam(value = "资源维度", required = false)
-        @RequestParam(value = "dimension", required = false) String dimension,
-        @ApiParam(value = "资源维度取值", required = false)
-        @RequestParam(value = "dimensionValue", required = false) String dimensionValue,
-        @ApiParam(value = "统计日期(yyyy-MM-dd)", required = false)
-        @RequestParam(value = "dateStr", required = false) String dateStr
-    );
-
-    @ApiOperation(value = "触发指定时间的数据统计", produces = "application/json")
-    @PostMapping("/service/metrics/statistics/trigger")
-    InternalResponse<Boolean> triggerStatistics(
-        @ApiParam(value = "统计日期(yyyy-MM-dd)", required = false)
-        @RequestBody ServiceTriggerStatisticsRequest request
-    );
-
 }

--- a/src/backend/job-execute/api-job-execute/src/main/java/com/tencent/bk/job/execute/api/inner/ServiceMetricsResource.java
+++ b/src/backend/job-execute/api-job-execute/src/main/java/com/tencent/bk/job/execute/api/inner/ServiceMetricsResource.java
@@ -27,10 +27,13 @@ package com.tencent.bk.job.execute.api.inner;
 import com.tencent.bk.job.common.annotation.InternalAPI;
 import com.tencent.bk.job.common.model.InternalResponse;
 import com.tencent.bk.job.common.statistics.model.dto.StatisticsDTO;
+import com.tencent.bk.job.execute.model.inner.request.ServiceTriggerStatisticsRequest;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -71,5 +74,12 @@ public interface ServiceMetricsResource {
         @RequestParam(value = "dimensionValue", required = true) String dimensionValue,
         @ApiParam(value = "统计日期(yyyy-MM-dd)", required = true)
         @RequestParam(value = "dateStr", required = true) String dateStr
+    );
+
+    @ApiOperation(value = "触发指定时间的数据统计", produces = "application/json")
+    @PostMapping("/service/metrics/statistics/trigger")
+    InternalResponse<Boolean> triggerStatistics(
+        @ApiParam(value = "统计日期(yyyy-MM-dd)", required = false)
+        @RequestBody ServiceTriggerStatisticsRequest request
     );
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v3/EsbGetJobInstanceListV3ResourceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v3/EsbGetJobInstanceListV3ResourceImpl.java
@@ -147,8 +147,13 @@ public class EsbGetJobInstanceListV3ResourceImpl implements EsbGetJobInstanceLis
             return ValidateResult.fail(ErrorCode.MISSING_OR_ILLEGAL_PARAM_WITH_PARAM_NAME, "create_time_end");
         }
         long period = request.getCreateTimeEnd() - request.getCreateTimeStart();
-        if (period > Consts.MAX_SEARCH_TASK_HISTORY_RANGE_MILLS) {
-            log.warn("Search time range greater than 30 days!");
+        if (period <= 0) {
+            log.warn("CreateStartTime is greater or equal to createTimeEnd, getCreateTimeStart={}, createTimeEnd={}",
+                request.getCreateTimeStart(), request.getCreateTimeEnd());
+            return ValidateResult.fail(ErrorCode.MISSING_OR_ILLEGAL_PARAM_WITH_PARAM_NAME,
+                "create_time_start|create_time_end");
+        } else if (period > Consts.MAX_SEARCH_TASK_HISTORY_RANGE_MILLS) {
+            log.warn("Search time range greater than {} days!", Consts.MAX_SEARCH_TASK_HISTORY_RANGE_MILLS);
             return ValidateResult.fail(ErrorCode.ILLEGAL_PARAM, "create_time_start|create_time_end");
         }
         if (request.getTaskType() != null && TaskTypeEnum.valueOf(request.getTaskType()) == null) {

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/inner/ServiceMetricsResourceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/inner/ServiceMetricsResourceImpl.java
@@ -26,14 +26,8 @@ package com.tencent.bk.job.execute.api.inner;
 
 import com.tencent.bk.job.common.model.InternalResponse;
 import com.tencent.bk.job.common.statistics.model.dto.StatisticsDTO;
-import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
-import com.tencent.bk.job.execute.common.constants.StepExecuteTypeEnum;
-import com.tencent.bk.job.execute.common.constants.TaskStartupModeEnum;
-import com.tencent.bk.job.execute.common.constants.TaskTypeEnum;
-import com.tencent.bk.job.execute.model.inner.request.ServiceTriggerStatisticsRequest;
 import com.tencent.bk.job.execute.service.TaskInstanceService;
 import com.tencent.bk.job.execute.statistics.StatisticsService;
-import com.tencent.bk.job.manage.common.consts.script.ScriptTypeEnum;
 import io.micrometer.core.annotation.Timed;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RestController;
@@ -68,47 +62,9 @@ public class ServiceMetricsResourceImpl implements ServiceMetricsResource {
     }
 
     @Override
-    @Timed(extraTags = {IGNORE_TAG, BOOLEAN_TRUE_TAG_VALUE})
-    public InternalResponse<Integer> countFastPushFile(Long appId, Integer transferMode, Boolean localUpload,
-                                                  RunStatusEnum runStatus, Long fromTime, Long toTime) {
-        return InternalResponse.buildSuccessResp(taskInstanceService.countFastPushFile(appId, transferMode,
-            localUpload, runStatus, fromTime, toTime));
-    }
-
-    @Override
-    @Timed(extraTags = {IGNORE_TAG, BOOLEAN_TRUE_TAG_VALUE})
-    public InternalResponse<Integer> countStepInstances(Long appId, List<Long> stepIdList,
-                                                   StepExecuteTypeEnum stepExecuteType, Integer scriptType,
-                                                   RunStatusEnum runStatus, Long fromTime, Long toTime) {
-        return InternalResponse.buildSuccessResp(taskInstanceService.countStepInstances(appId, stepIdList,
-            stepExecuteType, ScriptTypeEnum.valueOf(scriptType), runStatus, fromTime, toTime));
-    }
-
-    @Override
-    @Timed(extraTags = {IGNORE_TAG, BOOLEAN_TRUE_TAG_VALUE})
-    public InternalResponse<Integer> countTaskInstances(Long appId, Long minTotalTime, Long maxTotalTime,
-                                                   TaskStartupModeEnum taskStartupMode, TaskTypeEnum taskType,
-                                                   List<Byte> runStatusList, Long fromTime, Long toTime) {
-        return InternalResponse.buildSuccessResp(taskInstanceService.countTaskInstances(appId, minTotalTime,
-            maxTotalTime, taskStartupMode, taskType, runStatusList, fromTime, toTime));
-    }
-
-    @Override
     public InternalResponse<StatisticsDTO> getStatistics(Long appId, String resource, String dimension,
-                                                    String dimensionValue, String dateStr) {
+                                                         String dimensionValue, String dateStr) {
         return InternalResponse.buildSuccessResp(statisticsService.getStatistics(appId, resource, dimension,
             dimensionValue, dateStr));
-    }
-
-    @Override
-    public InternalResponse<List<StatisticsDTO>> listStatistics(Long appId, String resource, String dimension,
-                                                           String dimensionValue, String dateStr) {
-        return InternalResponse.buildSuccessResp(statisticsService.listStatistics(appId, resource, dimension,
-            dimensionValue, dateStr));
-    }
-
-    @Override
-    public InternalResponse<Boolean> triggerStatistics(ServiceTriggerStatisticsRequest request) {
-        return InternalResponse.buildSuccessResp(statisticsService.triggerStatistics(request.getDateList()));
     }
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/inner/ServiceMetricsResourceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/inner/ServiceMetricsResourceImpl.java
@@ -26,6 +26,7 @@ package com.tencent.bk.job.execute.api.inner;
 
 import com.tencent.bk.job.common.model.InternalResponse;
 import com.tencent.bk.job.common.statistics.model.dto.StatisticsDTO;
+import com.tencent.bk.job.execute.model.inner.request.ServiceTriggerStatisticsRequest;
 import com.tencent.bk.job.execute.service.TaskInstanceService;
 import com.tencent.bk.job.execute.statistics.StatisticsService;
 import io.micrometer.core.annotation.Timed;
@@ -66,5 +67,10 @@ public class ServiceMetricsResourceImpl implements ServiceMetricsResource {
                                                          String dimensionValue, String dateStr) {
         return InternalResponse.buildSuccessResp(statisticsService.getStatistics(appId, resource, dimension,
             dimensionValue, dateStr));
+    }
+
+    @Override
+    public InternalResponse<Boolean> triggerStatistics(ServiceTriggerStatisticsRequest request) {
+        return InternalResponse.buildSuccessResp(statisticsService.triggerStatistics(request.getDateList()));
     }
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/web/impl/WebTaskExecutionResultResourceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/web/impl/WebTaskExecutionResultResourceImpl.java
@@ -108,9 +108,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -286,9 +283,8 @@ public class WebTaskExecutionResultResourceImpl implements WebTaskExecutionResul
                 log.warn("Param timeRange should less then 30");
                 return ValidateResult.fail(ErrorCode.TASK_INSTANCE_QUERY_TIME_SPAN_MORE_THAN_30_DAYS);
             }
-            // 当天结束时间
-            long todayMaxMills = LocalDateTime.of(LocalDate.now(), LocalTime.MAX).getSecond() * 1000L;
-            start = todayMaxMills - 30 * 24 * 3600 * 1000L;
+            // 当天结束时间 - 往前的天数
+            start = DateUtils.getUTCCurrentDayEndTimestamp() - timeRange * 24 * 3600 * 1000L;
         } else {
             if (StringUtils.isNotBlank(startTime)) {
                 start = DateUtils.convertUnixTimestampFromDateTimeStr(startTime, "yyyy-MM-dd HH:mm:ss",

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/TaskInstanceDAO.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/TaskInstanceDAO.java
@@ -28,8 +28,6 @@ import com.tencent.bk.job.common.model.BaseSearchCondition;
 import com.tencent.bk.job.common.model.PageData;
 import com.tencent.bk.job.common.model.dto.HostDTO;
 import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
-import com.tencent.bk.job.execute.common.constants.TaskStartupModeEnum;
-import com.tencent.bk.job.execute.common.constants.TaskTypeEnum;
 import com.tencent.bk.job.execute.model.TaskInstanceDTO;
 import com.tencent.bk.job.execute.model.TaskInstanceQuery;
 
@@ -65,9 +63,9 @@ public interface TaskInstanceDAO {
     /**
      * 分页查询作业执行实例
      *
-     * @param taskQuery
-     * @param baseSearchCondition
-     * @return
+     * @param taskQuery           查询
+     * @param baseSearchCondition 基础查询条件
+     * @return 分页结果
      */
     PageData<TaskInstanceDTO> listPageTaskInstance(TaskInstanceQuery taskQuery,
                                                    BaseSearchCondition baseSearchCondition);
@@ -82,7 +80,7 @@ public interface TaskInstanceDAO {
      * @param latestTimeInSeconds 时间范围
      * @param status              任务状态,如果为NULL,那么返回所有状态
      * @param limit               返回记录个数；如果未NULL,那么不限制返回数量
-     * @return
+     * @return 作业实例列表
      */
     List<TaskInstanceDTO> listLatestCronTaskInstance(long appId, Long cronTaskId,
                                                      Long latestTimeInSeconds, RunStatusEnum status, Integer limit);
@@ -108,29 +106,13 @@ public interface TaskInstanceDAO {
     void resetTaskExecuteInfoForRetry(long taskInstanceId);
 
     /**
-     * 根据条件统计执行过的任务
-     *
-     * @param appId           业务Id
-     * @param minTotalTime    最小执行时间
-     * @param maxTotalTime    最大执行时间
-     * @param taskStartupMode 启动模式
-     * @param taskType        任务类型
-     * @param runStatusList   任务状态
-     * @param fromTime        统计时间起点
-     * @param toTime          统计时间终点
-     * @return
-     */
-    Integer countTaskInstances(Long appId, Long minTotalTime, Long maxTotalTime, TaskStartupModeEnum taskStartupMode,
-                               TaskTypeEnum taskType, List<Byte> runStatusList, Long fromTime, Long toTime);
-
-    /**
      * 查询大于某个时间的定时任务执行记录对应的业务Id
      * ！！！调用时需要注意查询效率，可能慢查询
      *
      * @param inAppIdList   指定appId的范围
      * @param cronTaskId    定时任务Id
      * @param minCreateTime 最小创建时间
-     * @return
+     * @return 业务 ID 列表
      */
     List<Long> listTaskInstanceAppId(List<Long> inAppIdList, Long cronTaskId, Long minCreateTime);
 
@@ -141,7 +123,7 @@ public interface TaskInstanceDAO {
      * @param cronTaskId 定时任务Id
      * @param fromTime   起始时间
      * @param toTime     终止时间
-     * @return
+     * @return 是否存在执行记录
      */
     boolean hasExecuteHistory(Long appId, Long cronTaskId, Long fromTime, Long toTime);
 

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/TaskInstanceDAOImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/TaskInstanceDAOImpl.java
@@ -29,8 +29,6 @@ import com.tencent.bk.job.common.model.PageData;
 import com.tencent.bk.job.common.model.dto.HostDTO;
 import com.tencent.bk.job.common.util.CollectionUtil;
 import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
-import com.tencent.bk.job.execute.common.constants.TaskStartupModeEnum;
-import com.tencent.bk.job.execute.common.constants.TaskTypeEnum;
 import com.tencent.bk.job.execute.common.util.JooqDataTypeUtil;
 import com.tencent.bk.job.execute.dao.TaskInstanceDAO;
 import com.tencent.bk.job.execute.model.TaskInstanceDTO;
@@ -470,43 +468,6 @@ public class TaskInstanceDAOImpl implements TaskInstanceDAO {
             .set(TASK_INSTANCE.STATUS, RunStatusEnum.RUNNING.getValue().byteValue())
             .where(TASK_INSTANCE.ID.eq(taskInstanceId))
             .execute();
-    }
-
-    public Integer countTaskInstanceByConditions(Collection<Condition> conditions) {
-        return ctx.selectCount().from(TASK_INSTANCE)
-            .where(conditions).fetchOne().value1();
-    }
-
-    @Override
-    public Integer countTaskInstances(Long appId, Long minTotalTime, Long maxTotalTime,
-                                      TaskStartupModeEnum taskStartupMode, TaskTypeEnum taskType,
-                                      List<Byte> runStatusList, Long fromTime, Long toTime) {
-        List<Condition> conditions = new ArrayList<>();
-        if (appId != null) {
-            conditions.add(TASK_INSTANCE.APP_ID.eq(appId));
-        }
-        if (taskStartupMode != null) {
-            conditions.add(TASK_INSTANCE.STARTUP_MODE.eq((byte) (taskStartupMode.getValue())));
-        }
-        if (taskType != null) {
-            conditions.add(TASK_INSTANCE.TYPE.eq(taskType.getValue().byteValue()));
-        }
-        if (runStatusList != null) {
-            conditions.add(TASK_INSTANCE.STATUS.in(runStatusList));
-        }
-        if (minTotalTime != null) {
-            conditions.add(TASK_INSTANCE.TOTAL_TIME.greaterOrEqual(minTotalTime * 1000));
-        }
-        if (maxTotalTime != null) {
-            conditions.add(TASK_INSTANCE.TOTAL_TIME.lessOrEqual(maxTotalTime * 1000));
-        }
-        if (fromTime != null) {
-            conditions.add(TASK_INSTANCE.CREATE_TIME.greaterOrEqual(fromTime));
-        }
-        if (toTime != null) {
-            conditions.add(TASK_INSTANCE.CREATE_TIME.lessThan(toTime));
-        }
-        return countTaskInstanceByConditions(conditions);
     }
 
     @Override

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/TaskInstanceService.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/TaskInstanceService.java
@@ -26,14 +26,10 @@ package com.tencent.bk.job.execute.service;
 
 import com.tencent.bk.job.common.model.dto.HostDTO;
 import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
-import com.tencent.bk.job.execute.common.constants.StepExecuteTypeEnum;
-import com.tencent.bk.job.execute.common.constants.TaskStartupModeEnum;
-import com.tencent.bk.job.execute.common.constants.TaskTypeEnum;
 import com.tencent.bk.job.execute.model.FileSourceDTO;
 import com.tencent.bk.job.execute.model.StepInstanceBaseDTO;
 import com.tencent.bk.job.execute.model.StepInstanceDTO;
 import com.tencent.bk.job.execute.model.TaskInstanceDTO;
-import com.tencent.bk.job.manage.common.consts.script.ScriptTypeEnum;
 
 import java.util.Collection;
 import java.util.List;
@@ -218,15 +214,6 @@ public interface TaskInstanceService {
      * @return 步骤详情
      */
     StepInstanceDTO getStepInstanceByTaskInstanceId(long taskInstanceId);
-
-    Integer countTaskInstances(Long appId, Long minTotalTime, Long maxTotalTime, TaskStartupModeEnum taskStartupMode,
-                               TaskTypeEnum taskType, List<Byte> runStatusList, Long fromTime, Long toTime);
-
-    Integer countStepInstances(Long appId, List<Long> stepIdList, StepExecuteTypeEnum stepExecuteType,
-                               ScriptTypeEnum scriptType, RunStatusEnum runStatus, Long fromTime, Long toTime);
-
-    Integer countFastPushFile(Long appId, Integer transferMode, Boolean localUpload, RunStatusEnum runStatus,
-                              Long fromTime, Long toTime);
 
     List<Long> getJoinedAppIdList();
 

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/statistics/StatisticsServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/statistics/StatisticsServiceImpl.java
@@ -531,7 +531,6 @@ public class StatisticsServiceImpl implements StatisticsService {
                             updateStartJobStatistics(taskInstance);
                         }
                         offset += limit;
-                        Thread.sleep(2000);
                     } while (taskInstanceIds.size() == limit);
                 }
             }


### PR DESCRIPTION
#2228 

### 修改
1. 修复时间范围计算的逻辑错误
2. 删除 job-execute metric 废弃 API
3.  优化 OpenApi 日志格式，防止因为英文冒号问题导致 ES 分词结果不正确，进而导致检索无法命中