### PR TITLE
perf: 容器化宿主机路径与PV使用策略调整 #1782

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v2/impl/EsbPushConfigFileResourceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v2/impl/EsbPushConfigFileResourceImpl.java
@@ -44,7 +44,7 @@ import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
 import com.tencent.bk.job.execute.common.constants.StepExecuteTypeEnum;
 import com.tencent.bk.job.execute.common.constants.TaskStartupModeEnum;
 import com.tencent.bk.job.execute.common.constants.TaskTypeEnum;
-import com.tencent.bk.job.execute.config.StorageSystemConfig;
+import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
 import com.tencent.bk.job.execute.metrics.ExecuteMetricsConstants;
 import com.tencent.bk.job.execute.model.AccountDTO;
 import com.tencent.bk.job.execute.model.FastTaskDTO;
@@ -72,19 +72,19 @@ public class EsbPushConfigFileResourceImpl extends JobExecuteCommonProcessor imp
     private final TaskExecuteService taskExecuteService;
 
     private final AccountService accountService;
-    private final StorageSystemConfig storageSystemConfig;
+    private final StorageAndDistributeConfig storageAndDistributeConfig;
     private final AgentService agentService;
     private final AppScopeMappingService appScopeMappingService;
 
     @Autowired
     public EsbPushConfigFileResourceImpl(TaskExecuteService taskExecuteService,
                                          AccountService accountService,
-                                         StorageSystemConfig storageSystemConfig,
+                                         StorageAndDistributeConfig storageAndDistributeConfig,
                                          AgentService agentService,
                                          AppScopeMappingService appScopeMappingService) {
         this.taskExecuteService = taskExecuteService;
         this.accountService = accountService;
-        this.storageSystemConfig = storageSystemConfig;
+        this.storageAndDistributeConfig = storageAndDistributeConfig;
         this.agentService = agentService;
         this.appScopeMappingService = appScopeMappingService;
     }
