### PR TITLE
fix: 执行历史归档读取数据重复，导致归档数据写入冲突 #2952

### DIFF
--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/FileSourceTaskLogArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/FileSourceTaskLogArchivist.java
@@ -58,4 +58,6 @@ public class FileSourceTaskLogArchivist extends AbstractArchivist<FileSourceTask
             archiveErrorTaskCounter);
         this.deleteIdStepSize = 1_000;
     }
+
+
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/AbstractExecuteRecordDAO.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/AbstractExecuteRecordDAO.java
@@ -1,14 +1,18 @@
 package com.tencent.bk.job.backup.dao.impl;
 
 import com.tencent.bk.job.backup.dao.ExecuteRecordDAO;
+import org.apache.commons.collections4.CollectionUtils;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
+import org.jooq.OrderField;
 import org.jooq.Record;
 import org.jooq.Record1;
 import org.jooq.Result;
+import org.jooq.SelectConditionStep;
 import org.jooq.Table;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import static org.jooq.impl.DSL.min;
@@ -51,12 +55,19 @@ public abstract class AbstractExecuteRecordDAO<T extends Record> implements Exec
         return totalDeleteRows;
     }
 
-    private Result<Record> query(Table<?> table, List<Condition> conditions, Long offset, Long limit) {
-        return context.select()
+    private Result<Record> query(Table<?> table,
+                                 List<Condition> conditions,
+                                 Long offset,
+                                 Long limit) {
+        SelectConditionStep<Record> selectConditionStep = context.select()
             .from(table)
-            .where(conditions)
-            .limit(offset, limit)
-            .fetch();
+            .where(conditions);
+
+        if (CollectionUtils.isNotEmpty(getListRecordsOrderFields())) {
+            return selectConditionStep.orderBy(getListRecordsOrderFields()).limit(offset, limit).fetch();
+        } else {
+            return selectConditionStep.limit(offset, limit).fetch();
+        }
     }
 
     @Override
@@ -69,4 +80,8 @@ public abstract class AbstractExecuteRecordDAO<T extends Record> implements Exec
     }
 
     public abstract Table<T> getTable();
+
+    protected Collection<? extends OrderField<?>> getListRecordsOrderFields() {
+        return null;
+    }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/FileSourceTaskLogRecordDAO.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/FileSourceTaskLogRecordDAO.java
@@ -4,8 +4,13 @@ package com.tencent.bk.job.backup.dao.impl;
 import com.tencent.bk.job.execute.model.tables.FileSourceTaskLog;
 import com.tencent.bk.job.execute.model.tables.records.FileSourceTaskLogRecord;
 import org.jooq.DSLContext;
+import org.jooq.OrderField;
 import org.jooq.Table;
 import org.jooq.TableField;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * file_source_task_log DAO
