### PR TITLE
perf: 执行历史归档优化 #2831

### DIFF
--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/ArchiveTaskLock.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/ArchiveTaskLock.java
@@ -118,7 +118,7 @@ public class ArchiveTaskLock {
 
         String archiveLockKey = ARCHIVE_LOCK_KEY_PREFIX + "_" + tableName;
         LockUtils.releaseDistributedLock(archiveLockKey, lockRequestId);
-        this.locks.remove(archiveLockKey);
+        this.locks.remove(tableName);
     }
 
     public synchronized void unlock(String tableName) {


### PR DESCRIPTION
修复 ArchiveTaskLock.unlockAll() 报错的问题。
- 报错
<img width="1317" alt="image" src="https://github.com/TencentBlueKing/bk-job/assets/28581184/8364005f-8543-4fa3-b6bd-b86de4648b3b">

<img width="791" alt="image" src="https://github.com/TencentBlueKing/bk-job/assets/28581184/55f50e93-ca96-474c-8af0-64f981336ead">
