### PR TITLE
fix: 临时文件清理导致本地文件分发小概率失败 #2771

### DIFF
--- a/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/file/FileUtil.java
+++ b/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/file/FileUtil.java
@@ -313,11 +313,12 @@ public class FileUtil {
      * 删除空目录
      *
      * @param directory 目录文件
+     * @return 是否删除了目录
      */
-    public static void deleteEmptyDirectory(File directory) {
+    public static boolean deleteEmptyDirectory(File directory) {
         if (directory == null) {
             log.warn("Directory is null!");
-            return;
+            return false;
         }
 
         if (isEmpty(directory.toPath())) {
@@ -327,8 +328,10 @@ public class FileUtil {
             } else {
                 log.warn("Delete directory {} failed!", directory.getPath());
             }
+            return delete;
         } else {
             log.debug("Directory {} not empty!", directory.getPath());
+            return false;
         }
     }
 

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/local/LocalFileDownloadTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/local/LocalFileDownloadTask.java
@@ -105,6 +105,12 @@ public class LocalFileDownloadTask implements Callable<Boolean> {
         localPath = PathUtil.joinFilePath(localPath, filePath);
         // 如果本地文件还未下载就已存在并且Md5正确，直接完成准备阶段
         if (currentLocalFileValid(localPath, nodeDTO)) {
+            // 将最后修改时间设置为当前时间，避免在分发过程中被清理
+            File localFile = new File(localPath);
+            boolean lastModifyTimeSet = localFile.setLastModified(System.currentTimeMillis());
+            if (!lastModifyTimeSet) {
+                log.warn("Fail to set lastModifyTime for {}", localPath);
+            }
             return true;
         }
         Pair<InputStream, HttpRequestBase> pair = artifactoryClient.getFileInputStream(


### PR DESCRIPTION
1.分发时更新临时文件最后修改时间避免被清理便于复用；
2.优化清理策略：将分发过程产生的无用上级目录一并清理，避免inode耗尽。