### PR TITLE
perf: 容器化前端静态资源文件支持gzip压缩 #2743

### DIFF
--- a/support-files/kubernetes/charts/bk-job/templates/job-frontend/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-frontend/configmap.yaml
@@ -31,6 +31,13 @@ data:
         listen                  [::]:80;
         server_name             {{ .Values.job.web.domain }};
         gzip on;
+        gzip_min_length  1k;
+        gzip_buffers     4 16k;
+        gzip_http_version 1.1;
+        gzip_comp_level  2;
+        gzip_types  text/plain text/css text/javascript application/javascript;
+        gzip_disable "MSIE [1-6]\.";
+        gzip_vary on;
         client_max_body_size 5120M;
         root /data/job/job-frontend;
         index index.html;


### PR DESCRIPTION
配置前端nginx gzip相关参数，Nginx gzip相关配置文档：
https://nginx.org/en/docs/http/ngx_http_gzip_module.html