### PR TITLE
fix: 编辑文件源报错报错 404 #2554

### DIFF
--- a/src/backend/job-file-gateway/api-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/api/web/WebFileSourceResource.java
+++ b/src/backend/job-file-gateway/api-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/api/web/WebFileSourceResource.java
@@ -98,7 +98,7 @@ public interface WebFileSourceResource {
     );
 
     @ApiOperation(value = "更新文件源", produces = "application/json")
-    @PutMapping("")
+    @PutMapping("/{id}")
     Response<FileSourceVO> updateFileSource(
         @ApiParam("用户名，网关自动传入")
         @RequestHeader("username")
@@ -112,6 +112,9 @@ public interface WebFileSourceResource {
         @ApiParam(value = "资源范围ID", required = true)
         @PathVariable(value = "scopeId")
             String scopeId,
+        @ApiParam(value = "文件源 ID", required = true)
+        @PathVariable("id")
+            Integer id,
         @ApiParam(value = "更新文件源请求")
         @RequestBody
             FileSourceCreateUpdateReq fileSourceCreateUpdateReq

--- a/src/backend/job-file-gateway/api-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/model/req/web/FileSourceCreateUpdateReq.java
+++ b/src/backend/job-file-gateway/api-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/model/req/web/FileSourceCreateUpdateReq.java
@@ -37,9 +37,6 @@ import java.util.Map;
 @ApiModel("文件源创建、更新请求")
 public class FileSourceCreateUpdateReq {
 
-    @Deprecated
-    @ApiModelProperty(value = "文件源 ID", hidden = true)
-    private Integer id;
     /**
      * 文件源Code
      */

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceServiceImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceServiceImpl.java
@@ -32,6 +32,7 @@ import com.tencent.bk.job.common.audit.JobAuditAttributeNames;
 import com.tencent.bk.job.common.audit.constants.EventContentConstants;
 import com.tencent.bk.job.common.constant.ErrorCode;
 import com.tencent.bk.job.common.exception.AlreadyExistsException;
+import com.tencent.bk.job.common.exception.FailedPreconditionException;
 import com.tencent.bk.job.common.exception.NotFoundException;
 import com.tencent.bk.job.common.iam.constant.ActionId;
 import com.tencent.bk.job.common.iam.constant.ResourceTypeId;
@@ -141,10 +142,18 @@ public class FileSourceServiceImpl implements FileSourceService {
     public FileSourceDTO saveFileSource(String username, Long appId, FileSourceDTO fileSource) {
         authCreate(username, appId);
 
+        if (existsCode(appId, fileSource.getCode())) {
+            throw new FailedPreconditionException(
+                ErrorCode.FILE_SOURCE_CODE_ALREADY_EXISTS,
+                new String[]{fileSource.getCode()}
+            );
+        }
+
         if (fileSourceDAO.checkFileSourceExists(fileSource.getAppId(), fileSource.getAlias())) {
             throw new AlreadyExistsException(ErrorCode.FILE_SOURCE_ALIAS_ALREADY_EXISTS,
                 new String[]{fileSource.getAlias()});
         }
+
         Integer id = fileSourceDAO.insertFileSource(fileSource);
         fileSource.setId(id);
 
@@ -182,6 +191,13 @@ public class FileSourceServiceImpl implements FileSourceService {
     )
     public FileSourceDTO updateFileSourceById(String username, Long appId, FileSourceDTO fileSource) {
         authManage(username, appId, fileSource.getId());
+
+        if (existsCodeExceptId(appId, fileSource.getCode(), fileSource.getId())) {
+            throw new FailedPreconditionException(
+                ErrorCode.FILE_SOURCE_CODE_ALREADY_EXISTS,
+                new String[]{fileSource.getCode()}
+            );
+        }
 
         FileSourceDTO originFileSource = getFileSourceById(fileSource.getId());
         if (originFileSource == null) {


### PR DESCRIPTION
问题描述见 #2554 

修改：
1. 更新文件源 API URL 更改为正确的，加上 /{id}
2. 创建/更新操作的业务逻辑校验放到 Service 层