### PR TITLE
perf: 作业执行日志量太大导致请求 job-logsvr 服务超时 #2549

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/ScriptResultHandleTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/ScriptResultHandleTask.java
@@ -364,12 +364,13 @@ public class ScriptResultHandleTask extends AbstractResultHandleTask<ScriptTaskR
                 return;
             }
             int offset = agentTask.getScriptLogOffset();
+            int bytes = 0;
             if (StringUtils.isNotEmpty(content)) {
-                int bytes = content.getBytes(StandardCharsets.UTF_8).length;
+                bytes = content.getBytes(StandardCharsets.UTF_8).length;
                 offset += bytes;
                 agentTask.setScriptLogOffset(offset);
             }
-            logs.add(new ServiceScriptLogDTO(host, offset, agentTaskResult.getScreen()));
+            logs.add(new ServiceScriptLogDTO(host, offset, bytes, agentTaskResult.getScreen()));
         }
         // 刷新日志拉取偏移量
         refreshPullLogProgress(agentTaskResult.getScreen(), agentId, agentTaskResult.getAtomicTaskId());

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/LogServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/LogServiceImpl.java
@@ -59,6 +59,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.PostConstruct;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
@@ -80,7 +81,10 @@ public class LogServiceImpl implements LogService {
     private final StepInstanceService stepInstanceService;
 
     // 脚本日志阈值128MB，当批量保存脚本日志时，如果日志集合超过阈值，采用分批保存
-    @Value("${job.execute.scriptLog.requestContentSizeThreshold:134217728}")
+    @Value("${job.execute.scriptLog.requestContentSizeThresholdMB:128}")
+    private int requestContentSizeThresholdMB;
+
+    // 脚本日志阈值-字节
     private int requestContentSizeThreshold;
 
     @Autowired
@@ -94,6 +98,11 @@ public class LogServiceImpl implements LogService {
         this.scriptAgentTaskService = scriptAgentTaskService;
         this.fileAgentTaskService = fileAgentTaskService;
         this.stepInstanceService = stepInstanceService;
+    }
+
+    @PostConstruct
+    public void init() {
+        requestContentSizeThreshold = requestContentSizeThresholdMB * 1024 * 1024;
     }
 
     @Override

--- a/src/backend/job-logsvr/api-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/model/service/ServiceScriptLogDTO.java
+++ b/src/backend/job-logsvr/api-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/model/service/ServiceScriptLogDTO.java
@@ -67,6 +67,12 @@ public class ServiceScriptLogDTO {
     private Integer offset;
 
     /**
+     * 日志大小 - 字节
+     */
+    @ApiModelProperty("日志大小 - 字节")
+    private Integer logSize = 0;
+
+    /**
      * 日志内容
      */
     @ApiModelProperty("日志内容")
@@ -86,6 +92,26 @@ public class ServiceScriptLogDTO {
         this.cloudIp = host.toCloudIp();
         this.cloudIpv6 = host.toCloudIpv6();
         this.offset = offset;
+        this.content = content;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param host    主机
+     * @param offset  日志偏移量(byte)
+     * @param logSize  日志大小(byte)
+     * @param content 日志内容
+     */
+    public ServiceScriptLogDTO(HostDTO host,
+                               Integer offset,
+                               Integer logSize,
+                               String content) {
+        this.hostId = host.getHostId();
+        this.cloudIp = host.toCloudIp();
+        this.cloudIpv6 = host.toCloudIpv6();
+        this.offset = offset;
+        this.logSize = logSize;
         this.content = content;
     }
 


### PR DESCRIPTION
设置脚本日志阈值1MB，当批量保存脚本日志时，遍历集合，如果日志内容大小累计超过阈值，采用分批保存