### PR TITLE
fix: 定时任务服务更新后偶现任务不触发 #2926 

### DIFF
--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/runner/LoadCronJobRunner.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/runner/LoadCronJobRunner.java
@@ -22,33 +22,39 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.crontab.task;
+package com.tencent.bk.job.crontab.runner;
 
 import com.tencent.bk.job.crontab.service.CronJobLoadingService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * 进程启动时立即将DB中的定时任务加载到Quartz
+ */
 @Slf4j
-@Component("jobCrontabScheduledTasks")
-@EnableScheduling
-public class ScheduledTasks {
+@Component
+public class LoadCronJobRunner implements CommandLineRunner {
 
     private final CronJobLoadingService cronJobLoadingService;
+    private final ThreadPoolExecutor crontabInitRunnerExecutor;
 
     @Autowired
-    public ScheduledTasks(CronJobLoadingService cronJobLoadingService) {
+    public LoadCronJobRunner(CronJobLoadingService cronJobLoadingService,
+                             @Qualifier("crontabInitRunnerExecutor") ThreadPoolExecutor crontabInitRunnerExecutor) {
         this.cronJobLoadingService = cronJobLoadingService;
+        this.crontabInitRunnerExecutor = crontabInitRunnerExecutor;
     }
 
-    /**
-     * 每天早上9:30更新一次定时任务数据到Quartz内存
-     */
-    @Scheduled(cron = "0 30 9 * * *")
-    public void loadCronToQuartzPeriodically() {
-        log.info("loadCronToQuartzPeriodically");
-        cronJobLoadingService.loadAllCronJob();
+    @Override
+    public void run(String... args) {
+        crontabInitRunnerExecutor.submit(() -> {
+            log.info("loadCronToQuartzOnStartup");
+            cronJobLoadingService.loadAllCronJob();
+        });
     }
 }

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobLoadingServiceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobLoadingServiceImpl.java
@@ -49,6 +49,7 @@ public class CronJobLoadingServiceImpl implements CronJobLoadingService {
 
     @Override
     public void loadAllCronJob() {
+        long start = System.currentTimeMillis();
         try {
             if (loadingCronToQuartz) {
                 log.info("Last loading not finish, ignore");
@@ -60,6 +61,7 @@ public class CronJobLoadingServiceImpl implements CronJobLoadingService {
             log.warn("Fail to loadAllCronJob", e);
         } finally {
             loadingCronToQuartz = false;
+            log.info("loadAllCronJob end, duration={}ms", System.currentTimeMillis() - start);
         }
     }
 

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobServiceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobServiceImpl.java
@@ -850,11 +850,11 @@ public class CronJobServiceImpl implements CronJobService {
             }
             return true;
         } catch (ServiceException e) {
-            informAllToDeleteJobFromQuartz(appId, cronJobId);
+            deleteJobFromQuartz(appId, cronJobId);
             log.debug("Error while schedule job", e);
             throw e;
         } catch (Exception e) {
-            informAllToDeleteJobFromQuartz(appId, cronJobId);
+            deleteJobFromQuartz(appId, cronJobId);
             log.error("Unknown exception while process cron status change!", e);
             throw new InternalException(ErrorCode.UPDATE_CRON_JOB_FAILED);
         }

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/task/ScheduledTasks.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/task/ScheduledTasks.java
@@ -44,11 +44,24 @@ public class ScheduledTasks {
     }
 
     /**
-     * 每间隔30min更新一次定时任务数据到Quartz内存
+     * 启动时更新一次定时任务数据到Quartz内存
      */
-    @Scheduled(initialDelay = 5 * 1000, fixedDelay = 30 * 60 * 1000)
+    @Scheduled(initialDelay = 5 * 1000)
+    public void loadCronToQuartzOnStartup() {
+        log.info("loadCronToQuartzOnStartup");
+        loadCronToQuartz();
+    }
+
+    /**
+     * 每天早上9:30更新一次定时任务数据到Quartz内存
+     */
+    @Scheduled(cron = "0 30 9 * * *")
+    public void loadCronToQuartzPeriodically() {
+        log.info("loadCronToQuartzPeriodically");
+        loadCronToQuartz();
+    }
+
     public void loadCronToQuartz() {
-        log.info("loadCronToQuartz");
         long start = System.currentTimeMillis();
         try {
             cronJobLoadingService.loadAllCronJob();


### PR DESCRIPTION
1.修复添加定时任务到Quartz失败后的删除操作；
2.调整定时任务重加载时间与频率。