### PR TITLE
perf: 执行历史归档优化 #2831

### DIFF
--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractArchivist.java
@@ -155,7 +155,7 @@ public abstract class AbstractArchivist<T extends TableRecord<?>> {
         }
     }
 
-    private boolean isBackupEnable(ArchiveDBProperties archiveDBProperties) {
+    protected boolean isBackupEnable(ArchiveDBProperties archiveDBProperties) {
         return archiveDBProperties.isEnabled()
             && ArchiveModeEnum.BACKUP_THEN_DELETE == ArchiveModeEnum.valOf(archiveDBProperties.getMode());
     }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractArchivist.java
@@ -92,10 +92,13 @@ public abstract class AbstractArchivist<T extends TableRecord<?>> {
     private ArchiveSummary archiveSummary;
     private boolean isAcquireLock;
 
+    private ArchiveTaskLock archiveTaskLock;
+
     public AbstractArchivist(ExecuteRecordDAO<T> executeRecordDAO,
                              ExecuteArchiveDAO executeArchiveDAO,
                              ArchiveProgressService archiveProgressService,
                              ArchiveDBProperties archiveDBProperties,
+                             ArchiveTaskLock archiveTaskLock,
                              Long maxNeedArchiveId,
                              CountDownLatch countDownLatch) {
         this.executeRecordDAO = executeRecordDAO;
@@ -108,6 +111,7 @@ public abstract class AbstractArchivist<T extends TableRecord<?>> {
         this.countDownLatch = countDownLatch;
         this.tableName = executeRecordDAO.getTable().getName().toLowerCase();
         this.archiveSummary = new ArchiveSummary(this.tableName);
+        this.archiveTaskLock = archiveTaskLock;
     }
 
     public void archive() {
@@ -149,7 +153,7 @@ public abstract class AbstractArchivist<T extends TableRecord<?>> {
             archiveSummary.setArchiveMode(archiveDBProperties.getMode());
             storeArchiveSummary();
             if (this.isAcquireLock) {
-                ArchiveTaskLock.getInstance().unlock(tableName);
+                archiveTaskLock.unlock(tableName);
             }
             countDownLatch.countDown();
         }
@@ -161,7 +165,7 @@ public abstract class AbstractArchivist<T extends TableRecord<?>> {
     }
 
     private boolean acquireLock() {
-        this.isAcquireLock = ArchiveTaskLock.getInstance().lock(tableName);
+        this.isAcquireLock = archiveTaskLock.lock(tableName);
         archiveSummary.setSkip(!isAcquireLock);
         if (!isAcquireLock) {
             log.info("[{}] Acquire lock fail", tableName);

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobExecuteArchiveManage.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobExecuteArchiveManage.java
@@ -96,6 +96,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
     private final RollingConfigRecordDAO rollingConfigRecordDAO;
     private final TaskInstanceHostRecordDAO taskInstanceHostRecordDAO;
     private final ExecuteArchiveDAO executeArchiveDAO;
+    private final ArchiveTaskLock archiveTaskLock;
 
 
     /**
@@ -123,7 +124,8 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                                    ExecuteArchiveDAO executeArchiveDAO,
                                    ArchiveProgressService archiveProgressService,
                                    ArchiveDBProperties archiveDBProperties,
-                                   ExecutorService archiveExecutor) {
+                                   ExecutorService archiveExecutor,
+                                   ArchiveTaskLock archiveTaskLock) {
         log.info("Init JobExecuteArchiveManage! archiveConfig: {}", archiveDBProperties);
         this.archiveDBProperties = archiveDBProperties;
         this.archiveProgressService = archiveProgressService;
@@ -146,6 +148,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
         this.rollingConfigRecordDAO = rollingConfigRecordDAO;
         this.taskInstanceHostRecordDAO = taskInstanceHostRecordDAO;
         this.executeArchiveDAO = executeArchiveDAO;
+        this.archiveTaskLock = archiveTaskLock;
     }
 
     @Scheduled(cron = "${job.backup.archive.execute.cron:0 0 4 * * *}")
@@ -169,7 +172,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
     @Override
     public void stop() {
         log.info("Stop JobExecuteArchiveManage!");
-        ArchiveTaskLock.getInstance().unlockAll();
+        archiveTaskLock.unlockAll();
         log.info("Release all archive locks when stop!");
         this.running = false;
     }
@@ -314,6 +317,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveTaskInstanceId,
                 countDownLatch
             ).archive());
@@ -326,6 +330,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveStepInstanceId,
                 countDownLatch)
                 .archive());
@@ -338,6 +343,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveStepInstanceId,
                 countDownLatch)
                 .archive());
@@ -350,6 +356,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveStepInstanceId,
                 countDownLatch)
                 .archive());
@@ -362,6 +369,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveStepInstanceId,
                 countDownLatch)
                 .archive());
@@ -374,6 +382,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveStepInstanceId,
                 countDownLatch)
                 .archive());
@@ -386,6 +395,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveStepInstanceId,
                 countDownLatch)
                 .archive());
@@ -398,6 +408,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveStepInstanceId,
                 countDownLatch)
                 .archive());
@@ -410,6 +421,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveTaskInstanceId,
                 countDownLatch
             ).archive());
@@ -422,6 +434,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveStepInstanceId,
                 countDownLatch)
                 .archive());
@@ -434,6 +447,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveTaskInstanceId,
                 countDownLatch
             ).archive());
@@ -446,6 +460,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveStepInstanceId,
                 countDownLatch)
                 .archive());
@@ -458,6 +473,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveStepInstanceId,
                 countDownLatch)
                 .archive());
@@ -470,6 +486,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveStepInstanceId,
                 countDownLatch)
                 .archive());
@@ -483,6 +500,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveStepInstanceId,
                 countDownLatch)
                 .archive());
@@ -495,6 +513,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveTaskInstanceId,
                 countDownLatch
             ).archive());
@@ -507,6 +526,7 @@ public class JobExecuteArchiveManage implements SmartLifecycle {
                 executeArchiveDAO,
                 archiveProgressService,
                 archiveDBProperties,
+                archiveTaskLock,
                 maxNeedArchiveTaskInstanceId,
                 countDownLatch
             ).archive());

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/FileSourceTaskLogArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/FileSourceTaskLogArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.FileSourceTaskLogRecordDAO;
@@ -42,12 +43,14 @@ public class FileSourceTaskLogArchivist extends AbstractArchivist<FileSourceTask
                                       ExecuteArchiveDAO executeArchiveDAO,
                                       ArchiveProgressService archiveProgressService,
                                       ArchiveDBProperties archiveDBProperties,
+                                      ArchiveTaskLock archiveTaskLock,
                                       Long maxNeedArchiveId,
                                       CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 1_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/GseFileAgentTaskArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/GseFileAgentTaskArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.GseFileAgentTaskRecordDAO;
@@ -42,12 +43,14 @@ public class GseFileAgentTaskArchivist extends AbstractArchivist<GseFileAgentTas
                                      ExecuteArchiveDAO executeArchiveDAO,
                                      ArchiveProgressService archiveProgressService,
                                      ArchiveDBProperties archiveDBProperties,
+                                     ArchiveTaskLock archiveTaskLock,
                                      Long maxNeedArchiveId,
                                      CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 1_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/GseScriptAgentTaskArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/GseScriptAgentTaskArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.GseScriptAgentTaskRecordDAO;
@@ -42,12 +43,14 @@ public class GseScriptAgentTaskArchivist extends AbstractArchivist<GseScriptAgen
                                        ExecuteArchiveDAO executeArchiveDAO,
                                        ArchiveProgressService archiveProgressService,
                                        ArchiveDBProperties archiveDBProperties,
+                                       ArchiveTaskLock archiveTaskLock,
                                        Long maxNeedArchiveId,
                                        CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 1_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/GseTaskArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/GseTaskArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.GseTaskRecordDAO;
@@ -42,12 +43,14 @@ public class GseTaskArchivist extends AbstractArchivist<GseTaskRecord> {
                             ExecuteArchiveDAO executeArchiveDAO,
                             ArchiveProgressService archiveProgressService,
                             ArchiveDBProperties archiveDBProperties,
+                            ArchiveTaskLock archiveTaskLock,
                             Long maxNeedArchiveId,
                             CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 10_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/GseTaskIpLogArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/GseTaskIpLogArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.GseTaskIpLogRecordDAO;
@@ -42,12 +43,14 @@ public class GseTaskIpLogArchivist extends AbstractArchivist<GseTaskIpLogRecord>
                                  ExecuteArchiveDAO executeArchiveDAO,
                                  ArchiveProgressService archiveProgressService,
                                  ArchiveDBProperties archiveDBProperties,
+                                 ArchiveTaskLock archiveTaskLock,
                                  Long maxNeedArchiveId,
                                  CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 1_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/GseTaskLogArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/GseTaskLogArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.GseTaskLogRecordDAO;
@@ -42,12 +43,14 @@ public class GseTaskLogArchivist extends AbstractArchivist<GseTaskLogRecord> {
                                ExecuteArchiveDAO executeArchiveDAO,
                                ArchiveProgressService archiveProgressService,
                                ArchiveDBProperties archiveDBProperties,
+                               ArchiveTaskLock archiveTaskLock,
                                Long maxNeedArchiveId,
                                CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 10_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/OperationLogArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/OperationLogArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.OperationLogRecordDAO;
@@ -42,12 +43,14 @@ public class OperationLogArchivist extends AbstractArchivist<OperationLogRecord>
                                  ExecuteArchiveDAO executeArchiveDAO,
                                  ArchiveProgressService archiveProgressService,
                                  ArchiveDBProperties archiveDBProperties,
+                                 ArchiveTaskLock archiveTaskLock,
                                  Long maxNeedArchiveId,
                                  CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 10_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/RollingConfigArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/RollingConfigArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.RollingConfigRecordDAO;
@@ -42,12 +43,14 @@ public class RollingConfigArchivist extends AbstractArchivist<RollingConfigRecor
                                   ExecuteArchiveDAO executeArchiveDAO,
                                   ArchiveProgressService archiveProgressService,
                                   ArchiveDBProperties archiveDBProperties,
+                                  ArchiveTaskLock archiveTaskLock,
                                   Long maxNeedArchiveId,
                                   CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 100_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/StepInstanceArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/StepInstanceArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.StepInstanceRecordDAO;
@@ -42,12 +43,14 @@ public class StepInstanceArchivist extends AbstractArchivist<StepInstanceRecord>
                                  ExecuteArchiveDAO executeArchiveDAO,
                                  ArchiveProgressService archiveProgressService,
                                  ArchiveDBProperties archiveDBProperties,
+                                 ArchiveTaskLock archiveTaskLock,
                                  Long maxNeedArchiveId,
                                  CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 10_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/StepInstanceConfirmArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/StepInstanceConfirmArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.StepInstanceConfirmRecordDAO;
@@ -42,12 +43,14 @@ public class StepInstanceConfirmArchivist extends AbstractArchivist<StepInstance
                                         ExecuteArchiveDAO executeArchiveDAO,
                                         ArchiveProgressService archiveProgressService,
                                         ArchiveDBProperties archiveDBProperties,
+                                        ArchiveTaskLock archiveTaskLock,
                                         Long maxNeedArchiveId,
                                         CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 100_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/StepInstanceFileArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/StepInstanceFileArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.StepInstanceFileRecordDAO;
@@ -42,12 +43,14 @@ public class StepInstanceFileArchivist extends AbstractArchivist<StepInstanceFil
                                      ExecuteArchiveDAO executeArchiveDAO,
                                      ArchiveProgressService archiveProgressService,
                                      ArchiveDBProperties archiveDBProperties,
+                                     ArchiveTaskLock archiveTaskLock,
                                      Long maxNeedArchiveId,
                                      CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 10_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/StepInstanceRollingTaskArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/StepInstanceRollingTaskArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.StepInstanceRollingTaskRecordDAO;
@@ -42,12 +43,14 @@ public class StepInstanceRollingTaskArchivist extends AbstractArchivist<StepInst
                                             ExecuteArchiveDAO executeArchiveDAO,
                                             ArchiveProgressService archiveProgressService,
                                             ArchiveDBProperties archiveDBProperties,
+                                            ArchiveTaskLock archiveTaskLock,
                                             Long maxNeedArchiveId,
                                             CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 100_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/StepInstanceScriptArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/StepInstanceScriptArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.StepInstanceScriptRecordDAO;
@@ -42,12 +43,14 @@ public class StepInstanceScriptArchivist extends AbstractArchivist<StepInstanceS
                                        ExecuteArchiveDAO executeArchiveDAO,
                                        ArchiveProgressService archiveProgressService,
                                        ArchiveDBProperties archiveDBProperties,
+                                       ArchiveTaskLock archiveTaskLock,
                                        Long maxNeedArchiveId,
                                        CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 10_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/StepInstanceVariableArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/StepInstanceVariableArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.StepInstanceVariableRecordDAO;
@@ -42,12 +43,14 @@ public class StepInstanceVariableArchivist extends AbstractArchivist<StepInstanc
                                          ExecuteArchiveDAO executeArchiveDAO,
                                          ArchiveProgressService archiveProgressService,
                                          ArchiveDBProperties archiveDBProperties,
+                                         ArchiveTaskLock archiveTaskLock,
                                          Long maxNeedArchiveId,
                                          CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 100_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/TaskInstanceArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/TaskInstanceArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.TaskInstanceRecordDAO;
@@ -42,12 +43,14 @@ public class TaskInstanceArchivist extends AbstractArchivist<TaskInstanceRecord>
                                  ExecuteArchiveDAO executeArchiveDAO,
                                  ArchiveProgressService archiveProgressService,
                                  ArchiveDBProperties archiveDBProperties,
+                                 ArchiveTaskLock archiveTaskLock,
                                  Long maxNeedArchiveId,
                                  CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 10_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/TaskInstanceHostArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/TaskInstanceHostArchivist.java
@@ -34,7 +34,7 @@ import com.tencent.bk.job.execute.model.tables.records.TaskInstanceHostRecord;
 import java.util.concurrent.CountDownLatch;
 
 /**
- * gse_task 表归档
+ * task_instance_host 表归档
  */
 public class TaskInstanceHostArchivist extends AbstractArchivist<TaskInstanceHostRecord> {
 
@@ -51,5 +51,10 @@ public class TaskInstanceHostArchivist extends AbstractArchivist<TaskInstanceHos
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 10_000;
+    }
+
+    protected boolean isBackupEnable(ArchiveDBProperties archiveDBProperties) {
+        // task_instance_host 属于检索表，用于根据主机ip查询作业执行历史。该表数据较大，归档慢，且归档之后冷数据并无价值，无需归档
+        return false;
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/TaskInstanceHostArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/TaskInstanceHostArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.TaskInstanceHostRecordDAO;
@@ -42,12 +43,14 @@ public class TaskInstanceHostArchivist extends AbstractArchivist<TaskInstanceHos
                                      ExecuteArchiveDAO executeArchiveDAO,
                                      ArchiveProgressService archiveProgressService,
                                      ArchiveDBProperties archiveDBProperties,
+                                     ArchiveTaskLock archiveTaskLock,
                                      Long maxNeedArchiveId,
                                      CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 10_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/TaskInstanceVariableArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/TaskInstanceVariableArchivist.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.backup.archive.impl;
 
 import com.tencent.bk.job.backup.archive.AbstractArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
 import com.tencent.bk.job.backup.config.ArchiveDBProperties;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.TaskInstanceVariableRecordDAO;
@@ -42,12 +43,14 @@ public class TaskInstanceVariableArchivist extends AbstractArchivist<TaskInstanc
                                          ExecuteArchiveDAO executeArchiveDAO,
                                          ArchiveProgressService archiveProgressService,
                                          ArchiveDBProperties archiveDBProperties,
+                                         ArchiveTaskLock archiveTaskLock,
                                          Long maxNeedArchiveId,
                                          CountDownLatch countDownLatch) {
         super(executeRecordDAO,
             executeArchiveDAO,
             archiveProgressService,
             archiveDBProperties,
+            archiveTaskLock,
             maxNeedArchiveId,
             countDownLatch);
         this.deleteIdStepSize = 100_000;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfiguration.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfiguration.java
@@ -25,7 +25,6 @@
 package com.tencent.bk.job.backup.config;
 
 import com.tencent.bk.job.backup.archive.JobExecuteArchiveManage;
-import com.tencent.bk.job.backup.constant.ArchiveModeEnum;
 import com.tencent.bk.job.backup.dao.ExecuteArchiveDAO;
 import com.tencent.bk.job.backup.dao.impl.ExecuteArchiveDAOImpl;
 import com.tencent.bk.job.backup.dao.impl.FileSourceTaskLogRecordDAO;
@@ -51,9 +50,9 @@ import org.jooq.DSLContext;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -217,8 +216,7 @@ public class ArchiveConfiguration {
      * job-execute 归档数据备份 DB 配置
      */
     @Configuration
-    @ConditionalOnProperty(value = "job.backup.archive.execute.mode",
-        havingValue = ArchiveModeEnum.Constants.BACKUP_THEN_DELETE)
+    @Conditional(ExecuteBackupDbConfiguration.JobExecuteBackupDbInitCondition.class)
     public static class ExecuteBackupDAOConfig {
         @Bean(name = "execute-archive-dao")
         public ExecuteArchiveDAO executeArchiveDAO(@Qualifier("job-execute-archive-dsl-context") DSLContext context) {


### PR DESCRIPTION
1. 修复 backupConfig.archive.execute.enabled=false, 且  backupConfig.archive.execute.mode=backupThenDelete 这种配置下，job-backup 启动报错的问题
2. 优化归档逻辑： task_instance_host 直接删除，无需归档
3. 优化归档程序分布式锁机制。如果当前归档没有完成，锁会自动续期，而不是在一天都被 redis 自动过期