@@ -13,6 +18,12 @@ import org.jooq.TableField;
 public class FileSourceTaskLogRecordDAO extends AbstractExecuteRecordDAO<FileSourceTaskLogRecord> {
 
     private static final FileSourceTaskLog TABLE = FileSourceTaskLog.FILE_SOURCE_TASK_LOG;
+    private static final List<OrderField<?>> ORDER_FIELDS = new ArrayList<>();
+
+    static {
+        ORDER_FIELDS.add(FileSourceTaskLog.FILE_SOURCE_TASK_LOG.STEP_INSTANCE_ID.asc());
+        ORDER_FIELDS.add(FileSourceTaskLog.FILE_SOURCE_TASK_LOG.EXECUTE_COUNT.asc());
+    }
 
     public FileSourceTaskLogRecordDAO(DSLContext context) {
         super(context);
@@ -26,5 +37,10 @@ public class FileSourceTaskLogRecordDAO extends AbstractExecuteRecordDAO<FileSou
     @Override
     public TableField<FileSourceTaskLogRecord, Long> getArchiveIdField() {
         return TABLE.STEP_INSTANCE_ID;
+    }
+
+    @Override
+    protected Collection<? extends OrderField<?>> getListRecordsOrderFields() {
+        return ORDER_FIELDS;
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/GseFileAgentTaskRecordDAO.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/GseFileAgentTaskRecordDAO.java
@@ -3,8 +3,13 @@ package com.tencent.bk.job.backup.dao.impl;
 import com.tencent.bk.job.execute.model.tables.GseFileAgentTask;
 import com.tencent.bk.job.execute.model.tables.records.GseFileAgentTaskRecord;
 import org.jooq.DSLContext;
+import org.jooq.OrderField;
 import org.jooq.Table;
 import org.jooq.TableField;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * gse_file_agent_task DAO
@@ -12,6 +17,15 @@ import org.jooq.TableField;
 public class GseFileAgentTaskRecordDAO extends AbstractExecuteRecordDAO<GseFileAgentTaskRecord> {
 
     private static final GseFileAgentTask TABLE = GseFileAgentTask.GSE_FILE_AGENT_TASK;
+    private static final List<OrderField<?>> ORDER_FIELDS = new ArrayList<>();
+
+    static {
+        ORDER_FIELDS.add(GseFileAgentTask.GSE_FILE_AGENT_TASK.STEP_INSTANCE_ID.asc());
+        ORDER_FIELDS.add(GseFileAgentTask.GSE_FILE_AGENT_TASK.EXECUTE_COUNT.asc());
+        ORDER_FIELDS.add(GseFileAgentTask.GSE_FILE_AGENT_TASK.BATCH.asc());
+        ORDER_FIELDS.add(GseFileAgentTask.GSE_FILE_AGENT_TASK.MODE.asc());
+        ORDER_FIELDS.add(GseFileAgentTask.GSE_FILE_AGENT_TASK.HOST_ID.asc());
+    }
 
     public GseFileAgentTaskRecordDAO(DSLContext context) {
         super(context);
@@ -25,5 +39,10 @@ public class GseFileAgentTaskRecordDAO extends AbstractExecuteRecordDAO<GseFileA
     @Override
     public TableField<GseFileAgentTaskRecord, Long> getArchiveIdField() {
         return TABLE.STEP_INSTANCE_ID;
+    }
+
+    @Override
+    protected Collection<? extends OrderField<?>> getListRecordsOrderFields() {
+        return ORDER_FIELDS;
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/GseScriptAgentTaskRecordDAO.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/GseScriptAgentTaskRecordDAO.java
@@ -1,10 +1,16 @@
 package com.tencent.bk.job.backup.dao.impl;
 
+import com.tencent.bk.job.execute.model.tables.GseFileAgentTask;
 import com.tencent.bk.job.execute.model.tables.GseScriptAgentTask;
 import com.tencent.bk.job.execute.model.tables.records.GseScriptAgentTaskRecord;
 import org.jooq.DSLContext;
+import org.jooq.OrderField;
 import org.jooq.Table;
 import org.jooq.TableField;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * gse_script_agent_task DAO
@@ -12,6 +18,14 @@ import org.jooq.TableField;
 public class GseScriptAgentTaskRecordDAO extends AbstractExecuteRecordDAO<GseScriptAgentTaskRecord> {
 
     private static final GseScriptAgentTask TABLE = GseScriptAgentTask.GSE_SCRIPT_AGENT_TASK;
+    private static final List<OrderField<?>> ORDER_FIELDS = new ArrayList<>();
+
+    static {
+        ORDER_FIELDS.add(GseScriptAgentTask.GSE_SCRIPT_AGENT_TASK.STEP_INSTANCE_ID.asc());
+        ORDER_FIELDS.add(GseScriptAgentTask.GSE_SCRIPT_AGENT_TASK.EXECUTE_COUNT.asc());
+        ORDER_FIELDS.add(GseScriptAgentTask.GSE_SCRIPT_AGENT_TASK.BATCH.asc());
+        ORDER_FIELDS.add(GseScriptAgentTask.GSE_SCRIPT_AGENT_TASK.HOST_ID.asc());
+    }
 
     public GseScriptAgentTaskRecordDAO(DSLContext context) {
         super(context);
@@ -25,5 +39,10 @@ public class GseScriptAgentTaskRecordDAO extends AbstractExecuteRecordDAO<GseScr
     @Override
     public TableField<GseScriptAgentTaskRecord, Long> getArchiveIdField() {
         return TABLE.STEP_INSTANCE_ID;
+    }
+
+    @Override
+    protected Collection<? extends OrderField<?>> getListRecordsOrderFields() {
+        return ORDER_FIELDS;
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/GseTaskRecordDAO.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/GseTaskRecordDAO.java
@@ -3,12 +3,24 @@ package com.tencent.bk.job.backup.dao.impl;
 import com.tencent.bk.job.execute.model.tables.GseTask;
 import com.tencent.bk.job.execute.model.tables.records.GseTaskRecord;
 import org.jooq.DSLContext;
+import org.jooq.OrderField;
 import org.jooq.Table;
 import org.jooq.TableField;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 public class GseTaskRecordDAO extends AbstractExecuteRecordDAO<GseTaskRecord> {
 
     private static final GseTask TABLE = GseTask.GSE_TASK;
+    private static final List<OrderField<?>> ORDER_FIELDS = new ArrayList<>();
+
+    static {
+        ORDER_FIELDS.add(GseTask.GSE_TASK.STEP_INSTANCE_ID.asc());
+        ORDER_FIELDS.add(GseTask.GSE_TASK.EXECUTE_COUNT.asc());
+        ORDER_FIELDS.add(GseTask.GSE_TASK.BATCH.asc());
+    }
 
     public GseTaskRecordDAO(DSLContext context) {
         super(context);
@@ -22,5 +34,10 @@ public class GseTaskRecordDAO extends AbstractExecuteRecordDAO<GseTaskRecord> {
     @Override
     public TableField<GseTaskRecord, Long> getArchiveIdField() {
         return TABLE.STEP_INSTANCE_ID;
+    }
+
+    @Override
+    protected Collection<? extends OrderField<?>> getListRecordsOrderFields() {
+        return ORDER_FIELDS;
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/StepInstanceRollingTaskRecordDAO.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/StepInstanceRollingTaskRecordDAO.java
@@ -3,8 +3,13 @@ package com.tencent.bk.job.backup.dao.impl;
 import com.tencent.bk.job.execute.model.tables.StepInstanceRollingTask;
 import com.tencent.bk.job.execute.model.tables.records.StepInstanceRollingTaskRecord;
 import org.jooq.DSLContext;
+import org.jooq.OrderField;
 import org.jooq.Table;
 import org.jooq.TableField;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * step_instance_rolling_task DAO
@@ -12,6 +17,13 @@ import org.jooq.TableField;
 public class StepInstanceRollingTaskRecordDAO extends AbstractExecuteRecordDAO<StepInstanceRollingTaskRecord> {
 
     private static final StepInstanceRollingTask TABLE = StepInstanceRollingTask.STEP_INSTANCE_ROLLING_TASK;
+    private static final List<OrderField<?>> ORDER_FIELDS = new ArrayList<>();
+
+    static {
+        ORDER_FIELDS.add(StepInstanceRollingTask.STEP_INSTANCE_ROLLING_TASK.STEP_INSTANCE_ID.asc());
+        ORDER_FIELDS.add(StepInstanceRollingTask.STEP_INSTANCE_ROLLING_TASK.EXECUTE_COUNT.asc());
+        ORDER_FIELDS.add(StepInstanceRollingTask.STEP_INSTANCE_ROLLING_TASK.BATCH.asc());
+    }
 
     public StepInstanceRollingTaskRecordDAO(DSLContext context) {
         super(context);
@@ -25,5 +37,10 @@ public class StepInstanceRollingTaskRecordDAO extends AbstractExecuteRecordDAO<S
     @Override
     public TableField<StepInstanceRollingTaskRecord, Long> getArchiveIdField() {
         return TABLE.STEP_INSTANCE_ID;
+    }
+
+    @Override
+    protected Collection<? extends OrderField<?>> getListRecordsOrderFields() {
+        return ORDER_FIELDS;
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/StepInstanceVariableRecordDAO.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/StepInstanceVariableRecordDAO.java
@@ -3,8 +3,13 @@ package com.tencent.bk.job.backup.dao.impl;
 import com.tencent.bk.job.execute.model.tables.StepInstanceVariable;
 import com.tencent.bk.job.execute.model.tables.records.StepInstanceVariableRecord;
 import org.jooq.DSLContext;
+import org.jooq.OrderField;
 import org.jooq.Table;
 import org.jooq.TableField;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * step_instance_variable DAO
@@ -12,6 +17,12 @@ import org.jooq.TableField;
 public class StepInstanceVariableRecordDAO extends AbstractExecuteRecordDAO<StepInstanceVariableRecord> {
 
     private static final StepInstanceVariable TABLE = StepInstanceVariable.STEP_INSTANCE_VARIABLE;
+    private static final List<OrderField<?>> ORDER_FIELDS = new ArrayList<>();
+
+    static {
+        ORDER_FIELDS.add(StepInstanceVariable.STEP_INSTANCE_VARIABLE.STEP_INSTANCE_ID.asc());
+        ORDER_FIELDS.add(StepInstanceVariable.STEP_INSTANCE_VARIABLE.EXECUTE_COUNT.asc());
+    }
 
     public StepInstanceVariableRecordDAO(DSLContext context) {
         super(context);
@@ -25,5 +36,10 @@ public class StepInstanceVariableRecordDAO extends AbstractExecuteRecordDAO<Step
     @Override
     public TableField<StepInstanceVariableRecord, Long> getArchiveIdField() {
         return TABLE.STEP_INSTANCE_ID;
+    }
+
+    @Override
+    protected Collection<? extends OrderField<?>> getListRecordsOrderFields() {
+        return ORDER_FIELDS;
     }
 }


### PR DESCRIPTION
问题描述与分析见 #2952 

## 修复方案
1. 读取表记录使用 order by 条件，保证每次查询数据顺序的唯一性；order by 的字段均有索引覆盖，保证读取效率