### PR TITLE
perf: 优化K8s健康检测探针参数 #2270

### DIFF
--- a/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
+++ b/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
@@ -620,3 +620,36 @@ tls:
 {{- end -}}
 {{- end -}}
 
+
+{{/*
+Return the Job Service Probes Config
+*/}}
+{{- define "job.service.probes" -}}
+startupProbe:
+  httpGet:
+    path: /actuator/health/liveness
+    port: {{ .port }}
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 30
+  successThreshold: 1
+livenessProbe:
+  httpGet:
+    path: /actuator/health/liveness
+    port: {{ .port }}
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 2
+  successThreshold: 1
+readinessProbe:
+  httpGet:
+    path: /actuator/health/readiness
+    port: {{ .port }}
+  initialDelaySeconds: 10
+  periodSeconds: 3
+  timeoutSeconds: 3
+  failureThreshold: 1
+  successThreshold: 1
+{{- end -}}

--- a/support-files/kubernetes/charts/bk-job/templates/config-watch/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/config-watch/deployment.yaml
@@ -76,24 +76,7 @@ spec:
               value: /etc/secrets
             - name: spring.cloud.kubernetes.configuration.watcher.refreshDelay
               value: "1000"
-          livenessProbe:
-            httpGet:
-              path: /actuator/health/liveness
-              port: http
-            initialDelaySeconds: 200  
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
-          readinessProbe:
-            httpGet:
-              path: /actuator/health/readiness
-              port: http
-            initialDelaySeconds: 200
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
+          {{- include "job.service.probes" ( dict "port" "http" "context" . ) | nindent 10 }}
           resources:
             {{- toYaml .Values.k8sConfigWatcherConfig.resources | nindent 12 }}
           volumeMounts:

--- a/support-files/kubernetes/charts/bk-job/templates/job-analysis/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-analysis/deployment.yaml
@@ -97,24 +97,7 @@ spec:
             - name: http
               containerPort: {{ .Values.analysisConfig.containerPort }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /actuator/health/liveness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
-          readinessProbe:
-            httpGet:
-              path: /actuator/health/readiness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
+          {{- include "job.service.probes" ( dict "port" "http" "context" . ) | nindent 10 }}
           resources:
             {{- toYaml .Values.analysisConfig.resources | nindent 12 }}
           volumeMounts:

--- a/support-files/kubernetes/charts/bk-job/templates/job-backup/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-backup/deployment.yaml
@@ -97,24 +97,7 @@ spec:
             - name: http
               containerPort: {{ .Values.backupConfig.containerPort }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /actuator/health/liveness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
-          readinessProbe:
-            httpGet:
-              path: /actuator/health/readiness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
+          {{- include "job.service.probes" ( dict "port" "http" "context" . ) | nindent 10 }}
           resources:
             {{- toYaml .Values.backupConfig.resources | nindent 12 }}
           volumeMounts:

--- a/support-files/kubernetes/charts/bk-job/templates/job-crontab/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-crontab/deployment.yaml
@@ -97,24 +97,7 @@ spec:
             - name: http
               containerPort: {{ .Values.crontabConfig.containerPort }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /actuator/health/liveness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
-          readinessProbe:
-            httpGet:
-              path: /actuator/health/readiness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
+          {{- include "job.service.probes" ( dict "port" "http" "context" . ) | nindent 10 }}
           resources:
             {{- toYaml .Values.crontabConfig.resources | nindent 12 }}
           volumeMounts:

--- a/support-files/kubernetes/charts/bk-job/templates/job-execute/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-execute/deployment.yaml
@@ -101,24 +101,7 @@ spec:
             - name: http
               containerPort: {{ .Values.executeConfig.containerPort }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /actuator/health/liveness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
-          readinessProbe:
-            httpGet:
-              path: /actuator/health/readiness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
+          {{- include "job.service.probes" ( dict "port" "http" "context" . ) | nindent 10 }}
           resources:
             {{- toYaml .Values.executeConfig.resources | nindent 12 }}
           volumeMounts:

--- a/support-files/kubernetes/charts/bk-job/templates/job-file-gateway/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-file-gateway/deployment.yaml
@@ -97,24 +97,7 @@ spec:
             - name: http
               containerPort: {{ .Values.fileGatewayConfig.containerPort }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /actuator/health/liveness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
-          readinessProbe:
-            httpGet:
-              path: /actuator/health/readiness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
+          {{- include "job.service.probes" ( dict "port" "http" "context" . ) | nindent 10 }}
           resources:
             {{- toYaml .Values.fileGatewayConfig.resources | nindent 12 }}
           volumeMounts:

--- a/support-files/kubernetes/charts/bk-job/templates/job-file-worker/statefulset.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-file-worker/statefulset.yaml
@@ -102,24 +102,7 @@ spec:
             - name: http
               containerPort: {{ .Values.fileWorkerConfig.containerPort }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /actuator/health/liveness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
-          readinessProbe:
-            httpGet:
-              path: /actuator/health/readiness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
+          {{- include "job.service.probes" ( dict "port" "http" "context" . ) | nindent 10 }}
           resources:
             {{- toYaml .Values.fileWorkerConfig.resources | nindent 12 }}
           volumeMounts:

--- a/support-files/kubernetes/charts/bk-job/templates/job-gateway/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-gateway/deployment.yaml
@@ -102,24 +102,7 @@ spec:
             - name: management
               containerPort: {{ .Values.gatewayConfig.containerPort.management }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /actuator/health/liveness
-              port: management
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
-          readinessProbe:
-            httpGet:
-              path: /actuator/health/readiness
-              port: management
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
+          {{- include "job.service.probes" ( dict "port" "management" "context" . ) | nindent 10 }}
           resources:
             {{- toYaml .Values.gatewayConfig.resources | nindent 12 }}
           volumeMounts:

--- a/support-files/kubernetes/charts/bk-job/templates/job-logsvr/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-logsvr/deployment.yaml
@@ -96,24 +96,7 @@ spec:
             - name: http
               containerPort: {{ .Values.logsvrConfig.containerPort }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /actuator/health/liveness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
-          readinessProbe:
-            httpGet:
-              path: /actuator/health/readiness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
+          {{- include "job.service.probes" ( dict "port" "http" "context" . ) | nindent 10 }}
           resources:
             {{- toYaml .Values.logsvrConfig.resources | nindent 12 }}
           volumeMounts:

--- a/support-files/kubernetes/charts/bk-job/templates/job-manage/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-manage/deployment.yaml
@@ -99,24 +99,7 @@ spec:
             - name: http
               containerPort: {{ .Values.manageConfig.containerPort }}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /actuator/health/liveness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
-          readinessProbe:
-            httpGet:
-              path: /actuator/health/readiness
-              port: http
-            initialDelaySeconds: 60
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 30
-            successThreshold: 1
+          {{- include "job.service.probes" ( dict "port" "http" "context" . ) | nindent 10 }}
           resources:
             {{- toYaml .Values.manageConfig.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
1.使用startupProbe优化启动阶段的探测，提高livenessProbe与readinessProbe灵敏度，避免滚动升级时的调用失败； 
2.抽象重复配置块。