### PR TITLE
feat: 容器执行支持灰度 #2903

### DIFF
--- a/docs/apidoc/bk-api-gateway/v3/zh/bkci_plugin_fast_execute_script.md
+++ b/docs/apidoc/bk-api-gateway/v3/zh/bkci_plugin_fast_execute_script.md
@@ -72,7 +72,7 @@
 | kube_workload_filter | object | 否 |  workload 过滤器. 过滤器定义见 kube_workload_filter |
 | kube_pod_filter | object | 否 | pod 属性过滤器，过滤器定义见 kube_pod_filter |
 | kube_container_prop_filter | object | 是 | 容器属性过滤器，过滤器定义见 kube_container_prop_filter |
-| is_empty_filter | boolean | false | 标识一个没有设置任何条件的过滤器；默认值为 false。如果为 true, 将忽略其他的条件（kube_cluster_filter/kube_namespace_filter/kube_workload_filter/kube_pod_filter/kube_container_prop_filter)，返回业务下的所有容器 |
+| is_empty_filter | boolean | 是 | 标识一个没有设置任何条件的过滤器；默认值为 false。如果为 true, 将忽略其他的条件（kube_cluster_filter/kube_namespace_filter/kube_workload_filter/kube_pod_filter/kube_container_prop_filter)，返回业务下的所有容器 |
 | fetch_any_one_container | boolean | 否 | 是否从过滤结果集中选择任意一个容器作为执行对象（只有一个容器会被执行）；默认为 false |
 
 ##### kube_cluster_filter

--- a/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/AbstractResourceScopeToggleStrategy.java
+++ b/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/AbstractResourceScopeToggleStrategy.java
@@ -114,7 +114,7 @@ public abstract class AbstractResourceScopeToggleStrategy extends AbstractToggle
      *
      * @param scope 管理空间
      */
-    protected boolean hitResourceScopeRange(ResourceScope scope) {
+    protected boolean hitResourceScopeList(ResourceScope scope) {
         ResourceScope checkScope = scope;
         if (!scope.getClass().equals(ResourceScope.class)) {
             // 需要转换为 ResourceScope 类型，避免后面 contains() 判断因为 class 不同出现预期之外的结果

--- a/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/AbstractResourceScopeToggleStrategy.java
+++ b/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/AbstractResourceScopeToggleStrategy.java
@@ -108,4 +108,18 @@ public abstract class AbstractResourceScopeToggleStrategy extends AbstractToggle
 
         return true;
     }
+
+    /**
+     * 判断是否命中配置的管理空间列表
+     *
+     * @param scope 管理空间
+     */
+    protected boolean hitResourceScopeRange(ResourceScope scope) {
+        ResourceScope checkScope = scope;
+        if (!scope.getClass().equals(ResourceScope.class)) {
+            // 需要转换为 ResourceScope 类型，避免后面 contains() 判断因为 class 不同出现预期之外的结果
+            checkScope = new ResourceScope(scope.getType(), scope.getId());
+        }
+        return this.resourceScopes.contains(checkScope);
+    }
 }

--- a/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/ResourceScopeBlackListToggleStrategy.java
+++ b/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/ResourceScopeBlackListToggleStrategy.java
@@ -47,7 +47,7 @@ public class ResourceScopeBlackListToggleStrategy extends AbstractResourceScopeT
     @Override
     public boolean evaluate(String featureId, FeatureExecutionContext ctx) {
         ResourceScope scope = (ResourceScope) ctx.getParam(ToggleStrategyContextParams.CTX_PARAM_RESOURCE_SCOPE);
-        return !hitResourceScopeRange(scope);
+        return !hitResourceScopeList(scope);
     }
 
     @Override

--- a/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/ResourceScopeBlackListToggleStrategy.java
+++ b/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/ResourceScopeBlackListToggleStrategy.java
@@ -47,7 +47,7 @@ public class ResourceScopeBlackListToggleStrategy extends AbstractResourceScopeT
     @Override
     public boolean evaluate(String featureId, FeatureExecutionContext ctx) {
         ResourceScope scope = (ResourceScope) ctx.getParam(ToggleStrategyContextParams.CTX_PARAM_RESOURCE_SCOPE);
-        return !this.resourceScopes.contains(scope);
+        return !hitResourceScopeRange(scope);
     }
 
     @Override

--- a/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/ResourceScopeWhiteListToggleStrategy.java
+++ b/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/ResourceScopeWhiteListToggleStrategy.java
@@ -47,7 +47,7 @@ public class ResourceScopeWhiteListToggleStrategy extends AbstractResourceScopeT
     @Override
     public boolean evaluate(String featureId, FeatureExecutionContext ctx) {
         ResourceScope scope = (ResourceScope) ctx.getParam(ToggleStrategyContextParams.CTX_PARAM_RESOURCE_SCOPE);
-        return this.resourceScopes.contains(scope);
+        return hitResourceScopeRange(scope);
     }
 
     @Override

--- a/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/ResourceScopeWhiteListToggleStrategy.java
+++ b/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/ResourceScopeWhiteListToggleStrategy.java
@@ -47,7 +47,7 @@ public class ResourceScopeWhiteListToggleStrategy extends AbstractResourceScopeT
     @Override
     public boolean evaluate(String featureId, FeatureExecutionContext ctx) {
         ResourceScope scope = (ResourceScope) ctx.getParam(ToggleStrategyContextParams.CTX_PARAM_RESOURCE_SCOPE);
-        return hitResourceScopeRange(scope);
+        return hitResourceScopeList(scope);
     }
 
     @Override


### PR DESCRIPTION
修复按业务灰度判断结果不正确的问题。原因：灰度策略上下文传入的是AppResourceScope类型的对象，但是策略计算的时候是直接比较 ResourceScope 类型，导致即使 scopeType&scopeId, 但是仍然会判定为false,与预期不符