### PR TITLE
perf: 执行历史归档优化 #2831

### DIFF
--- a/src/backend/commons/common-redis/src/main/java/com/tencent/bk/job/common/redis/util/LockUtils.java
+++ b/src/backend/commons/common-redis/src/main/java/com/tencent/bk/job/common/redis/util/LockUtils.java
@@ -35,12 +35,15 @@ import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 /**
- * @since 20/1/2020 10:49
+ * 分布式锁工具类
  */
 @Slf4j
 public class LockUtils {
 
-    private static final String LOCK_PREFIX = "job:util:lock:";
+    /**
+     * 分布式锁 key 的前缀
+     */
+    public static final String LOCK_KEY_PREFIX = "job:util:lock:";
     private static final Long RELEASE_SUCCESS = 1L;
     private static StringRedisTemplate redisTemplate = null;
     private static RedisScript<Long> unlockScript = null;
@@ -69,27 +72,7 @@ public class LockUtils {
      * @return 是否获取成功
      */
     public static boolean tryGetDistributedLock(String lockKey, String requestId, long expireTimeMillis) {
-        Boolean result = redisTemplate.opsForValue().setIfAbsent(LOCK_PREFIX + lockKey, requestId, expireTimeMillis,
-            TimeUnit.MILLISECONDS);
-        if (result != null) {
-            return result;
-        } else {
-            return false;
-        }
-    }
-
-    /**
-     * 尝试获取分布式锁
-     *
-     * @param prefix           锁前缀
-     * @param lockKey          锁
-     * @param requestId        请求标识
-     * @param expireTimeMillis 超期时间(毫秒)
-     * @return 是否获取成功
-     */
-    public static boolean tryGetDistributedLock(String prefix, String lockKey, String requestId,
-                                                long expireTimeMillis) {
-        Boolean result = redisTemplate.opsForValue().setIfAbsent(prefix + lockKey, requestId, expireTimeMillis,
+        Boolean result = redisTemplate.opsForValue().setIfAbsent(LOCK_KEY_PREFIX + lockKey, requestId, expireTimeMillis,
             TimeUnit.MILLISECONDS);
         if (result != null) {
             return result;
@@ -129,20 +112,8 @@ public class LockUtils {
      * @return 是否释放成功
      */
     public static boolean releaseDistributedLock(String lockKey, String requestId) {
-        Long result = redisTemplate.execute(unlockScript, Collections.singletonList(LOCK_PREFIX + lockKey), requestId);
-        return RELEASE_SUCCESS.equals(result);
-    }
-
-    /**
-     * 释放分布式锁
-     *
-     * @param prefix    锁前缀
-     * @param lockKey   锁
-     * @param requestId 请求标识
-     * @return 是否释放成功
-     */
-    public static boolean releaseDistributedLock(String prefix, String lockKey, String requestId) {
-        Long result = redisTemplate.execute(unlockScript, Collections.singletonList(prefix + lockKey), requestId);
+        Long result = redisTemplate.execute(unlockScript, Collections.singletonList(LOCK_KEY_PREFIX + lockKey),
+            requestId);
         return RELEASE_SUCCESS.equals(result);
     }
 
@@ -153,18 +124,7 @@ public class LockUtils {
      * @return 是否释放成功
      */
     public static boolean forceReleaseDistributedLock(String lockKey) {
-        return forceReleaseDistributedLock(LOCK_PREFIX, lockKey);
-    }
-
-    /**
-     * 强制释放分布式锁
-     *
-     * @param prefix  锁前缀
-     * @param lockKey 锁
-     * @return 是否释放成功
-     */
-    public static boolean forceReleaseDistributedLock(String prefix, String lockKey) {
-        Boolean result = redisTemplate.delete(prefix + lockKey);
+        Boolean result = redisTemplate.delete(LOCK_KEY_PREFIX + lockKey);
         if (result != null) {
             return result;
         } else {
@@ -188,18 +148,20 @@ public class LockUtils {
                 if (requestId != null && !requestId.isEmpty() && isHoldReentrantLock(lockKey, requestId)) {
                     return true;
                 }
-                return tryGetDistributedLock("", lockKey, requestId, expireTimeMillis);
+                return tryGetDistributedLock(lockKey, requestId, expireTimeMillis);
             } catch (Throwable e) {
+                String realLockKey = LOCK_KEY_PREFIX + lockKey;
                 if (e instanceof RedisException || e instanceof RedisSystemException) {
                     // Redis 故障
-                    String errorMsg = "Get lock from redis error! lockKey: " + lockKey + ", requestId: " + requestId
-                        + "! Block 1s until redis is up";
+                    String errorMsg = "Get lock from redis error! lockKey: " + realLockKey + ", requestId: "
+                        + requestId + "! Block 1s until redis is up";
                     log.error(errorMsg, e);
                     remainSeconds -= 1;
                     ThreadUtils.sleep(1000L);
                 } else {
                     // 非Redis原因导致的异常
-                    String errorMsg = "Get lock from redis error! lockKey: " + lockKey + ", requestId: " + requestId;
+                    String errorMsg = "Get lock from redis error! lockKey: " + realLockKey
+                        + ", requestId: " + requestId;
                     log.error(errorMsg, e);
                     return false;
                 }
@@ -211,8 +173,8 @@ public class LockUtils {
     /**
      * 是否已持有重入锁
      */
-    private static boolean isHoldReentrantLock(String key, String originValue) {
-        String v = redisTemplate.opsForValue().get(key);
+    private static boolean isHoldReentrantLock(String lockKey, String originValue) {
+        String v = redisTemplate.opsForValue().get(LOCK_KEY_PREFIX + lockKey);
         return originValue.equals(v);
     }
 

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/ArchiveTaskLock.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/ArchiveTaskLock.java
@@ -86,9 +86,10 @@ public class ArchiveTaskLock {
                                               String archiveLockKey,
                                               String lockRequestId) {
         // 开一个心跳子线程，维持锁状态不会因为超时失效
+        String realArchiveLockKey = LockUtils.LOCK_KEY_PREFIX + archiveLockKey;
         RedisKeyHeartBeatThread redisKeyHeartBeatThread = new RedisKeyHeartBeatThread(
             redisTemplate,
-            archiveLockKey,
+            realArchiveLockKey,
             lockRequestId,
             LOCK_TIME,
             30 * 60 * 1000L


### PR DESCRIPTION
1. 规范 LockUtils 工具，所有 key 必须包含 "job:util:lock:" 前缀 （不影响其它调用方的 key)
2. 修改 ArchiveTaskLock 的分布式锁续期的 key ，增加"job:util:lock:" 前缀，与实际锁定的 key 保持一致