### PR TITLE
feat: 执行历史归档源 DB 支持独立配置 #2929

### DIFF
--- a/support-files/kubernetes/charts/bk-job/VALUES_LOG.md
+++ b/support-files/kubernetes/charts/bk-job/VALUES_LOG.md
@@ -20,6 +20,10 @@ backupConfig:
     execute:
       # 是否启用 DB 归档
       enabled: true
+      # 被归档 DB 的配置
+      mariadb:
+        connection:
+          properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
       # 归档模式。deleteOnly: 仅删除； backupThenDelete: 先备份数据再删除。默认 deleteOnly
       mode: backupThenDelete
       # 归档任务运行的cron表达式，默认每天凌晨04:00

--- a/support-files/kubernetes/charts/bk-job/templates/job-backup/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-backup/configmap.yaml
@@ -51,7 +51,7 @@ data:
         job-execute:
           driver-class-name: {{ include "job.jdbcMysqlDriverClass" . }}
           type: com.zaxxer.hikari.HikariDataSource
-          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_execute{{ include "job.mariadb.connection.properties" . }}
+          jdbc-url: {{ include "job.jdbcMysqlScheme" . }}://{{- include "job.mariadb.host" . }}:{{- include "job.mariadb.port" . }}/job_execute{{ .Values.backupConfig.archive.execute.mariadb.connection.properties }}
           username: {{ include "job.mariadb.username" . }}
           {{ if .Values.externalMariaDB.existingPasswordSecret }}
           password: {{ .Values.externalMariaDB.existingPasswordKey | default "mariadb-password" | printf "${%s}" }}

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -1099,6 +1099,10 @@ backupConfig:
     execute:
       # 是否启用 DB 归档
       enabled: false
+      # 被归档 DB 的配置
+      mariadb:
+        connection:
+          properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
       # 归档模式。deleteOnly: 仅删除；backupThenDelete: 先备份数据再删除。默认 deleteOnly
       mode: deleteOnly
       # 归档任务运行的cron表达式，默认每天凌晨04:00


### PR DESCRIPTION
1. 支持独立配置被归档 db 的连接参数
2. 修改归档相关参数命名格式为驼峰方式，保持全局统一（ConfigurationProperties 会自动适配不同命名方式，无需修改 java 代码)