### PR TITLE
fix: 批量写入执行日志 API url 错误，导致发布过程中执行异常 #2800

### DIFF
--- a/src/backend/job-logsvr/api-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/api/ServiceLogResource.java
+++ b/src/backend/job-logsvr/api-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/api/ServiceLogResource.java
@@ -61,7 +61,7 @@ public interface ServiceLogResource {
      * @param request 保存日志请求
      */
     @ApiOperation("批量保存执行日志")
-    @PostMapping("/batch")
+    @PostMapping("/service/log/batch")
     InternalResponse<?> saveLogs(
         @ApiParam("批量保存日志请求报文")
         @RequestBody ServiceBatchSaveLogRequest request


### PR DESCRIPTION
原因：发布之前的api url 是 /service/log/batch, 发布的版本中被改成了 /batch, 导致发布过程中该 API 无法被调用