### PR TITLE
fix: file-worker任务状态更新请求无序到达导致第三方源文件偶现分发失败 #2434

### DIFF
--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/FileSourceTaskDAO.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/FileSourceTaskDAO.java
@@ -41,7 +41,7 @@ public interface FileSourceTaskDAO {
 
     FileSourceTaskDTO getFileSourceTaskByIdForUpdate(String id);
 
-    Long countFileSourceTasksByBatchTaskId(String batchTaskId, Byte status);
+    Long countFileSourceTasksByBatchTaskIdForUpdate(String batchTaskId, Byte status);
 
     List<FileSourceTaskDTO> listByBatchTaskId(String batchTaskId);
 }

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/FileTaskDAO.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/FileTaskDAO.java
@@ -47,5 +47,5 @@ public interface FileTaskDAO {
 
     List<FileTaskDTO> listFileTasks(String fileSourceTaskId);
 
-    Long countFileTask(String fileSourceTaskId, Byte status);
+    Long countFileTaskForUpdate(String fileSourceTaskId, Byte status);
 }

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/impl/FileSourceTaskDAOImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/impl/FileSourceTaskDAOImpl.java
@@ -190,7 +190,7 @@ public class FileSourceTaskDAOImpl extends BaseDAOImpl implements FileSourceTask
     }
 
     @Override
