### PR TITLE
fix: 审计中心回调 Job 获取资源实例 schema 报错 #2541

### DIFF
--- a/src/backend/job-execute/api-job-execute/src/main/java/com/tencent/bk/job/execute/model/esb/v3/EsbTaskInstanceV3DTO.java
+++ b/src/backend/job-execute/api-job-execute/src/main/java/com/tencent/bk/job/execute/model/esb/v3/EsbTaskInstanceV3DTO.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.execute.model.esb.v3;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.tencent.bk.job.common.esb.model.EsbAppScopeDTO;
 import lombok.Getter;
 import lombok.Setter;
@@ -38,69 +39,81 @@ public class EsbTaskInstanceV3DTO extends EsbAppScopeDTO {
      * id
      */
     @JsonProperty("job_instance_id")
+    @JsonPropertyDescription("Job instance id")
     private Long id;
 
     /**
      * 执行方案id
      */
     @JsonProperty("job_plan_id")
+    @JsonPropertyDescription("Job plan id")
     private Long taskId;
 
     /**
      * 作业模板id
      */
     @JsonProperty("job_template_id")
+    @JsonPropertyDescription("Job template id")
     private Long templateId;
 
     /**
      * 名称
      */
+    @JsonPropertyDescription("Job instance name")
     private String name;
 
     /**
      * 执行人
      */
+    @JsonPropertyDescription("Operator")
     private String operator;
 
     /**
      * 启动方式，1-页面执行、2-API调用、3-定时执行
      */
     @JsonProperty("launch_mode")
+    @JsonPropertyDescription("Launch mode")
     private Integer startupMode;
 
     /**
      * 任务状态。1 -  等待执行，2 - 正在执行，3 - 执行成功，4 - 执行失败，7 - 等待确认，10 - 强制终止中，11 - 强制终止成功，13 - 确认终止
      */
     @JsonProperty("status")
+    @JsonPropertyDescription("Job instance status")
     private Integer status;
 
     /**
      * 开始时间
      */
     @JsonProperty("start_time")
+    @JsonPropertyDescription("Job instance start time")
     private Long startTime;
 
     /**
      * 开始时间
      */
     @JsonProperty("end_time")
+    @JsonPropertyDescription("Job instance end time")
     private Long endTime;
 
     /**
      * 总耗时，单位：毫秒
      */
     @JsonProperty("total_time")
+    @JsonPropertyDescription("Job instance execution cost")
     private Long totalTime;
 
     /**
      * 创建时间
      */
     @JsonProperty("create_time")
+    @JsonPropertyDescription("Job instance create time")
     private Long createTime;
 
     /**
      * 任务类型,0-作业执行,1-脚本执行,2-文件分发
      */
     @JsonProperty("type")
+    @JsonPropertyDescription("Job instance type")
     private Integer type;
 }

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/esb/v3/response/EsbAccountV3DTO.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/esb/v3/response/EsbAccountV3DTO.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.manage.model.esb.v3.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.tencent.bk.job.common.esb.model.EsbAppScopeDTO;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -32,37 +33,49 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class EsbAccountV3DTO extends EsbAppScopeDTO {
+    @JsonPropertyDescription("Account ID")
     private Long id;
 
+    @JsonPropertyDescription("Account name")
     private String account;
 
+    @JsonPropertyDescription("Account alias")
     private String alias;
 
     // 账号用途（1：系统账号，2：DB账号）
+    @JsonPropertyDescription("Account usage. 1- OS Account, 2 - DB Account")
     private int category;
 
     // 账号类型（1：Linux，2：Windows，9：MySQL，10：Oracle，11：DB2）
+    @JsonPropertyDescription("Account type. 1 - Linux, 2 - Windows, 9 - MySQL, 10 - Oracle, 11 - DB2")
     private int type;
 
     @JsonProperty("db_system_account_id")
+    @JsonPropertyDescription("System account id for db account")
     private Long dbSystemAccountId;
 
+    @JsonPropertyDescription("Account OS")
     private String os;
 
+    @JsonPropertyDescription("Creator")
     private String creator;
 
     @JsonProperty("create_time")
+    @JsonPropertyDescription("Create time")
     private Long createTime;
 
     @JsonProperty("last_modify_user")
+    @JsonPropertyDescription("Last modify user")
     private String lastModifyUser;
 
+    @JsonPropertyDescription("Last modify time")
     @JsonProperty("last_modify_time")
     private Long lastModifyTime;
 
     /**
      * 账号描述
      */
+    @JsonPropertyDescription("Account description")
     @JsonProperty("description")
     private String description;
 }

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/esb/v3/response/EsbApprovalStepV3DTO.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/esb/v3/response/EsbApprovalStepV3DTO.java
@@ -24,6 +24,8 @@
 
 package com.tencent.bk.job.manage.model.esb.v3.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import lombok.Data;
 
 import java.util.List;
