### PR TITLE
fix: 文件分发使用严谨模式，目标目录如果不存在仍然会被自动创建 #2354

### DIFF
--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v1/GseV1ApiClient.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v1/GseV1ApiClient.java
@@ -405,7 +405,7 @@ public class GseV1ApiClient implements IGseClient {
     private List<api_copy_fileinfoV2> toV1CopyFileInfoRequest(TransferFileRequest request) {
         return request.getTasks().stream()
             .map(task -> buildCopyFileInfo(task, request.getUploadSpeed(),
-                request.getDownloadSpeed(), request.getTimeout()))
+                request.getDownloadSpeed(), request.getTimeout(), request.isAutoMkdir()))
             .collect(Collectors.toList());
     }
 
@@ -622,13 +622,18 @@ public class GseV1ApiClient implements IGseClient {
     /**
      * 构建 GSE 拷贝文件请求
      *
-     * @param task 文件拷贝任务
+     * @param task               文件拷贝任务
+     * @param uploadSpeedLimit   上传限速，null 表示不限速
+     * @param downloadSpeedLimit 下载限速，null 表示不限速
+     * @param timeout            任务超时时间
+     * @param autoMkdir          目标目录不存在，是否自动创建目录
      * @return 拷贝文件请求
      */
     public api_copy_fileinfoV2 buildCopyFileInfo(FileTransferTask task,
                                                  Integer uploadSpeedLimit,
                                                  Integer downloadSpeedLimit,
-                                                 Integer timeout) {
+                                                 Integer timeout,
+                                                 boolean autoMkdir) {
         api_copy_fileinfoV2 copyFileInfo = new api_copy_fileinfoV2();
 
         api_base_file_info baseFileInfo = new api_base_file_info();
@@ -657,6 +662,7 @@ public class GseV1ApiClient implements IGseClient {
         if (timeout != null) {
             copyFileInfo.setTimeout(timeout);
         }
+        copyFileInfo.setMkdirflag(autoMkdir ? 1 : 0);
         return copyFileInfo;
     }
 


### PR DESCRIPTION
#2354 