-    public Long countFileSourceTasksByBatchTaskId(String batchTaskId, Byte status) {
+    public Long countFileSourceTasksByBatchTaskIdForUpdate(String batchTaskId, Byte status) {
         List<Condition> conditions = new ArrayList<>();
         if (batchTaskId != null) {
             conditions.add(defaultTable.BATCH_TASK_ID.eq(batchTaskId));
@@ -198,15 +198,15 @@ public class FileSourceTaskDAOImpl extends BaseDAOImpl implements FileSourceTask
         if (status != null) {
             conditions.add(defaultTable.STATUS.eq(status));
         }
-        return countFileSourceTasksByConditions(conditions);
+        return countFileSourceTasksByConditionsForUpdate(conditions);
     }
 
-    public Long countFileSourceTasksByConditions(Collection<Condition> conditions) {
+    public Long countFileSourceTasksByConditionsForUpdate(Collection<Condition> conditions) {
         val query = dslContext.select(
             DSL.countDistinct(defaultTable.ID)
         ).from(defaultTable)
             .where(conditions);
-        return query.fetchOne(0, Long.class);
+        return query.forUpdate().fetchOne(0, Long.class);
     }
 
     public List<FileSourceTaskDTO> listByConditions(Collection<Condition> conditions,

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/impl/FileTaskDAOImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/impl/FileTaskDAOImpl.java
@@ -149,12 +149,12 @@ public class FileTaskDAOImpl extends BaseDAOImpl implements FileTaskDAO {
         }
     }
 
-    public Long countFileTasksByConditions(Collection<Condition> conditions) {
+    public Long countFileTasksByConditionsForUpdate(Collection<Condition> conditions) {
         val query = dslContext.select(
             DSL.countDistinct(defaultTable.ID)
         ).from(defaultTable)
             .where(conditions);
-        return query.fetchOne(0, Long.class);
+        return query.forUpdate().fetchOne(0, Long.class);
     }
 
     @Override
@@ -196,7 +196,7 @@ public class FileTaskDAOImpl extends BaseDAOImpl implements FileTaskDAO {
     }
 
     @Override
-    public Long countFileTask(String fileSourceTaskId, Byte status) {
+    public Long countFileTaskForUpdate(String fileSourceTaskId, Byte status) {
         List<Condition> conditions = new ArrayList<>();
         if (fileSourceTaskId != null) {
             conditions.add(defaultTable.FILE_SOURCE_TASK_ID.eq(fileSourceTaskId));
@@ -204,7 +204,7 @@ public class FileTaskDAOImpl extends BaseDAOImpl implements FileTaskDAO {
         if (status != null) {
             conditions.add(defaultTable.STATUS.eq(status));
         }
-        return countFileTasksByConditions(conditions);
+        return countFileTasksByConditionsForUpdate(conditions);
     }
 
     private FileTaskDTO convertRecordToDto(FileTaskRecord record) {

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceTaskServiceImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceTaskServiceImpl.java
@@ -228,8 +228,10 @@ public class FileSourceTaskServiceImpl implements FileSourceTaskService {
         redisTemplate.expireAt(PREFIX_REDIS_TASK_LOG + taskId, new Date(System.currentTimeMillis() + 3600 * 1000));
     }
 
-    private void notifyFileTaskStatusChangeListeners(FileTaskDTO fileTaskDTO, FileSourceTaskDTO fileSourceTaskDTO,
-                                                     FileWorkerDTO fileWorkerDTO, TaskStatusEnum previousStatus,
+    private void notifyFileTaskStatusChangeListeners(FileTaskDTO fileTaskDTO,
+                                                     FileSourceTaskDTO fileSourceTaskDTO,
+                                                     FileWorkerDTO fileWorkerDTO,
+                                                     TaskStatusEnum previousStatus,
                                                      TaskStatusEnum currentStatus) {
         TaskContext context = new DefaultTaskContext(fileTaskDTO, fileSourceTaskDTO, fileWorkerDTO);
         if (!fileTaskStatusChangeListenerList.isEmpty()) {
@@ -293,8 +295,7 @@ public class FileSourceTaskServiceImpl implements FileSourceTaskService {
         }
         // 通知关注者
         if (status != previousStatus) {
-            notifyFileTaskStatusChangeListeners(fileTaskDTO, fileSourceTaskDTO, fileWorkerDTO,
-                TaskStatusEnum.valueOf(fileTaskDTO.getStatus()), status);
+            notifyFileTaskStatusChangeListeners(fileTaskDTO, fileSourceTaskDTO, fileWorkerDTO, previousStatus, status);
         }
         // 进度上报
         writeLog(fileSourceTaskDTO, fileWorkerDTO, filePath, fileSize, speed, progress, content);

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/listener/FileSourceTaskStatusChangeListener.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/listener/FileSourceTaskStatusChangeListener.java
@@ -29,12 +29,12 @@ import com.tencent.bk.job.file_gateway.service.context.TaskContext;
 
 public interface FileSourceTaskStatusChangeListener {
     /**
-     * Invoked when FileSourceTask status change
+     * 在单个文件源任务状态改变时被调用
      *
-     * @param context
-     * @param previousStatus
-     * @param currentStatus
-     * @return true if need to stop event dispatch to later listeners
+     * @param context        任务上下文
+     * @param previousStatus 上一个状态
+     * @param currentStatus  当前状态
+     * @return true 如果需要终止事件向后续的Listener传递则返回true
      */
     boolean onStatusChange(TaskContext context, TaskStatusEnum previousStatus, TaskStatusEnum currentStatus);
 }

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/listener/FileTaskStatusChangeListener.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/listener/FileTaskStatusChangeListener.java
@@ -29,12 +29,12 @@ import com.tencent.bk.job.file_gateway.service.context.TaskContext;
 
 public interface FileTaskStatusChangeListener {
     /**
-     * Invoked when FileTask status change
+     * 在单个文件任务状态改变时被调用
      *
-     * @param context
-     * @param previousStatus
-     * @param currentStatus
-     * @return true if need to stop event dispatch to later listeners
+     * @param context        任务上下文
+     * @param previousStatus 上一个状态
+     * @param currentStatus  当前状态
+     * @return true 如果需要终止事件向后续的Listener传递则返回true
      */
     boolean onStatusChange(TaskContext context, TaskStatusEnum previousStatus, TaskStatusEnum currentStatus);
 }

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/listener/impl/BatchTaskStatusUpdater.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/listener/impl/BatchTaskStatusUpdater.java
@@ -65,8 +65,8 @@ public class BatchTaskStatusUpdater implements FileSourceTaskStatusChangeListene
         }
         if (TaskStatusEnum.SUCCESS.equals(currentStatus)) {
             //检查批量任务是否成功
-            if (fileSourceTaskDAO.countFileSourceTasksByBatchTaskId(batchTaskId, null)
-                .equals(fileSourceTaskDAO.countFileSourceTasksByBatchTaskId(
+            if (fileSourceTaskDAO.countFileSourceTasksByBatchTaskIdForUpdate(batchTaskId, null)
+                .equals(fileSourceTaskDAO.countFileSourceTasksByBatchTaskIdForUpdate(
                     batchTaskId, TaskStatusEnum.SUCCESS.getStatus()))) {
                 // 批量任务成功
                 fileSourceBatchTaskDTO.setStatus(TaskStatusEnum.SUCCESS.getStatus());

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/listener/impl/FileSourceTaskStatusUpdater.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/listener/impl/FileSourceTaskStatusUpdater.java
@@ -93,8 +93,8 @@ public class FileSourceTaskStatusUpdater implements FileTaskStatusChangeListener
             }
         } else if (TaskStatusEnum.SUCCESS.equals(currentStatus)) {
             //检查主任务是否成功
-            if (fileTaskDAO.countFileTask(fileSourceTaskId, null).equals(fileTaskDAO.countFileTask(fileSourceTaskId,
-                TaskStatusEnum.SUCCESS.getStatus()))) {
+            if (fileTaskDAO.countFileTaskForUpdate(fileSourceTaskId, null).equals(
+                fileTaskDAO.countFileTaskForUpdate(fileSourceTaskId, TaskStatusEnum.SUCCESS.getStatus()))) {
                 // 主任务成功
                 fileSourceTaskDTO.setStatus(TaskStatusEnum.SUCCESS.getStatus());
                 fileSourceTaskDAO.updateFileSourceTask(fileSourceTaskDTO);


### PR DESCRIPTION
统计子任务完成状态时加锁，防止应用统计结果的过程中数据被修改