### PR TITLE
fix: 脚本管理页面，批量编辑标签报错 #2263

### DIFF
--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebScriptResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebScriptResourceImpl.java
@@ -1093,6 +1093,11 @@ public class WebScriptResourceImpl implements WebScriptResource {
             return Response.buildValidateFailResp(validateResult);
         }
 
+        if (CollectionUtils.isEmpty(req.getAddTagIdList()) && CollectionUtils.isEmpty(req.getDeleteTagIdList())) {
+            // do nothing
+            return Response.buildSuccessResp(true);
+        }
+
         boolean isPublicScript = appResourceScope == null;
         List<String> scriptIdList = req.getIdList();
         AuthResult authResult;
@@ -1130,12 +1135,6 @@ public class WebScriptResourceImpl implements WebScriptResource {
         if (CollectionUtils.isEmpty(req.getIdList())) {
             log.warn("ScriptTagBatchUpdateReq->idList is empty");
             return ValidateResult.fail(ErrorCode.ILLEGAL_PARAM_WITH_PARAM_NAME, "idList");
-        }
-
-        if (CollectionUtils.isEmpty(req.getAddTagIdList()) && CollectionUtils.isEmpty(req.getDeleteTagIdList())) {
-            log.warn("ScriptTagBatchUpdateReq->No script tags changed!");
-            return ValidateResult.fail(ErrorCode.ILLEGAL_PARAM_WITH_PARAM_NAME,
-                "addTagIdList|deleteTagIdList");
         }
         return ValidateResult.pass();
     }


### PR DESCRIPTION
#2263 

### 修改
1. 兼容批量修改标签，新增/删除标签 ID 的参数同时为空的情况，默认不做任何处理，直接返回成功