### PR TITLE
fix: Job 后端国际化失效 #2570

### DIFF
--- a/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/config/I18nAutoConfiguration.java
+++ b/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/config/I18nAutoConfiguration.java
@@ -22,19 +22,25 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.common.web.i18n;
+package com.tencent.bk.job.common.web.config;
 
+import com.tencent.bk.job.common.web.i18n.JobLangHeaderLocaleResolver;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 import java.util.Locale;
 
-@Configuration
+/**
+ * 国际化自动配置。由于需要覆盖 LocaleResolver， 所以必须比 WebMvcAutoConfiguration 先解析
+ */
 @Slf4j
-public class I18nConfig {
-
+@AutoConfigureBefore(WebMvcAutoConfiguration.class)
+public class I18nAutoConfiguration {
     @Bean("localeResolver")
+    @Primary
     public JobLangHeaderLocaleResolver localeResolver() {
         log.info("Init JobLangHeaderLocaleResolver");
         JobLangHeaderLocaleResolver resolver = new JobLangHeaderLocaleResolver();
@@ -42,4 +48,3 @@ public class I18nConfig {
         return resolver;
     }
 }
-

--- a/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/config/WebAutoConfiguration.java
+++ b/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/config/WebAutoConfiguration.java
@@ -26,11 +26,11 @@ package com.tencent.bk.job.common.web.config;
 
 import com.tencent.bk.job.common.esb.metrics.EsbApiTimedAspect;
 import com.tencent.bk.job.common.web.feign.FeignConfiguration;
-import com.tencent.bk.job.common.web.i18n.I18nConfig;
 import com.tencent.bk.job.common.web.validation.ValidationConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
 @Import({
@@ -38,9 +38,9 @@ import org.springframework.context.annotation.Import;
     SwaggerAdapterConfig.class,
     FeignConfiguration.class,
     FilterConfig.class,
-    I18nConfig.class,
     ValidationConfiguration.class
 })
+@Configuration(proxyBeanMethods = false)
 public class WebAutoConfiguration {
 
     @Bean

--- a/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/config/WebAutoConfiguration.java
+++ b/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/config/WebAutoConfiguration.java
@@ -27,6 +27,7 @@ package com.tencent.bk.job.common.web.config;
 import com.tencent.bk.job.common.esb.metrics.EsbApiTimedAspect;
 import com.tencent.bk.job.common.web.feign.FeignConfiguration;
 import com.tencent.bk.job.common.web.i18n.I18nConfig;
+import com.tencent.bk.job.common.web.validation.ValidationConfiguration;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -37,8 +38,9 @@ import org.springframework.context.annotation.Import;
     SwaggerAdapterConfig.class,
     FeignConfiguration.class,
     FilterConfig.class,
-    I18nConfig.class}
-)
+    I18nConfig.class,
+    ValidationConfiguration.class
+})
 public class WebAutoConfiguration {
 
     @Bean

--- a/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/config/WebAutoConfiguration.java
+++ b/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/config/WebAutoConfiguration.java
@@ -26,12 +26,19 @@ package com.tencent.bk.job.common.web.config;
 
 import com.tencent.bk.job.common.esb.metrics.EsbApiTimedAspect;
 import com.tencent.bk.job.common.web.feign.FeignConfiguration;
+import com.tencent.bk.job.common.web.i18n.I18nConfig;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
-@Import({ActuatorSecurityConfig.class, SwaggerAdapterConfig.class, FeignConfiguration.class, FilterConfig.class})
+@Import({
+    ActuatorSecurityConfig.class,
+    SwaggerAdapterConfig.class,
+    FeignConfiguration.class,
+    FilterConfig.class,
+    I18nConfig.class}
+)
 public class WebAutoConfiguration {
 
     @Bean

--- a/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/validation/ValidationConfiguration.java
+++ b/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/validation/ValidationConfiguration.java
@@ -35,7 +35,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
 import org.springframework.core.ParameterNameDiscoverer;
@@ -55,12 +54,11 @@ import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
 
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @Slf4j
 public class ValidationConfiguration {
 
-    @Bean
-    @Primary
+    @Bean("jobLocalValidatorFactoryBean")
     public LocalValidatorFactoryBean localValidatorFactoryBean(
         @Qualifier("messageSource") MessageSource messageSource) {
         LocalValidatorFactoryBean localValidatorFactoryBean = new JobLocalValidatorFactoryBean(messageSource);

--- a/src/backend/commons/common-web/src/main/resources/META-INF/spring.factories
+++ b/src/backend/commons/common-web/src/main/resources/META-INF/spring.factories
@@ -3,4 +3,5 @@ com.tencent.bk.job.common.web.config.CustomTimedMetricsAutoConfiguration,\
 com.tencent.bk.job.common.web.config.WebAutoConfiguration,\
 com.tencent.bk.job.common.web.config.ExceptionAdviceAutoConfiguration,\
 com.tencent.bk.job.common.web.config.WebInterceptorAutoConfiguration,\
-com.tencent.bk.job.common.web.config.WebInterceptorRegisterAutoConfiguration
+com.tencent.bk.job.common.web.config.WebInterceptorRegisterAutoConfiguration,\
+com.tencent.bk.job.common.web.config.I18nAutoConfiguration


### PR DESCRIPTION
#2570 

1. 自动装配 Job 自定义的语言解析器(JobLangHeaderLocaleResolver)
2. 修复 ValidationConfiguraion 配置没有被自动装配的问题