### PR TITLE
perf: maven 配置优化 #2409

### DIFF
--- a/src/backend/build.gradle
+++ b/src/backend/build.gradle
@@ -34,26 +34,20 @@ buildscript {
     repositories {
         mavenLocal()
 
-        def mavenRepoUrl = System.getProperty("mavenRepoUrl")
-        if (mavenRepoUrl == null) {
-            mavenRepoUrl = System.getenv("mavenRepoUrl")
+        // 用户通过命令行方式指定的 maven repo
+        def mavenRepoUrls = System.getProperty("mavenRepoUrl")
+        if (mavenRepoUrls == null || mavenRepoUrls.trim().length() == 0) {
+            // gradle.properties 中的 maven repo。优先级从高到低:
+            // 1. command line, as set using -D.
+            // 2. gradle.properties in GRADLE_USER_HOME directory (<home directory of the current user>/.gradle by default)
+            // 3. gradle.properties in the project’s directory, then its parent project’s directory up to the build’s root directory.
+            // 4. gradle.properties in Gradle installation directory.
+            mavenRepoUrls = project.findProperty("MAVEN_REPO_URL")
         }
-        if (mavenRepoUrl == null) {
-            mavenRepoUrl = MAVEN_REPO_URL
-        }
-        if (mavenRepoUrl != null) {
-            println("Add default maven repo :" + mavenRepoUrl)
-            maven { url mavenRepoUrl }
-        }
-
-        def extraMavenRepoUrls = System.getProperty("extraMavenRepoUrls")
-        if (extraMavenRepoUrls == null) {
-            extraMavenRepoUrls = System.getenv("extraMavenRepoUrls")
-        }
-        if (extraMavenRepoUrls != null) {
-            String[] repoUrls = extraMavenRepoUrls.trim().replace(" ", "").split(",")
+        if (mavenRepoUrls != null && mavenRepoUrls.trim().length() > 0) {
+            String[] repoUrls = mavenRepoUrls.trim().replace(" ", "").split(",")
             for (String repoUrl : repoUrls) {
-                println("Add extra maven repo:" + repoUrl)
+                println("Add maven repo:" + repoUrl)
                 maven { url repoUrl }
             }
         }
@@ -175,26 +169,20 @@ allprojects {
     repositories {
         mavenLocal()
 
-        def mavenRepoUrl = System.getProperty("mavenRepoUrl")
-        if (mavenRepoUrl == null) {
-            mavenRepoUrl = System.getenv("mavenRepoUrl")
+        // 用户通过命令行方式指定的 maven repo
+        def mavenRepoUrls = System.getProperty("mavenRepoUrl")
+        if (mavenRepoUrls == null || mavenRepoUrls.trim().length() == 0) {
+            // gradle.properties 中的 maven repo。优先级从高到低:
+            // 1. command line, as set using -D.
+            // 2. gradle.properties in GRADLE_USER_HOME directory. (<home directory of the current user>/.gradle by default)
+            // 3. gradle.properties in the project’s directory, then its parent project’s directory up to the build’s root directory.
+            // 4. gradle.properties in Gradle installation directory.
+            mavenRepoUrls = project.findProperty("MAVEN_REPO_URL")
         }
-        if (mavenRepoUrl == null) {
-            mavenRepoUrl = MAVEN_REPO_URL
-        }
-        if (mavenRepoUrl != null) {
-            println("Add default maven repo :" + mavenRepoUrl)
-            maven { url mavenRepoUrl }
-        }
-
-        def extraMavenRepoUrls = System.getProperty("extraMavenRepoUrls")
-        if (extraMavenRepoUrls == null) {
-            extraMavenRepoUrls = System.getenv("extraMavenRepoUrls")
-        }
-        if (extraMavenRepoUrls != null) {
-            String[] repoUrls = extraMavenRepoUrls.trim().replace(" ", "").split(",")
+        if (mavenRepoUrls != null && mavenRepoUrls.trim().length() > 0) {
+            String[] repoUrls = mavenRepoUrls.trim().replace(" ", "").split(",")
             for (String repoUrl : repoUrls) {
-                println("Add extra maven repo:" + repoUrl)
+                println("Add maven repo:" + repoUrl)
                 maven { url repoUrl }
             }
         }

--- a/src/backend/gradle.properties
+++ b/src/backend/gradle.properties
@@ -27,7 +27,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 org.gradle.daemon=true
 org.gradle.daemon.idleTimeout=3600000
 MAVEN_REPO_URL=
-MAVEN_REPO_DEPLOY_URL=
 MAVEN_REPO_USERNAME=
 MAVEN_REPO_PASSWORD=
 DB_HOST=

--- a/src/backend/task_gen_jooq.gradle
+++ b/src/backend/task_gen_jooq.gradle
@@ -56,16 +56,10 @@ jooq {
             def mysqlPasswd = System.getProperty("mysqlPasswd")
 
             if (mysqlURL == null) {
-                mysqlURL = System.getenv("mysqlURL")
-                mysqlUser = System.getenv("mysqlUser")
-                mysqlPasswd = System.getenv("mysqlPasswd")
-            }
-
-            if (mysqlURL == null) {
-                println "use default mysql database."
-                mysqlURL = DB_HOST
-                mysqlUser = DB_USERNAME
-                mysqlPasswd = DB_PASSWORD
+                // gradle.properties 中的 Jooq DB 配置
+                mysqlURL = project.findProperty("DB_HOST")
+                mysqlUser = project.findProperty("DB_USERNAME")
+                mysqlPasswd = project.findProperty("DB_PASSWORD")
             }
 
             println("mysqlURL=" + mysqlURL)


### PR DESCRIPTION
1. 简化 maven 配置，删除 extraMavenRepoUrl
2. 扩展mavenRepoUrl， 支持传入多个 maven url
3. 简化 maven repo 的配置配置，仅支持命令行指定 -DmavenRepoUrl 和 从 gradle.properties 读取，不再支持从环境变量读取（容易混乱）