### PR TITLE
fix: get_job_instance_ip_log API, 根据 ip 查询执行日志报错 #2803

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/FileAgentTaskDAOImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/FileAgentTaskDAOImpl.java
@@ -344,14 +344,19 @@ public class FileAgentTaskDAOImpl implements FileAgentTaskDAO {
     @Override
     public ExecuteObjectTask getAgentTaskByHostId(Long stepInstanceId, Integer executeCount, Integer batch,
                                                   FileTaskModeEnum mode, long hostId) {
-        Record record = CTX.select(ALL_FIELDS)
-            .from(T_GSE_FILE_AGENT_TASK)
-            .where(T_GSE_FILE_AGENT_TASK.STEP_INSTANCE_ID.eq(stepInstanceId))
-            .and(T_GSE_FILE_AGENT_TASK.EXECUTE_COUNT.eq(executeCount.shortValue()))
-            .and(T_GSE_FILE_AGENT_TASK.BATCH.eq(batch == null ? 0 : batch.shortValue()))
-            .and(T_GSE_FILE_AGENT_TASK.MODE.eq(mode.getValue().byteValue()))
-            .and(T_GSE_FILE_AGENT_TASK.HOST_ID.eq(hostId))
-            .fetchOne();
+        SelectConditionStep<?> selectConditionStep =
+            CTX.select(ALL_FIELDS)
+                .from(T_GSE_FILE_AGENT_TASK)
+                .where(T_GSE_FILE_AGENT_TASK.STEP_INSTANCE_ID.eq(stepInstanceId))
+                .and(T_GSE_FILE_AGENT_TASK.EXECUTE_COUNT.eq(executeCount.shortValue()))
+                .and(T_GSE_FILE_AGENT_TASK.MODE.eq(mode.getValue().byteValue()))
+                .and(T_GSE_FILE_AGENT_TASK.HOST_ID.eq(hostId));
+        if (batch != null && batch > 0) {
+            // 滚动执行批次，传入null或者0将忽略该参数
+            selectConditionStep.and(T_GSE_FILE_AGENT_TASK.BATCH.eq(batch.shortValue()));
+        }
+        selectConditionStep.limit(1);
+        Record record = selectConditionStep.fetchOne();
         return extract(record);
     }
 

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/FileExecuteObjectTaskDAOImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/FileExecuteObjectTaskDAOImpl.java
@@ -351,14 +351,19 @@ public class FileExecuteObjectTaskDAOImpl implements FileExecuteObjectTaskDAO {
                                                       Integer batch,
                                                       FileTaskModeEnum mode,
                                                       String executeObjectId) {
-        Record record = CTX.select(ALL_FIELDS)
-            .from(T)
-            .where(T.STEP_INSTANCE_ID.eq(stepInstanceId))
-            .and(T.EXECUTE_COUNT.eq(executeCount.shortValue()))
-            .and(T.BATCH.eq(batch == null ? 0 : batch.shortValue()))
-            .and(T.MODE.eq(mode.getValue().byteValue()))
-            .and(T.EXECUTE_OBJ_ID.eq(executeObjectId))
-            .fetchOne();
+        SelectConditionStep<?> selectConditionStep =
+            CTX.select(ALL_FIELDS)
+                .from(T)
+                .where(T.STEP_INSTANCE_ID.eq(stepInstanceId))
+                .and(T.EXECUTE_COUNT.eq(executeCount.shortValue()))
+                .and(T.MODE.eq(mode.getValue().byteValue()))
+                .and(T.EXECUTE_OBJ_ID.eq(executeObjectId));
+        if (batch != null && batch > 0) {
+            // 滚动执行批次，传入null或者0将忽略该参数
+            selectConditionStep.and(T.BATCH.eq(batch.shortValue()));
+        }
+        selectConditionStep.limit(1);
+        Record record = selectConditionStep.fetchOne();
         return extract(record);
     }
 

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/ScriptAgentTaskDAOImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/ScriptAgentTaskDAOImpl.java
@@ -192,10 +192,10 @@ public class ScriptAgentTaskDAOImpl implements ScriptAgentTaskDAO {
 
     @Override
     public List<ExecuteObjectTask> listAgentTaskByResultGroup(Long stepInstanceId,
-                                                         Integer executeCount,
-                                                         Integer batch,
-                                                         Integer status,
-                                                         String tag) {
+                                                              Integer executeCount,
+                                                              Integer batch,
+                                                              Integer status,
+                                                              String tag) {
         SelectConditionStep<?> selectConditionStep = CTX.select(ALL_FIELDS)
             .from(T_GSE_SCRIPT_AGENT_TASK)
             .where(T_GSE_SCRIPT_AGENT_TASK.STEP_INSTANCE_ID.eq(stepInstanceId))
@@ -216,13 +216,13 @@ public class ScriptAgentTaskDAOImpl implements ScriptAgentTaskDAO {
 
     @Override
     public List<ExecuteObjectTask> listAgentTaskByResultGroup(Long stepInstanceId,
-                                                         Integer executeCount,
-                                                         Integer batch,
-                                                         Integer status,
-                                                         String tag,
-                                                         Integer limit,
-                                                         String orderField,
-                                                         Order order) {
+                                                              Integer executeCount,
+                                                              Integer batch,
+                                                              Integer status,
+                                                              String tag,
+                                                              Integer limit,
+                                                              String orderField,
+                                                              Order order) {
         List<Condition> conditions = new ArrayList<>();
         conditions.add(T_GSE_SCRIPT_AGENT_TASK.STEP_INSTANCE_ID.eq(stepInstanceId));
         conditions.add(T_GSE_SCRIPT_AGENT_TASK.EXECUTE_COUNT.eq(executeCount.shortValue()));
@@ -290,8 +290,8 @@ public class ScriptAgentTaskDAOImpl implements ScriptAgentTaskDAO {
 
     @Override
     public List<ExecuteObjectTask> listAgentTasks(Long stepInstanceId,
-                                             Integer executeCount,
-                                             Integer batch) {
+                                                  Integer executeCount,
+                                                  Integer batch) {
         SelectConditionStep<?> selectConditionStep = CTX.select(ALL_FIELDS)
             .from(T_GSE_SCRIPT_AGENT_TASK)
             .where(T_GSE_SCRIPT_AGENT_TASK.STEP_INSTANCE_ID.eq(stepInstanceId))
@@ -353,14 +353,20 @@ public class ScriptAgentTaskDAOImpl implements ScriptAgentTaskDAO {
     }
 
     @Override
-    public ExecuteObjectTask getAgentTaskByHostId(Long stepInstanceId, Integer executeCount, Integer batch, long hostId) {
-        Record record = CTX.select(ALL_FIELDS)
-            .from(T_GSE_SCRIPT_AGENT_TASK)
-            .where(T_GSE_SCRIPT_AGENT_TASK.STEP_INSTANCE_ID.eq(stepInstanceId))
-            .and(T_GSE_SCRIPT_AGENT_TASK.EXECUTE_COUNT.eq(executeCount.shortValue()))
-            .and(T_GSE_SCRIPT_AGENT_TASK.BATCH.eq(batch == null ? 0 : batch.shortValue()))
-            .and(T_GSE_SCRIPT_AGENT_TASK.HOST_ID.eq(hostId))
-            .fetchOne();
+    public ExecuteObjectTask getAgentTaskByHostId(Long stepInstanceId, Integer executeCount, Integer batch,
+                                                  long hostId) {
+        SelectConditionStep<?> selectConditionStep =
+            CTX.select(ALL_FIELDS)
+                .from(T_GSE_SCRIPT_AGENT_TASK)
+                .where(T_GSE_SCRIPT_AGENT_TASK.STEP_INSTANCE_ID.eq(stepInstanceId))
+                .and(T_GSE_SCRIPT_AGENT_TASK.EXECUTE_COUNT.eq(executeCount.shortValue()))
+                .and(T_GSE_SCRIPT_AGENT_TASK.HOST_ID.eq(hostId));
+        if (batch != null && batch > 0) {
+            // 滚动执行批次，传入null或者0将忽略该参数
+            selectConditionStep.and(T_GSE_SCRIPT_AGENT_TASK.BATCH.eq(batch.shortValue()));
+        }
+        selectConditionStep.limit(1);
+        Record record = selectConditionStep.fetchOne();
         return extract(record);
     }
 

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/ScriptExecuteObjectTaskDAOImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/ScriptExecuteObjectTaskDAOImpl.java
@@ -363,13 +363,18 @@ public class ScriptExecuteObjectTaskDAOImpl implements ScriptExecuteObjectTaskDA
                                                       Integer executeCount,
                                                       Integer batch,
                                                       String executeObjectId) {
-        Record record = CTX.select(ALL_FIELDS)
-            .from(T)
-            .where(T.STEP_INSTANCE_ID.eq(stepInstanceId))
-            .and(T.EXECUTE_COUNT.eq(executeCount.shortValue()))
-            .and(T.BATCH.eq(batch == null ? 0 : batch.shortValue()))
-            .and(T.EXECUTE_OBJ_ID.eq(executeObjectId))
-            .fetchOne();
+        SelectConditionStep<?> selectConditionStep =
+            CTX.select(ALL_FIELDS)
+                .from(T)
+                .where(T.STEP_INSTANCE_ID.eq(stepInstanceId))
+                .and(T.EXECUTE_COUNT.eq(executeCount.shortValue()))
+                .and(T.EXECUTE_OBJ_ID.eq(executeObjectId));
+        if (batch != null && batch > 0) {
+            // 滚动执行批次，传入null或者0将忽略该参数
+            selectConditionStep.and(T.BATCH.eq(batch.shortValue()));
+        }
+        selectConditionStep.limit(1);
+        Record record = selectConditionStep.fetchOne();
         return extract(record);
     }
 


### PR DESCRIPTION
# 问题分析
见 #2803

# 解决方案
DAO 查询的时候，batch参数 作为可选条件 ；如果传入 null 或者 小于 0，忽略 batch 参数

