### PR TITLE
feat: 本地文件上传类型限制，需要支持.xx.xx类型 #2917

### DIFF
--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/globalsetting/FileUploadSettingReq.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/request/globalsetting/FileUploadSettingReq.java
@@ -62,7 +62,7 @@ public class FileUploadSettingReq {
     private Integer restrictMode;
 
     @ApiModelProperty("后缀列表")
-    private List<@Pattern(regexp = "^\\.[A-Za-z0-9_-]{1,24}$",
+    private List<@Pattern(regexp = "^(\\.[A-Za-z0-9_-]{1,24})+$",
         message = "{validation.constraints.InvalidUploadFileSuffix.message}") String> suffixList;
 
 }


### PR DESCRIPTION
nekzhang: 直接改成不用分层吧, 本质上是对文件后缀的检测，可以不用定那么死必须只有1层