### PR TITLE
fix: GSE V2 查询任务结果 API 重试机制不生效 #2729

### DIFF
--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/BaseHttpHelper.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/BaseHttpHelper.java
@@ -154,7 +154,12 @@ public class BaseHttpHelper implements HttpHelper {
 
     private HttpContext buildHttpContext(HttpRequest request) {
         HttpCoreContext httpContext = HttpCoreContext.create();
-        httpContext.setAttribute(HttpContextAttributeNames.RETRY_MODE, request.getRetryMode().getValue());
+        if (request.getRetryMode() != null) {
+            httpContext.setAttribute(HttpContextAttributeNames.RETRY_MODE, request.getRetryMode().getValue());
+        }
+        if (request.getIdempotent() != null) {
+            httpContext.setAttribute(HttpContextAttributeNames.IS_IDEMPOTENT, request.getIdempotent());
+        }
         return httpContext;
     }
 

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/JobHttpRequestRetryHandler.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/JobHttpRequestRetryHandler.java
@@ -135,6 +135,9 @@ public class JobHttpRequestRetryHandler implements HttpRequestRetryHandler {
     private boolean isRequestIdempotent(HttpContext context) {
         // 判断方法使用幂等
         Object isIdempotentAttrVal = context.getAttribute(HttpContextAttributeNames.IS_IDEMPOTENT);
+        if (log.isDebugEnabled()) {
+            log.debug("HttpContext::IS_IDEMPOTENT: {}", isIdempotentAttrVal);
+        }
         boolean isIdempotent = isIdempotentAttrVal != null && (boolean) isIdempotentAttrVal;
         if (isIdempotent) {
             // 如果上下文主动设置了该请求的幂等参数，那么优先使用
@@ -146,6 +149,9 @@ public class JobHttpRequestRetryHandler implements HttpRequestRetryHandler {
         final HttpRequest request = clientContext.getRequest();
         final String method = request.getRequestLine().getMethod().toUpperCase(Locale.ROOT);
         final Boolean b = this.retryMethods.get(method);
+        if (log.isDebugEnabled()) {
+            log.debug("Method: {}, isRequestIdempotent: {}",method, isIdempotentAttrVal);
+        }
         return b != null && b;
     }
 


### PR DESCRIPTION
#2729 

缺陷原因：
由于 BaseHttpHelper 未在 HttpContext 中传递  HttpContextAttributeNames.IS_IDEMPOTENT 属性，导致使用 POST 方法的请求（实际上 API 是幂等的）被 JobHttpRequestRetryHandler 判定为非幂等导致无法重试