@@ -39,20 +41,28 @@ public class EsbApprovalStepV3DTO {
     /**
      * 确认类型
      */
+    @JsonProperty("approval_type")
+    @JsonPropertyDescription("Approval type")
     private Integer approvalType;
 
     /**
      * 确认角色
      */
+    @JsonPropertyDescription("Approval user info")
+    @JsonProperty("approval_user")
     private EsbUserRoleInfoV3DTO approvalUser;
 
     /**
      * 确认消息
      */
+    @JsonPropertyDescription("Approval message")
+    @JsonProperty("approval_message")
     private String approvalMessage;
 
     /**
      * 通知渠道列表
      */
+    @JsonPropertyDescription("Notify channel")
+    @JsonProperty("notify_channel")
     private List<String> notifyChannel;
 }

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/esb/v3/response/EsbScriptVersionDetailV3DTO.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/esb/v3/response/EsbScriptVersionDetailV3DTO.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.manage.model.esb.v3.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.tencent.bk.job.common.esb.model.EsbAppScopeDTO;
 import lombok.Getter;
 import lombok.Setter;
@@ -37,34 +38,45 @@ public class EsbScriptVersionDetailV3DTO extends EsbAppScopeDTO {
     /**
      * 脚本版本ID
      */
+    @JsonPropertyDescription("Script version ID")
     private Long id;
 
     @JsonProperty("script_id")
+    @JsonPropertyDescription("Script ID")
     private String scriptId;
 
     /**
      * 脚本名称
      */
+    @JsonPropertyDescription("Script name")
     private String name;
 
+    @JsonPropertyDescription("Script version")
     private String version;
 
+    @JsonPropertyDescription("Script content")
     private String content;
 
     // 脚本版本状态（0：未上线，1：已上线，2：已下线，3：已禁用）
+    @JsonPropertyDescription("Script status")
     private Integer status;
 
+    @JsonPropertyDescription("Script version description")
     @JsonProperty("version_desc")
     private String versionDesc;
 
+    @JsonPropertyDescription("Creator")
     private String creator;
 
     @JsonProperty("create_time")
+    @JsonPropertyDescription("Create time")
     private Long createTime;
 
     @JsonProperty("last_modify_user")
+    @JsonPropertyDescription("Last modify user")
     private String lastModifyUser;
 
+    @JsonPropertyDescription("Last modify time")
     @JsonProperty("last_modify_time")
     private Long lastModifyTime;
 
@@ -72,10 +84,12 @@ public class EsbScriptVersionDetailV3DTO extends EsbAppScopeDTO {
      * 脚本语言:1 - shell, 2 - bat, 3 - perl, 4 - python, 5 - powershell
      */
     @JsonProperty("script_language")
+    @JsonPropertyDescription("Script language")
     private Integer type;
 
     /**
      * 脚本描述
      */
+    @JsonPropertyDescription("Script description")
     private String description;
 }

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/esb/v3/response/EsbUserRoleInfoV3DTO.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/esb/v3/response/EsbUserRoleInfoV3DTO.java
@@ -24,6 +24,8 @@
 
 package com.tencent.bk.job.manage.model.esb.v3.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.tencent.bk.job.common.model.dto.UserRoleInfoDTO;
 import lombok.Data;
 
@@ -39,11 +41,15 @@ public class EsbUserRoleInfoV3DTO {
     /**
      * 用户名列表
      */
+    @JsonProperty("user_list")
+    @JsonPropertyDescription("User list")
     private List<String> userList;
 
     /**
      * 角色 ID 列表
      */
+    @JsonProperty("role_list")
+    @JsonPropertyDescription("Job role list ")
     private List<String> roleList;
 
     public static EsbUserRoleInfoV3DTO fromUserRoleInfo(UserRoleInfoDTO approvalUser) {


### PR DESCRIPTION
1. bug 修复见 https://github.com/TencentBlueKing/bk-audit-java-sdk/issues/9 （1.0.6-SNAPSHOT 版本)
2. 新增部分资源实例的 Json Schema 信息，用于审计中心回调