@@ -192,7 +192,7 @@ public class EsbPushConfigFileResourceImpl extends JobExecuteCommonProcessor imp
             fileSourceDTO.setFileType(TaskFileTypeEnum.BASE64_FILE.getType());
             // 保存配置文件至机器
             String configFileLocalPath = ConfigFileUtil.saveConfigFileToLocal(
-                storageSystemConfig.getJobStorageRootPath(),
+                storageAndDistributeConfig.getJobDistributeRootPath(),
                 userName,
                 configFile.getFileName(),
                 configFile.getContent()

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v2/impl/EsbPushConfigFileResourceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v2/impl/EsbPushConfigFileResourceImpl.java
@@ -44,7 +44,7 @@ import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
 import com.tencent.bk.job.execute.common.constants.StepExecuteTypeEnum;
 import com.tencent.bk.job.execute.common.constants.TaskStartupModeEnum;
 import com.tencent.bk.job.execute.common.constants.TaskTypeEnum;
-import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
+import com.tencent.bk.job.execute.config.FileDistributeConfig;
 import com.tencent.bk.job.execute.metrics.ExecuteMetricsConstants;
 import com.tencent.bk.job.execute.model.AccountDTO;
 import com.tencent.bk.job.execute.model.FastTaskDTO;
@@ -72,19 +72,19 @@ public class EsbPushConfigFileResourceImpl extends JobExecuteCommonProcessor imp
     private final TaskExecuteService taskExecuteService;
 
     private final AccountService accountService;
-    private final StorageAndDistributeConfig storageAndDistributeConfig;
+    private final FileDistributeConfig fileDistributeConfig;
     private final AgentService agentService;
     private final AppScopeMappingService appScopeMappingService;
 
     @Autowired
     public EsbPushConfigFileResourceImpl(TaskExecuteService taskExecuteService,
                                          AccountService accountService,
-                                         StorageAndDistributeConfig storageAndDistributeConfig,
+                                         FileDistributeConfig fileDistributeConfig,
                                          AgentService agentService,
                                          AppScopeMappingService appScopeMappingService) {
         this.taskExecuteService = taskExecuteService;
         this.accountService = accountService;
-        this.storageAndDistributeConfig = storageAndDistributeConfig;
+        this.fileDistributeConfig = fileDistributeConfig;
         this.agentService = agentService;
         this.appScopeMappingService = appScopeMappingService;
     }
@@ -192,7 +192,7 @@ public class EsbPushConfigFileResourceImpl extends JobExecuteCommonProcessor imp
             fileSourceDTO.setFileType(TaskFileTypeEnum.BASE64_FILE.getType());
             // 保存配置文件至机器
             String configFileLocalPath = ConfigFileUtil.saveConfigFileToLocal(
-                storageAndDistributeConfig.getJobDistributeRootPath(),
+                fileDistributeConfig.getJobDistributeRootPath(),
                 userName,
                 configFile.getFileName(),
                 configFile.getContent()

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v3/EsbPushConfigFileResourceV3Impl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v3/EsbPushConfigFileResourceV3Impl.java
@@ -40,7 +40,7 @@ import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
 import com.tencent.bk.job.execute.common.constants.StepExecuteTypeEnum;
 import com.tencent.bk.job.execute.common.constants.TaskStartupModeEnum;
 import com.tencent.bk.job.execute.common.constants.TaskTypeEnum;
-import com.tencent.bk.job.execute.config.StorageSystemConfig;
+import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
 import com.tencent.bk.job.execute.metrics.ExecuteMetricsConstants;
 import com.tencent.bk.job.execute.model.FastTaskDTO;
 import com.tencent.bk.job.execute.model.FileDetailDTO;
@@ -66,17 +66,17 @@ public class EsbPushConfigFileResourceV3Impl
     extends JobExecuteCommonV3Processor
     implements EsbPushConfigFileV3Resource {
     private final TaskExecuteService taskExecuteService;
-    private final StorageSystemConfig storageSystemConfig;
+    private final StorageAndDistributeConfig storageAndDistributeConfig;
     private final AgentService agentService;
     private final AppScopeMappingService appScopeMappingService;
 
     @Autowired
     public EsbPushConfigFileResourceV3Impl(TaskExecuteService taskExecuteService,
-                                           StorageSystemConfig storageSystemConfig,
+                                           StorageAndDistributeConfig storageAndDistributeConfig,
                                            AgentService agentService,
                                            AppScopeMappingService appScopeMappingService) {
         this.taskExecuteService = taskExecuteService;
-        this.storageSystemConfig = storageSystemConfig;
+        this.storageAndDistributeConfig = storageAndDistributeConfig;
         this.agentService = agentService;
         this.appScopeMappingService = appScopeMappingService;
     }
@@ -173,7 +173,7 @@ public class EsbPushConfigFileResourceV3Impl
             List<FileDetailDTO> files = new ArrayList<>();
             // 保存配置文件至机器
             String configFileLocalPath = ConfigFileUtil.saveConfigFileToLocal(
-                storageSystemConfig.getJobStorageRootPath(),
+                storageAndDistributeConfig.getJobDistributeRootPath(),
                 userName,
                 configFile.getFileName(),
                 configFile.getContent()

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v3/EsbPushConfigFileResourceV3Impl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v3/EsbPushConfigFileResourceV3Impl.java
@@ -40,7 +40,7 @@ import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
 import com.tencent.bk.job.execute.common.constants.StepExecuteTypeEnum;
 import com.tencent.bk.job.execute.common.constants.TaskStartupModeEnum;
 import com.tencent.bk.job.execute.common.constants.TaskTypeEnum;
-import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
+import com.tencent.bk.job.execute.config.FileDistributeConfig;
 import com.tencent.bk.job.execute.metrics.ExecuteMetricsConstants;
 import com.tencent.bk.job.execute.model.FastTaskDTO;
 import com.tencent.bk.job.execute.model.FileDetailDTO;
@@ -66,17 +66,17 @@ public class EsbPushConfigFileResourceV3Impl
     extends JobExecuteCommonV3Processor
     implements EsbPushConfigFileV3Resource {
     private final TaskExecuteService taskExecuteService;
-    private final StorageAndDistributeConfig storageAndDistributeConfig;
+    private final FileDistributeConfig fileDistributeConfig;
     private final AgentService agentService;
     private final AppScopeMappingService appScopeMappingService;
 
     @Autowired
     public EsbPushConfigFileResourceV3Impl(TaskExecuteService taskExecuteService,
-                                           StorageAndDistributeConfig storageAndDistributeConfig,
+                                           FileDistributeConfig fileDistributeConfig,
                                            AgentService agentService,
                                            AppScopeMappingService appScopeMappingService) {
         this.taskExecuteService = taskExecuteService;
-        this.storageAndDistributeConfig = storageAndDistributeConfig;
+        this.fileDistributeConfig = fileDistributeConfig;
         this.agentService = agentService;
         this.appScopeMappingService = appScopeMappingService;
     }
@@ -173,7 +173,7 @@ public class EsbPushConfigFileResourceV3Impl
             List<FileDetailDTO> files = new ArrayList<>();
             // 保存配置文件至机器
             String configFileLocalPath = ConfigFileUtil.saveConfigFileToLocal(
-                storageAndDistributeConfig.getJobDistributeRootPath(),
+                fileDistributeConfig.getJobDistributeRootPath(),
                 userName,
                 configFile.getFileName(),
                 configFile.getContent()

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/web/impl/WebTaskLogResourceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/web/impl/WebTaskLogResourceImpl.java
@@ -36,7 +36,7 @@ import com.tencent.bk.job.common.model.dto.AppResourceScope;
 import com.tencent.bk.job.common.util.date.DateUtils;
 import com.tencent.bk.job.execute.api.web.WebTaskLogResource;
 import com.tencent.bk.job.execute.config.LogExportConfig;
-import com.tencent.bk.job.execute.config.StorageSystemConfig;
+import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
 import com.tencent.bk.job.execute.engine.consts.FileDirTypeConf;
 import com.tencent.bk.job.execute.engine.util.NFSUtils;
 import com.tencent.bk.job.execute.model.LogExportJobInfoDTO;
@@ -76,14 +76,14 @@ public class WebTaskLogResourceImpl implements WebTaskLogResource {
 
     @Autowired
     public WebTaskLogResourceImpl(TaskInstanceService taskInstanceService,
-                                  StorageSystemConfig storageSystemConfig,
+                                  StorageAndDistributeConfig storageAndDistributeConfig,
                                   LogExportService logExportService,
                                   @Qualifier("jobArtifactoryClient") ArtifactoryClient artifactoryClient,
                                   ArtifactoryConfig artifactoryConfig,
                                   LogExportConfig logExportConfig) {
         this.taskInstanceService = taskInstanceService;
         this.logExportService = logExportService;
-        this.logFileDir = NFSUtils.getFileDir(storageSystemConfig.getJobStorageRootPath(),
+        this.logFileDir = NFSUtils.getFileDir(storageAndDistributeConfig.getJobStorageRootPath(),
             FileDirTypeConf.JOB_INSTANCE_PATH);
         this.artifactoryClient = artifactoryClient;
         this.artifactoryConfig = artifactoryConfig;

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/web/impl/WebTaskLogResourceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/web/impl/WebTaskLogResourceImpl.java
@@ -36,7 +36,7 @@ import com.tencent.bk.job.common.model.dto.AppResourceScope;
 import com.tencent.bk.job.common.util.date.DateUtils;
 import com.tencent.bk.job.execute.api.web.WebTaskLogResource;
 import com.tencent.bk.job.execute.config.LogExportConfig;
-import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
+import com.tencent.bk.job.execute.config.StorageConfig;
 import com.tencent.bk.job.execute.engine.consts.FileDirTypeConf;
 import com.tencent.bk.job.execute.engine.util.NFSUtils;
 import com.tencent.bk.job.execute.model.LogExportJobInfoDTO;
@@ -76,14 +76,14 @@ public class WebTaskLogResourceImpl implements WebTaskLogResource {
 
     @Autowired
     public WebTaskLogResourceImpl(TaskInstanceService taskInstanceService,
-                                  StorageAndDistributeConfig storageAndDistributeConfig,
+                                  StorageConfig storageConfig,
                                   LogExportService logExportService,
                                   @Qualifier("jobArtifactoryClient") ArtifactoryClient artifactoryClient,
                                   ArtifactoryConfig artifactoryConfig,
                                   LogExportConfig logExportConfig) {
         this.taskInstanceService = taskInstanceService;
         this.logExportService = logExportService;
-        this.logFileDir = NFSUtils.getFileDir(storageAndDistributeConfig.getJobStorageRootPath(),
+        this.logFileDir = NFSUtils.getFileDir(storageConfig.getJobStorageRootPath(),
             FileDirTypeConf.JOB_INSTANCE_PATH);
         this.artifactoryClient = artifactoryClient;
         this.artifactoryConfig = artifactoryConfig;
@@ -172,7 +172,8 @@ public class WebTaskLogResourceImpl implements WebTaskLogResource {
             throw new InternalException(ErrorCode.EXPORT_STEP_EXECUTION_LOG_FAIL);
         }
 
-        LogExportJobInfoDTO exportInfo = logExportService.packageLogFile(username, appId, stepInstanceId, hostId, cloudIp,
+        LogExportJobInfoDTO exportInfo = logExportService.packageLogFile(username, appId, stepInstanceId, hostId,
+            cloudIp,
             executeCount, logFileDir, logFileName, repackage);
         return Response.buildSuccessResp(LogExportJobInfoDTO.toVO(exportInfo));
     }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/config/FileDistributeConfig.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/config/FileDistributeConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.execute.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 文件分发配置
+ */
+@Getter
+@Configuration("jobExecuteFileDistributeConfig")
+public class FileDistributeConfig {
+    /**
+     * 要分发的文件存储根目录，二进制环境下与临时文件存储根目录相同
+     */
+    @Value("${job.execute.file.distribute.root-path:/data/bkee/job/data}")
+    private String jobDistributeRootPath;
+}

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/config/StorageAndDistributeConfig.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/config/StorageAndDistributeConfig.java
@@ -29,11 +29,19 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * 存储配置
+ * 存储与分发配置
  */
 @Getter
-@Configuration("jobExecuteStorageSystemConfig")
-public class StorageSystemConfig {
+@Configuration("jobExecuteStorageAndDistributeConfig")
+public class StorageAndDistributeConfig {
+    /**
+     * 临时文件存储根目录
+     */
     @Value("${job.storage.root-path:/data/bkee/job/data}")
     private String jobStorageRootPath;
+    /**
+     * 要分发的文件存储根目录，二进制环境下与临时文件存储根目录相同
+     */
+    @Value("${job.distribute.root-path:/data/bkee/job/data}")
+    private String jobDistributeRootPath;
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/config/StorageConfig.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/config/StorageConfig.java
@@ -32,16 +32,11 @@ import org.springframework.context.annotation.Configuration;
  * 存储与分发配置
  */
 @Getter
-@Configuration("jobExecuteStorageAndDistributeConfig")
-public class StorageAndDistributeConfig {
+@Configuration("jobExecuteStorageConfig")
+public class StorageConfig {
     /**
      * 临时文件存储根目录
      */
     @Value("${job.storage.root-path:/data/bkee/job/data}")
     private String jobStorageRootPath;
-    /**
-     * 要分发的文件存储根目录，二进制环境下与临时文件存储根目录相同
-     */
-    @Value("${job.distribute.root-path:/data/bkee/job/data}")
-    private String jobDistributeRootPath;
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/GseTaskManager.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/GseTaskManager.java
@@ -32,8 +32,8 @@ import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
 import com.tencent.bk.job.execute.common.constants.StepExecuteTypeEnum;
 import com.tencent.bk.job.execute.common.exception.MessageHandlerUnavailableException;
 import com.tencent.bk.job.execute.common.ha.DestroyOrder;
+import com.tencent.bk.job.execute.config.FileDistributeConfig;
 import com.tencent.bk.job.execute.config.JobExecuteConfig;
-import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
 import com.tencent.bk.job.execute.engine.evict.TaskEvictPolicyExecutor;
 import com.tencent.bk.job.execute.engine.listener.event.EventSource;
 import com.tencent.bk.job.execute.engine.listener.event.StepEvent;
@@ -94,7 +94,7 @@ public class GseTaskManager implements SmartLifecycle {
     private final JobBuildInVariableResolver jobBuildInVariableResolver;
     private final Tracer tracer;
     private final ExecuteMonitor executeMonitor;
-    private final StorageAndDistributeConfig storageAndDistributeConfig;
+    private final FileDistributeConfig fileDistributeConfig;
     private final JobExecuteConfig jobExecuteConfig;
     private final TaskEvictPolicyExecutor taskEvictPolicyExecutor;
     private final GseTasksExceptionCounter gseTasksExceptionCounter;
@@ -144,7 +144,7 @@ public class GseTaskManager implements SmartLifecycle {
                           TaskInstanceVariableService taskInstanceVariableService,
                           StepInstanceVariableValueService stepInstanceVariableValueService,
                           JobBuildInVariableResolver jobBuildInVariableResolver,
-                          StorageAndDistributeConfig storageAndDistributeConfig,
+                          FileDistributeConfig fileDistributeConfig,
                           AgentService agentService,
                           ResultHandleTaskKeepaliveManager resultHandleTaskKeepaliveManager,
                           GseTasksExceptionCounter gseTasksExceptionCounter,
@@ -167,7 +167,7 @@ public class GseTaskManager implements SmartLifecycle {
         this.taskInstanceVariableService = taskInstanceVariableService;
         this.stepInstanceVariableValueService = stepInstanceVariableValueService;
         this.jobBuildInVariableResolver = jobBuildInVariableResolver;
-        this.storageAndDistributeConfig = storageAndDistributeConfig;
+        this.fileDistributeConfig = fileDistributeConfig;
         this.agentService = agentService;
         this.resultHandleTaskKeepaliveManager = resultHandleTaskKeepaliveManager;
         this.gseTasksExceptionCounter = gseTasksExceptionCounter;
@@ -392,7 +392,7 @@ public class GseTaskManager implements SmartLifecycle {
                 taskInstance,
                 stepInstance,
                 gseTask,
-                storageAndDistributeConfig.getJobDistributeRootPath()
+                fileDistributeConfig.getJobDistributeRootPath()
             );
             fileTaskCounter.incrementAndGet();
         }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/GseTaskManager.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/GseTaskManager.java
@@ -33,7 +33,7 @@ import com.tencent.bk.job.execute.common.constants.StepExecuteTypeEnum;
 import com.tencent.bk.job.execute.common.exception.MessageHandlerUnavailableException;
 import com.tencent.bk.job.execute.common.ha.DestroyOrder;
 import com.tencent.bk.job.execute.config.JobExecuteConfig;
-import com.tencent.bk.job.execute.config.StorageSystemConfig;
+import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
 import com.tencent.bk.job.execute.engine.evict.TaskEvictPolicyExecutor;
 import com.tencent.bk.job.execute.engine.listener.event.EventSource;
 import com.tencent.bk.job.execute.engine.listener.event.StepEvent;
@@ -94,7 +94,7 @@ public class GseTaskManager implements SmartLifecycle {
     private final JobBuildInVariableResolver jobBuildInVariableResolver;
     private final Tracer tracer;
     private final ExecuteMonitor executeMonitor;
-    private final StorageSystemConfig storageSystemConfig;
+    private final StorageAndDistributeConfig storageAndDistributeConfig;
     private final JobExecuteConfig jobExecuteConfig;
     private final TaskEvictPolicyExecutor taskEvictPolicyExecutor;
     private final GseTasksExceptionCounter gseTasksExceptionCounter;
@@ -144,7 +144,7 @@ public class GseTaskManager implements SmartLifecycle {
                           TaskInstanceVariableService taskInstanceVariableService,
                           StepInstanceVariableValueService stepInstanceVariableValueService,
                           JobBuildInVariableResolver jobBuildInVariableResolver,
-                          StorageSystemConfig storageSystemConfig,
+                          StorageAndDistributeConfig storageAndDistributeConfig,
                           AgentService agentService,
                           ResultHandleTaskKeepaliveManager resultHandleTaskKeepaliveManager,
                           GseTasksExceptionCounter gseTasksExceptionCounter,
@@ -167,7 +167,7 @@ public class GseTaskManager implements SmartLifecycle {
         this.taskInstanceVariableService = taskInstanceVariableService;
         this.stepInstanceVariableValueService = stepInstanceVariableValueService;
         this.jobBuildInVariableResolver = jobBuildInVariableResolver;
-        this.storageSystemConfig = storageSystemConfig;
+        this.storageAndDistributeConfig = storageAndDistributeConfig;
         this.agentService = agentService;
         this.resultHandleTaskKeepaliveManager = resultHandleTaskKeepaliveManager;
         this.gseTasksExceptionCounter = gseTasksExceptionCounter;
@@ -392,7 +392,7 @@ public class GseTaskManager implements SmartLifecycle {
                 taskInstance,
                 stepInstance,
                 gseTask,
-                storageSystemConfig.getJobStorageRootPath()
+                storageAndDistributeConfig.getJobDistributeRootPath()
             );
             fileTaskCounter.incrementAndGet();
         }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/ResultHandleResumeListener.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/ResultHandleResumeListener.java
@@ -27,7 +27,7 @@ package com.tencent.bk.job.execute.engine.listener;
 import com.tencent.bk.job.common.gse.GseClient;
 import com.tencent.bk.job.common.util.FilePathUtils;
 import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
-import com.tencent.bk.job.execute.config.StorageSystemConfig;
+import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
 import com.tencent.bk.job.execute.engine.evict.TaskEvictPolicyExecutor;
 import com.tencent.bk.job.execute.engine.listener.event.ResultHandleTaskResumeEvent;
 import com.tencent.bk.job.execute.engine.listener.event.TaskExecuteMQEventDispatcher;
@@ -77,7 +77,7 @@ public class ResultHandleResumeListener {
 
     private final GseTaskService gseTaskService;
 
-    private final StorageSystemConfig storageSystemConfig;
+    private final StorageAndDistributeConfig storageAndDistributeConfig;
 
     private final LogService logService;
 
@@ -101,7 +101,7 @@ public class ResultHandleResumeListener {
                                       ResultHandleManager resultHandleManager,
                                       TaskInstanceVariableService taskInstanceVariableService,
                                       GseTaskService gseTaskService,
-                                      StorageSystemConfig storageSystemConfig,
+                                      StorageAndDistributeConfig storageAndDistributeConfig,
                                       LogService logService,
                                       StepInstanceVariableValueService stepInstanceVariableValueService,
                                       TaskExecuteMQEventDispatcher taskExecuteMQEventDispatcher,
@@ -115,7 +115,7 @@ public class ResultHandleResumeListener {
         this.resultHandleManager = resultHandleManager;
         this.taskInstanceVariableService = taskInstanceVariableService;
         this.gseTaskService = gseTaskService;
-        this.storageSystemConfig = storageSystemConfig;
+        this.storageAndDistributeConfig = storageAndDistributeConfig;
         this.logService = logService;
         this.stepInstanceVariableValueService = stepInstanceVariableValueService;
         this.taskExecuteMQEventDispatcher = taskExecuteMQEventDispatcher;
@@ -204,7 +204,7 @@ public class ResultHandleResumeListener {
                                 GseTaskDTO gseTask,
                                 String requestId) {
         Set<JobFile> sendFiles = JobSrcFileUtils.parseSrcFiles(stepInstance,
-            storageSystemConfig.getJobStorageRootPath());
+            storageAndDistributeConfig.getJobDistributeRootPath());
         String targetDir = FilePathUtils.standardizedDirPath(stepInstance.getResolvedFileTargetPath());
         Map<JobFile, FileDest> srcAndDestMap = JobSrcFileUtils.buildSourceDestPathMapping(
             sendFiles, targetDir, stepInstance.getFileTargetName());

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/ResultHandleResumeListener.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/listener/ResultHandleResumeListener.java
@@ -27,7 +27,7 @@ package com.tencent.bk.job.execute.engine.listener;
 import com.tencent.bk.job.common.gse.GseClient;
 import com.tencent.bk.job.common.util.FilePathUtils;
 import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
-import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
+import com.tencent.bk.job.execute.config.FileDistributeConfig;
 import com.tencent.bk.job.execute.engine.evict.TaskEvictPolicyExecutor;
 import com.tencent.bk.job.execute.engine.listener.event.ResultHandleTaskResumeEvent;
 import com.tencent.bk.job.execute.engine.listener.event.TaskExecuteMQEventDispatcher;
@@ -77,7 +77,7 @@ public class ResultHandleResumeListener {
 
     private final GseTaskService gseTaskService;
 
-    private final StorageAndDistributeConfig storageAndDistributeConfig;
+    private final FileDistributeConfig fileDistributeConfig;
 
     private final LogService logService;
 
@@ -101,7 +101,7 @@ public class ResultHandleResumeListener {
                                       ResultHandleManager resultHandleManager,
                                       TaskInstanceVariableService taskInstanceVariableService,
                                       GseTaskService gseTaskService,
-                                      StorageAndDistributeConfig storageAndDistributeConfig,
+                                      FileDistributeConfig fileDistributeConfig,
                                       LogService logService,
                                       StepInstanceVariableValueService stepInstanceVariableValueService,
                                       TaskExecuteMQEventDispatcher taskExecuteMQEventDispatcher,
@@ -115,7 +115,7 @@ public class ResultHandleResumeListener {
         this.resultHandleManager = resultHandleManager;
         this.taskInstanceVariableService = taskInstanceVariableService;
         this.gseTaskService = gseTaskService;
-        this.storageAndDistributeConfig = storageAndDistributeConfig;
+        this.fileDistributeConfig = fileDistributeConfig;
         this.logService = logService;
         this.stepInstanceVariableValueService = stepInstanceVariableValueService;
         this.taskExecuteMQEventDispatcher = taskExecuteMQEventDispatcher;
@@ -204,7 +204,7 @@ public class ResultHandleResumeListener {
                                 GseTaskDTO gseTask,
                                 String requestId) {
         Set<JobFile> sendFiles = JobSrcFileUtils.parseSrcFiles(stepInstance,
-            storageAndDistributeConfig.getJobDistributeRootPath());
+            fileDistributeConfig.getJobDistributeRootPath());
         String targetDir = FilePathUtils.standardizedDirPath(stepInstance.getResolvedFileTargetPath());
         Map<JobFile, FileDest> srcAndDestMap = JobSrcFileUtils.buildSourceDestPathMapping(
             sendFiles, targetDir, stepInstance.getFileTargetName());

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/local/LocalFilePrepareService.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/local/LocalFilePrepareService.java
@@ -27,8 +27,8 @@ package com.tencent.bk.job.execute.engine.prepare.local;
 import com.tencent.bk.job.common.artifactory.config.ArtifactoryConfig;
 import com.tencent.bk.job.common.artifactory.sdk.ArtifactoryClient;
 import com.tencent.bk.job.common.constant.JobConstants;
+import com.tencent.bk.job.execute.config.FileDistributeConfig;
 import com.tencent.bk.job.execute.config.LocalFileConfigForExecute;
-import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
 import com.tencent.bk.job.execute.engine.prepare.JobTaskContext;
 import com.tencent.bk.job.execute.model.FileSourceDTO;
 import com.tencent.bk.job.execute.model.ServersDTO;
@@ -51,7 +51,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 @Service
 public class LocalFilePrepareService {
 
-    private final StorageAndDistributeConfig storageAndDistributeConfig;
+    private final FileDistributeConfig fileDistributeConfig;
     private final ArtifactoryConfig artifactoryConfig;
     private final LocalFileConfigForExecute localFileConfigForExecute;
     private final AgentService agentService;
@@ -61,14 +61,14 @@ public class LocalFilePrepareService {
     private final ThreadPoolExecutor localFilePrepareExecutor;
 
     @Autowired
-    public LocalFilePrepareService(StorageAndDistributeConfig storageAndDistributeConfig,
+    public LocalFilePrepareService(FileDistributeConfig fileDistributeConfig,
                                    ArtifactoryConfig artifactoryConfig,
                                    LocalFileConfigForExecute localFileConfigForExecute,
                                    AgentService agentService,
                                    TaskInstanceService taskInstanceService,
                                    @Qualifier("jobArtifactoryClient") ArtifactoryClient artifactoryClient,
                                    @Qualifier("localFilePrepareExecutor") ThreadPoolExecutor localFilePrepareExecutor) {
-        this.storageAndDistributeConfig = storageAndDistributeConfig;
+        this.fileDistributeConfig = fileDistributeConfig;
         this.artifactoryConfig = artifactoryConfig;
         this.localFileConfigForExecute = localFileConfigForExecute;
         this.agentService = agentService;
@@ -108,7 +108,7 @@ public class LocalFilePrepareService {
             artifactoryClient,
             artifactoryConfig.getArtifactoryJobProject(),
             localFileConfigForExecute.getLocalUploadRepo(),
-            storageAndDistributeConfig.getJobDistributeRootPath(),
+            fileDistributeConfig.getJobDistributeRootPath(),
             localFilePrepareExecutor
         );
         taskMap.put(stepInstance.getUniqueKey(), task);

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/local/LocalFilePrepareService.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/local/LocalFilePrepareService.java
@@ -28,7 +28,7 @@ import com.tencent.bk.job.common.artifactory.config.ArtifactoryConfig;
 import com.tencent.bk.job.common.artifactory.sdk.ArtifactoryClient;
 import com.tencent.bk.job.common.constant.JobConstants;
 import com.tencent.bk.job.execute.config.LocalFileConfigForExecute;
-import com.tencent.bk.job.execute.config.StorageSystemConfig;
+import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
 import com.tencent.bk.job.execute.engine.prepare.JobTaskContext;
 import com.tencent.bk.job.execute.model.FileSourceDTO;
 import com.tencent.bk.job.execute.model.ServersDTO;
@@ -51,7 +51,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 @Service
 public class LocalFilePrepareService {
 
-    private final StorageSystemConfig storageSystemConfig;
+    private final StorageAndDistributeConfig storageAndDistributeConfig;
     private final ArtifactoryConfig artifactoryConfig;
     private final LocalFileConfigForExecute localFileConfigForExecute;
     private final AgentService agentService;
@@ -61,14 +61,14 @@ public class LocalFilePrepareService {
     private final ThreadPoolExecutor localFilePrepareExecutor;
 
     @Autowired
-    public LocalFilePrepareService(StorageSystemConfig storageSystemConfig,
+    public LocalFilePrepareService(StorageAndDistributeConfig storageAndDistributeConfig,
                                    ArtifactoryConfig artifactoryConfig,
                                    LocalFileConfigForExecute localFileConfigForExecute,
                                    AgentService agentService,
                                    TaskInstanceService taskInstanceService,
                                    @Qualifier("jobArtifactoryClient") ArtifactoryClient artifactoryClient,
                                    @Qualifier("localFilePrepareExecutor") ThreadPoolExecutor localFilePrepareExecutor) {
-        this.storageSystemConfig = storageSystemConfig;
+        this.storageAndDistributeConfig = storageAndDistributeConfig;
         this.artifactoryConfig = artifactoryConfig;
         this.localFileConfigForExecute = localFileConfigForExecute;
         this.agentService = agentService;
@@ -108,7 +108,7 @@ public class LocalFilePrepareService {
             artifactoryClient,
             artifactoryConfig.getArtifactoryJobProject(),
             localFileConfigForExecute.getLocalUploadRepo(),
-            storageSystemConfig.getJobStorageRootPath(),
+            storageAndDistributeConfig.getJobDistributeRootPath(),
             localFilePrepareExecutor
         );
         taskMap.put(stepInstance.getUniqueKey(), task);

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/task/LocalTmpFileCleanTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/task/LocalTmpFileCleanTask.java
@@ -27,7 +27,7 @@ package com.tencent.bk.job.execute.task;
 import com.tencent.bk.job.common.constant.JobConstants;
 import com.tencent.bk.job.common.util.file.PathUtil;
 import com.tencent.bk.job.execute.config.LocalFileConfigForExecute;
-import com.tencent.bk.job.execute.config.StorageSystemConfig;
+import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
 import com.tencent.bk.job.execute.constants.Consts;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
@@ -44,13 +44,13 @@ import java.util.Iterator;
 public class LocalTmpFileCleanTask {
 
     private final LocalFileConfigForExecute localFileConfigForExecute;
-    private final StorageSystemConfig storageSystemConfig;
+    private final StorageAndDistributeConfig storageAndDistributeConfig;
 
     public LocalTmpFileCleanTask(
         LocalFileConfigForExecute localFileConfigForExecute,
-        StorageSystemConfig storageSystemConfig) {
+        StorageAndDistributeConfig storageAndDistributeConfig) {
         this.localFileConfigForExecute = localFileConfigForExecute;
-        this.storageSystemConfig = storageSystemConfig;
+        this.storageAndDistributeConfig = storageAndDistributeConfig;
     }
 
     public void execute() {
@@ -77,7 +77,7 @@ public class LocalTmpFileCleanTask {
             System.currentTimeMillis() - 3600 * 24 * 1000
         );
         String localFileDirPath = PathUtil.joinFilePath(
-            storageSystemConfig.getJobStorageRootPath(), Consts.LOCAL_FILE_DIR_NAME
+            storageAndDistributeConfig.getJobDistributeRootPath(), Consts.LOCAL_FILE_DIR_NAME
         );
         Iterator<File> fileIterator = FileUtils.iterateFiles(
             new File(localFileDirPath),

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/task/LocalTmpFileCleanTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/task/LocalTmpFileCleanTask.java
@@ -26,8 +26,8 @@ package com.tencent.bk.job.execute.task;
 
 import com.tencent.bk.job.common.constant.JobConstants;
 import com.tencent.bk.job.common.util.file.PathUtil;
+import com.tencent.bk.job.execute.config.FileDistributeConfig;
 import com.tencent.bk.job.execute.config.LocalFileConfigForExecute;
-import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
 import com.tencent.bk.job.execute.constants.Consts;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
@@ -44,13 +44,13 @@ import java.util.Iterator;
 public class LocalTmpFileCleanTask {
 
     private final LocalFileConfigForExecute localFileConfigForExecute;
-    private final StorageAndDistributeConfig storageAndDistributeConfig;
+    private final FileDistributeConfig fileDistributeConfig;
 
     public LocalTmpFileCleanTask(
         LocalFileConfigForExecute localFileConfigForExecute,
-        StorageAndDistributeConfig storageAndDistributeConfig) {
+        FileDistributeConfig fileDistributeConfig) {
         this.localFileConfigForExecute = localFileConfigForExecute;
-        this.storageAndDistributeConfig = storageAndDistributeConfig;
+        this.fileDistributeConfig = fileDistributeConfig;
     }
 
     public void execute() {
@@ -77,7 +77,7 @@ public class LocalTmpFileCleanTask {
             System.currentTimeMillis() - 3600 * 24 * 1000
         );
         String localFileDirPath = PathUtil.joinFilePath(
-            storageAndDistributeConfig.getJobDistributeRootPath(), Consts.LOCAL_FILE_DIR_NAME
+            fileDistributeConfig.getJobDistributeRootPath(), Consts.LOCAL_FILE_DIR_NAME
         );
         Iterator<File> fileIterator = FileUtils.iterateFiles(
             new File(localFileDirPath),

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/task/LogExportFileCleanTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/task/LogExportFileCleanTask.java
@@ -32,7 +32,7 @@ import com.tencent.bk.job.common.constant.JobConstants;
 import com.tencent.bk.job.common.util.date.DateUtils;
 import com.tencent.bk.job.common.util.file.PathUtil;
 import com.tencent.bk.job.execute.config.LogExportConfig;
-import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
+import com.tencent.bk.job.execute.config.StorageConfig;
 import com.tencent.bk.job.execute.constants.Consts;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -59,16 +59,16 @@ public class LogExportFileCleanTask {
 
     private final LogExportConfig logExportConfig;
     private final ArtifactoryConfig artifactoryConfig;
-    private final StorageAndDistributeConfig storageAndDistributeConfig;
+    private final StorageConfig storageConfig;
     private final ArtifactoryClient artifactoryClient;
 
     public LogExportFileCleanTask(LogExportConfig logExportConfig,
                                   ArtifactoryConfig artifactoryConfig,
-                                  StorageAndDistributeConfig storageAndDistributeConfig,
+                                  StorageConfig storageConfig,
                                   @Qualifier("jobArtifactoryClient") ArtifactoryClient artifactoryClient) {
         this.logExportConfig = logExportConfig;
         this.artifactoryConfig = artifactoryConfig;
-        this.storageAndDistributeConfig = storageAndDistributeConfig;
+        this.storageConfig = storageConfig;
         this.artifactoryClient = artifactoryClient;
     }
 
@@ -161,7 +161,7 @@ public class LogExportFileCleanTask {
             System.currentTimeMillis() - logExportConfig.getArtifactoryFileExpireDays() * 3600 * 24 * 1000
         );
         String logExportFileDirPath = PathUtil.joinFilePath(
-            storageAndDistributeConfig.getJobStorageRootPath(), Consts.LOG_EXPORT_DIR_NAME
+            storageConfig.getJobStorageRootPath(), Consts.LOG_EXPORT_DIR_NAME
         );
         Iterator<File> fileIterator = FileUtils.iterateFiles(
             new File(logExportFileDirPath),

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/task/LogExportFileCleanTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/task/LogExportFileCleanTask.java
@@ -32,7 +32,7 @@ import com.tencent.bk.job.common.constant.JobConstants;
 import com.tencent.bk.job.common.util.date.DateUtils;
 import com.tencent.bk.job.common.util.file.PathUtil;
 import com.tencent.bk.job.execute.config.LogExportConfig;
-import com.tencent.bk.job.execute.config.StorageSystemConfig;
+import com.tencent.bk.job.execute.config.StorageAndDistributeConfig;
 import com.tencent.bk.job.execute.constants.Consts;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -59,16 +59,16 @@ public class LogExportFileCleanTask {
 
     private final LogExportConfig logExportConfig;
     private final ArtifactoryConfig artifactoryConfig;
-    private final StorageSystemConfig storageSystemConfig;
+    private final StorageAndDistributeConfig storageAndDistributeConfig;
     private final ArtifactoryClient artifactoryClient;
 
     public LogExportFileCleanTask(LogExportConfig logExportConfig,
                                   ArtifactoryConfig artifactoryConfig,
-                                  StorageSystemConfig storageSystemConfig,
+                                  StorageAndDistributeConfig storageAndDistributeConfig,
                                   @Qualifier("jobArtifactoryClient") ArtifactoryClient artifactoryClient) {
         this.logExportConfig = logExportConfig;
         this.artifactoryConfig = artifactoryConfig;
-        this.storageSystemConfig = storageSystemConfig;
+        this.storageAndDistributeConfig = storageAndDistributeConfig;
         this.artifactoryClient = artifactoryClient;
     }
 
@@ -161,7 +161,7 @@ public class LogExportFileCleanTask {
             System.currentTimeMillis() - logExportConfig.getArtifactoryFileExpireDays() * 3600 * 24 * 1000
         );
         String logExportFileDirPath = PathUtil.joinFilePath(
-            storageSystemConfig.getJobStorageRootPath(), Consts.LOG_EXPORT_DIR_NAME
+            storageAndDistributeConfig.getJobStorageRootPath(), Consts.LOG_EXPORT_DIR_NAME
         );
         Iterator<File> fileIterator = FileUtils.iterateFiles(
             new File(logExportFileDirPath),

--- a/support-files/kubernetes/charts/bk-job/README.md
+++ b/support-files/kubernetes/charts/bk-job/README.md
@@ -11,16 +11,21 @@ BK-JOB由11个微服务/独立程序构成
 - PV provisioner
 
 ## 宿主机要求
-注意：若完全使用默认参数，需要保证宿主机/data存在、可读写、且目录下有足够大的空间，chart将自动创建bkjob目录用于存放日志与临时文件，该目录在chart卸载后若无需保留则需要进行清理：
-参考命令：
+注意：若完全使用默认参数，需要保证宿主机/data存在、可读写、且目录下有足够大的空间，chart将自动创建job_temp_file目录用于存放临时文件，自动创建bkjob目录用于存放待分发文件，这些目录在chart卸载后若无需保留则需要进行清理：  
+参考命令：  
+rm -r /data/job_temp_file  
 rm -r /data/bkjob
 
-日志与临时文件存储说明：
-作业平台使用Persistent Volume存储程序产生的日志、导入导出操作产生的临时文件、第三方源文件分发产生的临时文件，使用PVC进行声明，若K8s集群不提供合适的共享存储作为PV资源，则默认采用宿主机路径进行HostPath挂载，需要保证配置的路径在宿主机上存在且可读写；
-默认路径为：/data/bkjob，其中bkjob层将自动创建，可通过values文件中的`persistence.localStorage.path`进行配置。
+临时文件存储说明：  
+作业平台使用Persistent Volume存储执行日志导出、作业导入导出操作产生的临时文件，使用PVC进行声明，若K8s集群不提供合适的共享存储作为PV资源，则默认采用宿主机路径进行HostPath挂载，需要保证配置的路径在宿主机上存在且可读写；  
+默认路径为：/data/job_temp_file，其中job_temp_file层将自动创建，可通过values文件中的`persistence.localStorage.path`进行配置。  
+
+分发文件存储说明：  
+作业平台分发文件依赖宿主机上的GSE Agent，因此使用HostPath将宿主机目录挂载至容器内，需要保证配置的路径在宿主机上存在且可读写；  
+默认路径为：/data/bkjob，其中bkjob层将自动创建，可通过values文件中的`distribute.hostPath`进行配置。  
 
 ## 安装Chart
-使用以下命令在命名空间bk-job中安装名称为`bk-job`的release, 其中`<bk-job helm repo url>`代表helm仓库地址:
+使用以下命令在命名空间bk-job中安装名称为`bk-job`的release, 其中`<bk-job helm repo url>`代表helm仓库地址:  
 
 ```shell
 $ helm repo add bkee <bk-job helm repo url>
@@ -40,12 +45,12 @@ $ kubectl delete pvc -n bk-job --all
 上述命令将移除所有和bk-job相关的Kubernetes组件，并删除release。
 
 ## Chart依赖
-bitnami/common
-bitnami/nginx-ingress-controller
-bitnami/mariadb
-bitnami/redis
-bitnami/mongodb
-bitnami/rabbitmq
+bitnami/common  
+bitnami/nginx-ingress-controller  
+bitnami/mariadb  
+bitnami/redis  
+bitnami/mongodb  
+bitnami/rabbitmq  
 
 ## 配置说明
 各项配置集中在仓库的一个values.yaml文件之中，下面展示了可配置的参数列表以及默认值
@@ -113,12 +118,19 @@ bitnami/rabbitmq
 | `job.ingress.https.certBase64` | 开启HTTPS时使用的证书base64编码    | ``       |
 | `job.ingress.https.keyBase64` | 开启HTTPS时使用的证书私钥base64编码    | ``       |
 
-### 持久化存储配置
+### 依赖宿主机GSE Agent的分发相关配置
 |参数|描述|默认值 |
 |---|---|---|
-| `persistence.enabled`       | 是否开启持久化存储              | `true`           |
-| `persistence.accessMode`    | 持久化存储模式                 | `ReadWriteOnce`  |
-| `persistence.size`          | 持久化存储空间大小，默认200Gi    | `200Gi`          |
+| `distribute.hostPath`     | 分发文件所在根目录：宿主机路径（以HostPath方式挂载到容器内）   | `/data/bkjob`  |
+
+### 持久化存储配置，用于存储本地文件上传、执行日志导出、作业导入导出操作产生的临时文件等
+|参数|描述|默认值 |
+|---|---|---|
+| `persistence.accessMode`            | 持久化存储模式                 | `ReadWriteMany`  |
+| `persistence.size`                  | 持久化存储空间大小，默认200Gi    | `200Gi`          |
+| `persistence.storageClass`          | 存储模式：默认将日志存储于pod所在节点HostPath下，若使用其他共享存储可配置为对应的storageClass，支持NFS    | `job-local`      |
+| `persistence.localStorage.enabled`  | 是否使用HostPath作为本地存储        | `true`          |
+| `persistence.localStorage.path`     | 临时文件根路径（使用HostPath作为本地存储时同时也是宿主机根路径）    | `/data/job_temp_file`          |
 
 ### 蓝鲸日志采集配置
 |参数|描述|默认值 |

--- a/support-files/kubernetes/charts/bk-job/README.md
+++ b/support-files/kubernetes/charts/bk-job/README.md
@@ -22,7 +22,7 @@ rm -r /data/bkjob
 
 分发文件存储说明：  
 作业平台分发文件依赖宿主机上的GSE Agent，因此使用HostPath将宿主机目录挂载至容器内，需要保证配置的路径在宿主机上存在且可读写；  
-默认路径为：/data/bkjob，其中bkjob层将自动创建，可通过values文件中的`distribute.hostPath`进行配置。  
+默认路径为：/data/bkjob，其中bkjob层将自动创建，可通过values文件中的`fileDistribute.hostPath`进行配置。  
 
 ## 安装Chart
 使用以下命令在命名空间bk-job中安装名称为`bk-job`的release, 其中`<bk-job helm repo url>`代表helm仓库地址:  
@@ -121,7 +121,7 @@ bitnami/rabbitmq
 ### 依赖宿主机GSE Agent的分发相关配置
 |参数|描述|默认值 |
 |---|---|---|
-| `distribute.hostPath`     | 分发文件所在根目录：宿主机路径（以HostPath方式挂载到容器内）   | `/data/bkjob`  |
+| `fileDistribute.hostPath`     | 分发文件所在根目录：宿主机路径（以HostPath方式挂载到容器内）   | `/data/bkjob`  |
 
 ### 持久化存储配置，用于存储本地文件上传、执行日志导出、作业导入导出操作产生的临时文件等
 |参数|描述|默认值 |

--- a/support-files/kubernetes/charts/bk-job/VALUES_LOG.md
+++ b/support-files/kubernetes/charts/bk-job/VALUES_LOG.md
@@ -3,8 +3,8 @@
 1.增加依赖宿主机GSE Agent的分发相关配置
 
 ```yaml
-## 依赖宿主机GSE Agent的分发相关配置
-distribute:
+## 依赖宿主机GSE Agent的文件分发相关配置
+fileDistribute:
   # 分发文件所在根目录：宿主机路径（以HostPath方式挂载到容器内）
   hostPath: /data/bkjob
 ```

--- a/support-files/kubernetes/charts/bk-job/VALUES_LOG.md
+++ b/support-files/kubernetes/charts/bk-job/VALUES_LOG.md
@@ -1,4 +1,18 @@
 # chart values 更新日志
+## 0.5.2
+1.增加依赖宿主机GSE Agent的分发相关配置
+
+```yaml
+## 依赖宿主机GSE Agent的分发相关配置
+distribute:
+  # 分发文件所在根目录：宿主机路径（以HostPath方式挂载到容器内）
+  hostPath: /data/bkjob
+```
+
+2.去除实际上并未用到的`persistence.enabled`配置
+
+3.临时文件存储根路径`persistence.localStorage.path`默认值修改为`/data/job_temp_file`
+
 ## 0.5.1
 1.增加轻量化部署配置
 

--- a/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
+++ b/support-files/kubernetes/charts/bk-job/templates/_helpers.tpl
@@ -668,3 +668,11 @@ Return the Archive MariaDB secret name
 {{- define "job.archiveMariadb.secretName" -}}
 {{ printf "%s-%s" (include "job.fullname" .) "archive-mariadb" }}
 {{- end -}}
+
+
+{{/*
+Return the storage PVC name
+*/}}
+{{- define "job.storage.pvc.name" -}}
+{{ printf "%s-pv-claim-%s" (include "common.names.fullname" .) .Values.persistence.storageClass }}
+{{- end -}}

--- a/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
@@ -99,6 +99,8 @@ data:
         url: {{ include "job.web.url" . }}
       storage:
         root-path: {{ .Values.persistence.localStorage.path }}/local
+      distribute:
+        root-path: {{ .Values.distribute.hostPath }}/local
     cmdb:
       default:
         supplier:

--- a/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
@@ -99,8 +99,6 @@ data:
         url: {{ include "job.web.url" . }}
       storage:
         root-path: {{ .Values.persistence.localStorage.path }}/local
-      distribute:
-        root-path: {{ .Values.distribute.hostPath }}/local
     cmdb:
       default:
         supplier:

--- a/support-files/kubernetes/charts/bk-job/templates/job-analysis/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-analysis/deployment.yaml
@@ -101,8 +101,6 @@ spec:
           resources:
             {{- toYaml .Values.analysisConfig.resources | nindent 12 }}
           volumeMounts:
-            - name: job-storage
-              mountPath: {{ .Values.persistence.localStorage.path }}
             - name: mariadb
               mountPath: /etc/secrets/mariadb
               readOnly: true
@@ -113,9 +111,6 @@ spec:
               mountPath: /etc/secrets/redis
               readOnly: true
       volumes:
-        - name: job-storage
-          persistentVolumeClaim:
-            claimName: {{ include "common.names.fullname" . }}-pv-claim
         - name: mariadb
           secret:
             secretName: {{ include "job.mariadb.secretName" . }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-assemble/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-assemble/deployment.yaml
@@ -122,6 +122,8 @@ spec:
           resources:
             {{- toYaml .Values.assembleConfig.resources | nindent 12 }}
           volumeMounts:
+            - name: distribute-volume
+              mountPath: {{ .Values.distribute.hostPath }}
             - name: job-storage
               mountPath: {{ .Values.persistence.localStorage.path }}
             - name: mariadb
@@ -141,9 +143,13 @@ spec:
               readOnly: true
       terminationGracePeriodSeconds: 120
       volumes:
+        - name: distribute-volume
+          hostPath:
+            path: {{ .Values.distribute.hostPath }}
+            type: DirectoryOrCreate
         - name: job-storage
           persistentVolumeClaim:
-            claimName: {{ include "common.names.fullname" . }}-pv-claim
+            claimName: {{ include "job.storage.pvc.name" . }}
         - name: mariadb
           secret:
             secretName: {{ include "job.mariadb.secretName" . }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-assemble/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-assemble/deployment.yaml
@@ -123,7 +123,7 @@ spec:
             {{- toYaml .Values.assembleConfig.resources | nindent 12 }}
           volumeMounts:
             - name: distribute-volume
-              mountPath: {{ .Values.distribute.hostPath }}
+              mountPath: {{ .Values.fileDistribute.hostPath }}
             - name: job-storage
               mountPath: {{ .Values.persistence.localStorage.path }}
             - name: mariadb
@@ -145,7 +145,7 @@ spec:
       volumes:
         - name: distribute-volume
           hostPath:
-            path: {{ .Values.distribute.hostPath }}
+            path: {{ .Values.fileDistribute.hostPath }}
             type: DirectoryOrCreate
         - name: job-storage
           persistentVolumeClaim:

--- a/support-files/kubernetes/charts/bk-job/templates/job-backup/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-backup/deployment.yaml
@@ -120,7 +120,7 @@ spec:
       volumes:
         - name: job-storage
           persistentVolumeClaim:
-            claimName: {{ include "common.names.fullname" . }}-pv-claim
+            claimName: {{ include "job.storage.pvc.name" . }}
         - name: mariadb
           secret:
             secretName: {{ include "job.mariadb.secretName" . }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-crontab/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-crontab/deployment.yaml
@@ -101,8 +101,6 @@ spec:
           resources:
             {{- toYaml .Values.crontabConfig.resources | nindent 12 }}
           volumeMounts:
-            - name: job-storage
-              mountPath: {{ .Values.persistence.localStorage.path }}
             - name: mariadb
               mountPath: /etc/secrets/mariadb
               readOnly: true
@@ -113,9 +111,6 @@ spec:
               mountPath: /etc/secrets/redis
               readOnly: true
       volumes:
-        - name: job-storage
-          persistentVolumeClaim:
-            claimName: {{ include "common.names.fullname" . }}-pv-claim
         - name: mariadb
           secret:
             secretName: {{ include "job.mariadb.secretName" . }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-execute/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-execute/configmap.yaml
@@ -205,4 +205,7 @@ data:
           storage-backend: {{ .Values.executeConfig.logExport.storageBackend }}
           artifactory:
             repo: {{ .Values.executeConfig.logExport.artifactory.repo }}
+        file:
+          distribute:
+            root-path: {{ .Values.fileDistribute.hostPath }}/local
 {{- end }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-execute/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-execute/deployment.yaml
@@ -105,6 +105,8 @@ spec:
           resources:
             {{- toYaml .Values.executeConfig.resources | nindent 12 }}
           volumeMounts:
+            - name: distribute-volume
+              mountPath: {{ .Values.distribute.hostPath }}
             - name: job-storage
               mountPath: {{ .Values.persistence.localStorage.path }}
             - name: mariadb
@@ -124,9 +126,13 @@ spec:
               readOnly: true
       terminationGracePeriodSeconds: 120
       volumes:
+        - name: distribute-volume
+          hostPath:
+            path: {{ .Values.distribute.hostPath }}
+            type: DirectoryOrCreate
         - name: job-storage
           persistentVolumeClaim:
-            claimName: {{ include "common.names.fullname" . }}-pv-claim
+            claimName: {{ include "job.storage.pvc.name" . }}
         - name: mariadb
           secret:
             secretName: {{ include "job.mariadb.secretName" . }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-execute/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-execute/deployment.yaml
@@ -106,7 +106,7 @@ spec:
             {{- toYaml .Values.executeConfig.resources | nindent 12 }}
           volumeMounts:
             - name: distribute-volume
-              mountPath: {{ .Values.distribute.hostPath }}
+              mountPath: {{ .Values.fileDistribute.hostPath }}
             - name: job-storage
               mountPath: {{ .Values.persistence.localStorage.path }}
             - name: mariadb
@@ -128,7 +128,7 @@ spec:
       volumes:
         - name: distribute-volume
           hostPath:
-            path: {{ .Values.distribute.hostPath }}
+            path: {{ .Values.fileDistribute.hostPath }}
             type: DirectoryOrCreate
         - name: job-storage
           persistentVolumeClaim:

--- a/support-files/kubernetes/charts/bk-job/templates/job-file-gateway/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-file-gateway/deployment.yaml
@@ -101,8 +101,6 @@ spec:
           resources:
             {{- toYaml .Values.fileGatewayConfig.resources | nindent 12 }}
           volumeMounts:
-            - name: job-storage
-              mountPath: {{ .Values.persistence.localStorage.path }}
             - name: mariadb
               mountPath: /etc/secrets/mariadb
               readOnly: true
@@ -113,9 +111,6 @@ spec:
               mountPath: /etc/secrets/redis
               readOnly: true
       volumes:
-        - name: job-storage
-          persistentVolumeClaim:
-            claimName: {{ include "common.names.fullname" . }}-pv-claim
         - name: mariadb
           secret:
             secretName: {{ include "job.mariadb.secretName" . }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-file-worker/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-file-worker/configmap.yaml
@@ -24,7 +24,7 @@ data:
           port: {{ .Values.fileWorkerConfig.containerPort }}
         cloud-area-id: {{ .Values.fileWorkerConfig.cloudAreaId }}
         download-file:
-          dir: {{ .Values.persistence.localStorage.path }}
+          dir: {{ .Values.distribute.hostPath }}
           max-size-gb: {{ .Values.fileWorkerConfig.downloadFile.maxSizeGB }}
           expire-days: {{ .Values.fileWorkerConfig.downloadFile.expireDays }}
         instance-name: {{ .Values.fileWorkerConfig.instanceName }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-file-worker/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-file-worker/configmap.yaml
@@ -24,7 +24,7 @@ data:
           port: {{ .Values.fileWorkerConfig.containerPort }}
         cloud-area-id: {{ .Values.fileWorkerConfig.cloudAreaId }}
         download-file:
-          dir: {{ .Values.distribute.hostPath }}
+          dir: {{ .Values.fileDistribute.hostPath }}
           max-size-gb: {{ .Values.fileWorkerConfig.downloadFile.maxSizeGB }}
           expire-days: {{ .Values.fileWorkerConfig.downloadFile.expireDays }}
         instance-name: {{ .Values.fileWorkerConfig.instanceName }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-file-worker/statefulset.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-file-worker/statefulset.yaml
@@ -77,7 +77,7 @@ spec:
             - name: BK_JOB_JAR
               value: job-file-worker.jar
             - name: BK_JOB_FILE_WORKER_WORKSPACE_DIR
-              value: {{ .Values.distribute.hostPath }}/JobFileWorkerWorkspace
+              value: {{ .Values.fileDistribute.hostPath }}/JobFileWorkerWorkspace
             - name: BK_JOB_NODE_IP
               valueFrom:
                 fieldRef:
@@ -107,10 +107,10 @@ spec:
             {{- toYaml .Values.fileWorkerConfig.resources | nindent 12 }}
           volumeMounts:
             - name: distribute-volume
-              mountPath: {{ .Values.distribute.hostPath }}
+              mountPath: {{ .Values.fileDistribute.hostPath }}
       volumes:
         - name: distribute-volume
           hostPath:
-            path: {{ .Values.distribute.hostPath }}
+            path: {{ .Values.fileDistribute.hostPath }}
             type: DirectoryOrCreate
 {{- end }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-file-worker/statefulset.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-file-worker/statefulset.yaml
@@ -77,7 +77,7 @@ spec:
             - name: BK_JOB_JAR
               value: job-file-worker.jar
             - name: BK_JOB_FILE_WORKER_WORKSPACE_DIR
-              value: {{ .Values.persistence.localStorage.path }}/JobFileWorkerWorkspace
+              value: {{ .Values.distribute.hostPath }}/JobFileWorkerWorkspace
             - name: BK_JOB_NODE_IP
               valueFrom:
                 fieldRef:
@@ -106,10 +106,11 @@ spec:
           resources:
             {{- toYaml .Values.fileWorkerConfig.resources | nindent 12 }}
           volumeMounts:
-            - name: job-storage
-              mountPath: {{ .Values.persistence.localStorage.path }}
+            - name: distribute-volume
+              mountPath: {{ .Values.distribute.hostPath }}
       volumes:
-        - name: job-storage
-          persistentVolumeClaim:
-            claimName: {{ include "common.names.fullname" . }}-pv-claim
+        - name: distribute-volume
+          hostPath:
+            path: {{ .Values.distribute.hostPath }}
+            type: DirectoryOrCreate
 {{- end }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-gateway/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-gateway/deployment.yaml
@@ -106,8 +106,6 @@ spec:
           resources:
             {{- toYaml .Values.gatewayConfig.resources | nindent 12 }}
           volumeMounts:
-            - name: job-storage
-              mountPath: {{ .Values.persistence.localStorage.path }}
             - name: job-gateway-tls-certs
               mountPath: /data/job/cert
               readOnly: true
@@ -118,9 +116,6 @@ spec:
               mountPath: /etc/secrets/rabbitmq
               readOnly: true
       volumes:
-        - name: job-storage
-          persistentVolumeClaim:
-            claimName: {{ include "common.names.fullname" . }}-pv-claim
         - name: job-gateway-tls-certs
           secret:
             secretName: {{ printf "%s-gateway-%s" (include "common.names.fullname" .) "tls-cert" }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-logsvr/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-logsvr/deployment.yaml
@@ -100,8 +100,6 @@ spec:
           resources:
             {{- toYaml .Values.logsvrConfig.resources | nindent 12 }}
           volumeMounts:
-            - name: job-storage
-              mountPath: {{ .Values.persistence.localStorage.path }}
             - name: mongodb
               mountPath: /etc/secrets/mongodb
               readOnly: true
@@ -109,9 +107,6 @@ spec:
               mountPath: /etc/secrets/rabbitmq
               readOnly: true
       volumes:
-        - name: job-storage
-          persistentVolumeClaim:
-            claimName: {{ include "common.names.fullname" . }}-pv-claim
         - name: mongodb
           secret:
             secretName: {{ include "job.mongodb.secretName" . }}

--- a/support-files/kubernetes/charts/bk-job/templates/job-manage/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-manage/deployment.yaml
@@ -123,7 +123,7 @@ spec:
       volumes:
         - name: job-storage
           persistentVolumeClaim:
-            claimName: {{ include "common.names.fullname" . }}-pv-claim
+            claimName: {{ include "job.storage.pvc.name" . }}
         - name: mariadb
           secret:
             secretName: {{ include "job.mariadb.secretName" . }}

--- a/support-files/kubernetes/charts/bk-job/templates/pv-default.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/pv-default.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ .Release.Namespace }}-{{ include "common.names.fullname" . }}-local
+  name: {{ .Release.Namespace }}-{{ include "common.names.fullname" . }}-local-{{ .Values.persistence.storageClass }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/support-files/kubernetes/charts/bk-job/templates/pvc-storage.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/pvc-storage.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "common.names.fullname" . }}-pv-claim
+  name: {{ include "job.storage.pvc.name" . }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -624,8 +624,8 @@ job:
       # ingress开启HTTPS时使用的证书私钥base64编码
       keyBase64: ""
 
-## 依赖宿主机GSE Agent的分发相关配置
-distribute:
+## 依赖宿主机GSE Agent的文件分发相关配置
+fileDistribute:
   # 分发文件所在根目录：宿主机路径（以HostPath方式挂载到容器内）
   hostPath: /data/bkjob
 

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -624,28 +624,22 @@ job:
       # ingress开启HTTPS时使用的证书私钥base64编码
       keyBase64: ""
 
-## 持久化存储配置
+## 依赖宿主机GSE Agent的分发相关配置
+distribute:
+  # 分发文件所在根目录：宿主机路径（以HostPath方式挂载到容器内）
+  hostPath: /data/bkjob
+
+## 持久化存储配置，用于存储本地文件上传、执行日志导出、作业导入导出操作产生的临时文件等
 persistence:
-  ## 是否开启数据持久化，false则使用emptyDir类型volume, pod结束后数据将被清空，无法持久化
-  enabled: true
   accessMode: ReadWriteMany
   size: 200Gi
-  # 存储模式：默认将日志存储于pod所在节点HostPath下，若使用其他共享存储可配置为对应的storageClass
+  # 存储模式：默认将日志存储于pod所在节点HostPath下，若使用其他共享存储可配置为对应的storageClass，支持NFS
   storageClass: job-local
   localStorage:
-    # 是否使用hostpath作为本地存储，用于存储日志、导入导出操作产生的临时文件等
+    # 是否使用HostPath作为本地存储
     enabled: true
-    # 节点本地存储路径
-    path: /data/bkjob
-
-  ## 如果不定义或设置为null, 将使用默认的storageClass(minikube上是hostPath, AWS上的gp2, GKE上是standard, TKE上是cbs)
-  ## 如果设置为"-", 则禁用动态卷供应
-  ## 如果设置为其它值，则storageClassName: <storageClass>
-  # storageClass: "-"
-
-  ## 如果开启持久化，并且没有任何上述配置，将使用动态卷供应方式提供存储，使用storageClass定义的存储类。
-  ## 在删除该声明后，这个卷也会被销毁(用于单节点环境，生产环境不推荐)。
-  # ref: https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/
+    # 临时文件根路径（使用HostPath作为本地存储时同时也是宿主机根路径）
+    path: /data/job_temp_file
 
 ## 蓝鲸日志采集配置
 bkLogConfig:

--- a/support-files/templates/#etc#job#job-assemble#application-assemble.yml
+++ b/support-files/templates/#etc#job#job-assemble#application-assemble.yml
@@ -386,6 +386,10 @@ job:
       # artifactory:
       #   # 存储执行日志导出临时文件的仓库名称
       #   repo: filedata
+    file:
+      # 存储要分发的文件的根目录，二进制环境下与存储临时文件的根目录一致
+      distribute:
+        root-path: __BK_HOME__/public/job
   crontab:
     # 定时任务连续启动失败通知策略：默认 从第一次失败开始，连续失败每5次通知第一次 begin = 1；frequency = 5；totalTimes = -1
     notification-policy:

--- a/support-files/templates/#etc#job#job-common#application.yml
+++ b/support-files/templates/#etc#job#job-common#application.yml
@@ -100,9 +100,6 @@ job:
   # 存储临时文件的根目录
   storage:
     root-path: __BK_HOME__/public/job
-  # 存储要分发的文件的根目录，二进制环境下与存储临时文件的根目录一致
-  distribute:
-    root-path: __BK_HOME__/public/job
 
 # 制品库相关配置
 artifactory:

--- a/support-files/templates/#etc#job#job-common#application.yml
+++ b/support-files/templates/#etc#job#job-common#application.yml
@@ -97,7 +97,11 @@ job:
     # 是否对接GSE2.0。 如果需要对接GSE1.0，设置job.features.gseV2.enabled=false
     gseV2:
       enabled: true
+  # 存储临时文件的根目录
   storage:
+    root-path: __BK_HOME__/public/job
+  # 存储要分发的文件的根目录，二进制环境下与存储临时文件的根目录一致
+  distribute:
     root-path: __BK_HOME__/public/job
 
 # 制品库相关配置

--- a/support-files/templates/#etc#job#job-execute#job-execute.yml
+++ b/support-files/templates/#etc#job#job-execute#job-execute.yml
@@ -210,3 +210,7 @@ job:
       # artifactory:
       #   # 存储执行日志导出临时文件的仓库名称
       #   repo: filedata
+    file:
+      # 存储要分发的文件的根目录，二进制环境下与存储临时文件的根目录一致
+      distribute:
+        root-path: __BK_HOME__/public/job


### PR DESCRIPTION
1. 分离分发对HostPath的依赖与临时文件对存储的依赖，支持分别配置；
2. 去除某些Pod不必要的PVC声明；
3. PVC名称与storageClass关联，解决变更storageClass导致更新失败的问题。