### PR TITLE
perf: 主机分布式缓存新增 key 命中率统计 metrics #2816

### DIFF
--- a/src/backend/commons/common-redis/src/main/java/com/tencent/bk/job/common/redis/BaseRedisCache.java
+++ b/src/backend/commons/common-redis/src/main/java/com/tencent/bk/job/common/redis/BaseRedisCache.java
@@ -49,7 +49,7 @@ public class BaseRedisCache {
     /**
      * 增加缓存命中 key 次数
      */
-    public void addHits(int hitCount) {
+    public void addHits(long hitCount) {
         meterRegistry.counter(METRIC_NAME_JOB_REDIS_CACHE_HITS_TOTAL, TAG_CACHE_NAME, cacheName)
             .increment(hitCount);
     }
@@ -57,7 +57,7 @@ public class BaseRedisCache {
     /**
      * 增加缓存命中 key 次数
      */
-    public void addMisses(int missCount) {
+    public void addMisses(long missCount) {
         meterRegistry.counter(METRIC_NAME_JOB_REDIS_CACHE_MISSES_TOTAL, TAG_CACHE_NAME, cacheName)
             .increment(missCount);
     }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/manager/host/HostCache.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/manager/host/HostCache.java
@@ -43,6 +43,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -89,15 +90,16 @@ public class HostCache extends BaseRedisCache {
     }
 
     private List<CacheHostDO> getHostsByKeys(List<String> hostKeys) {
-        int hitCount = 0;
-        int missCount = 0;
+        long hitCount = 0;
+        long missCount = 0;
         try {
             List<Object> results = redisTemplate.opsForValue().multiGet(hostKeys);
             // 通过 Object 间接强制转换 List
             List<CacheHostDO> foundHosts = results == null ?
                 Collections.emptyList() : (List<CacheHostDO>) (Object) results;
 
-            hitCount = foundHosts.size();
+            // multiGet 获取到的 list 中的元素可能为 null （如果key 不存在)
+            hitCount = foundHosts.stream().filter(Objects::nonNull).count();
             missCount = hostKeys.size() - hitCount;
 
             return foundHosts;


### PR DESCRIPTION
1. job_redis_cache_misses_count 始终为 0 的问题