### PR TITLE
job 调用 cmdb list_kube_workload api 查询条件不正确导致循环查询 #2924

### DIFF
--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/model/container/KubeWorkloadDTO.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/model/container/KubeWorkloadDTO.java
@@ -63,7 +63,7 @@ public class KubeWorkloadDTO {
     private Long bizId;
 
     /**
-     * namespace 资源 ID（namespace 在 cmdb 中注册资源的 ID）
+     * workload 资源 ID（wordload 在 cmdb 中注册资源的 ID）
      */
     private Long id;
 

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizCmdbClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizCmdbClient.java
@@ -1701,7 +1701,7 @@ public class BizCmdbClient extends BaseCmdbApiClient implements IBizCmdbClient {
         ListKubeClusterReq nextPageReq = new ListKubeClusterReq();
         nextPageReq.setPage(originReq.getPage());
         nextPageReq.setBizId(originReq.getBizId());
-        originReq.setFields(originReq.getFields());
+        nextPageReq.setFields(originReq.getFields());
         nextPageReq.setBkSupplierAccount(originReq.getBkSupplierAccount());
 
         // 添加 cluster ID 作为分页查询 offset 条件
@@ -1790,7 +1790,7 @@ public class BizCmdbClient extends BaseCmdbApiClient implements IBizCmdbClient {
         ListKubeNamespaceReq nextPageReq = new ListKubeNamespaceReq();
         nextPageReq.setPage(originReq.getPage());
         nextPageReq.setBizId(originReq.getBizId());
-        originReq.setFields(originReq.getFields());
+        nextPageReq.setFields(originReq.getFields());
         nextPageReq.setBkSupplierAccount(originReq.getBkSupplierAccount());
 
         // 添加 namespace ID 作为分页查询 offset 条件
@@ -1845,18 +1845,15 @@ public class BizCmdbClient extends BaseCmdbApiClient implements IBizCmdbClient {
                     return buildNextPageListKubeWorkloadReq(req, latestElement.getId());
                 }
             },
-            pageReq -> listPage(
-                req,
-                false,
-                cmdbPageReq -> requestCmdbApi(
-                    ApiGwType.BK_APIGW,
-                    HttpMethodEnum.POST,
-                    requestUrl,
-                    null,
-                    cmdbPageReq,
-                    new TypeReference<EsbResp<BaseCcSearchResult<KubeWorkloadDTO>>>() {
-                    })),
-            PageData::getData,
+            cmdbPageReq -> requestCmdbApi(
+                ApiGwType.BK_APIGW,
+                HttpMethodEnum.POST,
+                requestUrl,
+                null,
+                cmdbPageReq,
+                new TypeReference<EsbResp<BaseCcSearchResult<KubeWorkloadDTO>>>() {
+                }),
+            resp -> resp.getData().getInfo(),
             workload -> {
                 // cmdb API 返回的数据没有包含 kind 信息，需要补全
                 workload.setKind(req.getKind());


### PR DESCRIPTION
#2924

- 缺陷原因：list_kube_workload 一直都是是用原始的 request, 而不是使用 buildNextPageListKubeWorkloadReq(req) 中生成的请求，导致一直循环查询，直到超时。（传参错误）