### PR TITLE
perf: mongodb数据支持自动清理 #2783

### DIFF
--- a/src/backend/job-backup/service-job-backup/build.gradle
+++ b/src/backend/job-backup/service-job-backup/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-jooq")
+    implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
     implementation "org.apache.commons:commons-collections4"
     implementation "commons-io:commons-io"
     implementation "ch.qos.logback:logback-core"

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractMongoDBArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractMongoDBArchivist.java
@@ -1,0 +1,264 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.backup.archive;
+
+import com.tencent.bk.job.backup.config.ArchiveDBProperties;
+import com.tencent.bk.job.backup.constant.ArchiveModeEnum;
+import com.tencent.bk.job.backup.constant.MongoDBLogTypeEnum;
+import com.tencent.bk.job.backup.metrics.ArchiveErrorTaskCounter;
+import com.tencent.bk.job.backup.model.dto.ArchiveSummary;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.helpers.MessageFormatter;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * mongodb归档基础实现
+ */
+@Slf4j
+public abstract class AbstractMongoDBArchivist {
+    protected ArchiveDBProperties archiveDBProperties;
+    protected CountDownLatch countDownLatch;
+    protected ArchiveSummary archiveSummary;
+    protected boolean isAcquireLock;
+    protected ArchiveTaskLock archiveTaskLock;
+    protected MongoDBLogTypeEnum mongoDBLogTypeEnum;
+    protected AtomicInteger deleteCounter;
+    protected AtomicInteger backupCounter;
+    protected AtomicInteger failCounter;
+
+    protected final ArchiveErrorTaskCounter archiveErrorTaskCounter;
+    protected final MongoTemplate mongoTemplate;
+    protected final String SCRIPT_LOG_PREFIX = "job_log_script";
+    protected final String FILE_LOG_PREFIX = "job_log_file";
+    protected final String COLLECTION_NAME_SEPARATOR = "_";
+    protected final String COLLECTION_NAME_DATE_FORMATTER = "yyyy_MM_dd";
+
+    public AbstractMongoDBArchivist(MongoTemplate mongoTemplate,
+                                    ArchiveDBProperties archiveDBProperties,
+                                    ArchiveTaskLock archiveTaskLock,
+                                    CountDownLatch countDownLatch,
+                                    ArchiveErrorTaskCounter archiveErrorTaskCounter,
+                                    MongoDBLogTypeEnum mongoDBLogTypeEnum) {
+        this.mongoTemplate = mongoTemplate;
+        this.archiveDBProperties = archiveDBProperties;
+        this.countDownLatch = countDownLatch;
+        this.archiveSummary = new ArchiveSummary();
+        this.archiveTaskLock = archiveTaskLock;
+        this.archiveErrorTaskCounter = archiveErrorTaskCounter;
+        this.mongoDBLogTypeEnum = mongoDBLogTypeEnum;
+        deleteCounter = new AtomicInteger(0);
+        backupCounter = new AtomicInteger(0);
+        failCounter = new AtomicInteger(0);
+    }
+
+    public void archive() {
+        if (!archiveDBProperties.isEnabled()) {
+            archiveSummary.setSkip(true);
+            log.info("[{}] Archive is disabled, skip archive", getLogTypeStr());
+            return;
+        }
+        archiveSummary.setEnabled(true);
+        log.info("[{}] Start archive, keep days:{}", getLogTypeStr(), archiveDBProperties.getKeepDays());
+        List<String> targetCollectionNames = listArchiveCollectionName(archiveDBProperties.getKeepDays());
+        log.debug("[{}] archive, target collections:{}", getLogTypeStr(), targetCollectionNames);
+
+        long startTime = System.currentTimeMillis();
+        boolean success = true;
+        for (String collectionName : targetCollectionNames) {
+            if (!acquireLock(collectionName)) {
+                continue;
+            }
+            backupAndDelete(collectionName, isBackupEnable());
+        }
+
+        if (targetCollectionNames.size() > 0
+            && targetCollectionNames.size() == failCounter.get()) {
+            archiveErrorTaskCounter.increment();
+            success = false;
+        }
+
+        long archiveCost = System.currentTimeMillis() - startTime;
+        log.info("[{}] Archive finished, totalCollectionSize:{},deleteCollectionSize:{}, backupCollectionSize:{}," +
+            "cost: {}ms",
+            getLogTypeStr(),
+            targetCollectionNames.size(),
+            deleteCounter.get(),
+            backupCounter.get(),
+            archiveCost
+        );
+        setArchiveSummary(getLogTypeStr(),
+            archiveDBProperties.getMode(),
+            archiveCost,
+            deleteCounter.get(),
+            backupCounter.get(),
+            targetCollectionNames.size(),
+            success
+        );
+        storeArchiveSummary();
+
+        countDownLatch.countDown();
+    }
+
+    private void backupAndDelete(String collectionName, boolean backupEnabled) {
+        long startTime = System.currentTimeMillis();
+        boolean success = true;
+        try {
+            if (backupEnabled) {
+                backupRecords(collectionName);
+            }
+            deleteRecord(collectionName);
+        } catch (Exception e) {
+            success = false;
+            failCounter.incrementAndGet();
+            String msg = MessageFormatter.format(
+                "[{}] archive error, collectionName:{}",
+                getLogTypeStr(),
+                collectionName
+            ).getMessage();
+            log.error(msg, e);
+        } finally {
+            long archiveCost = System.currentTimeMillis() - startTime;
+            log.info(
+                "Archive {} finished, result: {}, cost: {}ms",
+                collectionName,
+                success ? "success" : "fail",
+                archiveCost
+            );
+            if (this.isAcquireLock) {
+                archiveTaskLock.unlock(collectionName);
+            }
+        }
+    }
+
+    protected void backupRecords(String collectionName) {
+        // 暂不支持备份
+    }
+
+    private void deleteRecord(String collectionName) {
+        mongoTemplate.dropCollection(collectionName);
+        deleteCounter.incrementAndGet();
+    }
+
+    /**
+     * 获取满足归档条件的集合名称
+     */
+    private List<String> listArchiveCollectionName(int keepDays) {
+        Set<String> allCollectionNames = mongoTemplate.getCollectionNames();
+        List<String> targetCollectionNames = filterCollectionNames(allCollectionNames, keepDays);
+        return targetCollectionNames;
+    }
+
+    /**
+     * 从所有集合名称中过滤出要归档的集合名称，返回集合名称列表，并按日期排序
+     */
+    private List<String> filterCollectionNames(Set<String> collectionNames, int keepDays) {
+        LocalDate endDate = LocalDate.now().minusDays(keepDays);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(COLLECTION_NAME_DATE_FORMATTER);
+        String endDateString = endDate.format(formatter);
+        log.info("[{}] archive,the deadline is {}", getLogTypeStr(), endDateString);
+        return collectionNames.stream()
+            .filter(collectionName -> {
+                if (collectionName.startsWith(getCollectionNamePrefix())) {
+                    String dateString = collectionName.substring(getCollectionNamePrefix().length());
+                    LocalDate collectionDate = LocalDate.parse(dateString, formatter);
+                    return collectionDate.isBefore(endDate);
+                }
+                return false;
+            })
+            .sorted((collectionName1, collectionName2) -> {
+                LocalDate date1 = extractDateFromCollectionName(collectionName1);
+                LocalDate date2 = extractDateFromCollectionName(collectionName2);
+                return date1.compareTo(date2);
+            })
+            .collect(Collectors.toList());
+    }
+
+    private String getCollectionNamePrefix() {
+        Integer type = mongoDBLogTypeEnum.getValue();
+        String prefix = "";
+        if (MongoDBLogTypeEnum.SCRIPT.getValue().equals(type)) {
+            prefix = SCRIPT_LOG_PREFIX + COLLECTION_NAME_SEPARATOR;
+        } else if (MongoDBLogTypeEnum.FILE.getValue().equals(type)) {
+            prefix = FILE_LOG_PREFIX + COLLECTION_NAME_SEPARATOR;
+        }
+        return prefix;
+    }
+
+    private LocalDate extractDateFromCollectionName(String collectionName) {
+        String dateString = collectionName.substring(getCollectionNamePrefix().length());
+        return LocalDate.parse(dateString, DateTimeFormatter.ofPattern(COLLECTION_NAME_DATE_FORMATTER));
+    }
+
+    private String getLogTypeStr() {
+        Integer type = mongoDBLogTypeEnum.getValue();
+        String str = "script_log";
+        if (MongoDBLogTypeEnum.FILE.getValue().equals(type)) {
+            str = "file_log";
+        }
+        return str;
+    }
+
+    private boolean acquireLock(String collectionName) {
+        this.isAcquireLock = archiveTaskLock.lock(collectionName);
+        if (!isAcquireLock) {
+            log.info("[{}] Acquire lock fail", collectionName);
+        }
+        return isAcquireLock;
+    }
+
+    private boolean isBackupEnable() {
+        return archiveDBProperties.isEnabled()
+            && ArchiveModeEnum.BACKUP_THEN_DELETE == ArchiveModeEnum.valOf(archiveDBProperties.getMode());
+    }
+
+    private void setArchiveSummary(String tableName,
+                                   String archiveMode,
+                                   long archiveCost,
+                                   long deleteCollectionSize,
+                                   long backupCollectionSize,
+                                   long totalCollectionSize,
+                                   boolean success) {
+        archiveSummary.setArchiveCost(archiveCost);
+        archiveSummary.setArchiveMode(archiveMode);
+        archiveSummary.setSuccess(success);
+        archiveSummary.setTableName(tableName);
+        archiveSummary.setDeleteCollectionSize(deleteCollectionSize);
+        archiveSummary.setBackupCollectionSize(backupCollectionSize);
+        archiveSummary.setTotalCollectionSize(totalCollectionSize);
+    }
+
+    private void storeArchiveSummary() {
+        ArchiveSummaryHolder.getInstance().addArchiveSummary(this.archiveSummary);
+    }
+
+}

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/MongoDBFileLogArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/MongoDBFileLogArchivist.java
@@ -22,40 +22,33 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.backup.model.dto;
+package com.tencent.bk.job.backup.archive.impl;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import com.tencent.bk.job.backup.archive.AbstractMongoDBArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
+import com.tencent.bk.job.backup.config.ArchiveDBProperties;
+import com.tencent.bk.job.backup.constant.MongoDBLogTypeEnum;
+import com.tencent.bk.job.backup.metrics.ArchiveErrorTaskCounter;
+import org.springframework.data.mongodb.core.MongoTemplate;
 
-@Data
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
-@NoArgsConstructor
-public class ArchiveSummary {
-    private boolean enabled;
-    private String tableName;
-    private String archiveEndDate;
-    private boolean skip;
-    private boolean success;
+import java.util.concurrent.CountDownLatch;
 
-    private String archiveMode;
-    private Long archiveCost;
+/**
+ * mongodb 文件日志归档
+ */
+public class MongoDBFileLogArchivist extends AbstractMongoDBArchivist {
 
-    private Long archiveIdStart;
-    private Long archiveIdEnd;
-    private Long needArchiveRecordSize;
-
-    private Long lastBackupId;
-    private Long backupRecordSize;
-
-    private Long lastDeletedId;
-    private Long deleteRecordSize;
-
-    private Long deleteCollectionSize;
-    private Long backupCollectionSize;
-    private Long totalCollectionSize;
-
-    public ArchiveSummary(String tableName) {
-        this.tableName = tableName;
+    public MongoDBFileLogArchivist(MongoTemplate mongoTemplate,
+                                   ArchiveDBProperties archiveDBProperties,
+                                   ArchiveTaskLock archiveTaskLock,
+                                   CountDownLatch countDownLatch,
+                                   ArchiveErrorTaskCounter archiveErrorTaskCounter,
+                                   MongoDBLogTypeEnum mongoDBLogTypeEnum) {
+        super(mongoTemplate,
+            archiveDBProperties,
+            archiveTaskLock,
+            countDownLatch,
+            archiveErrorTaskCounter,
+            mongoDBLogTypeEnum);
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/MongoDBScriptLogArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/impl/MongoDBScriptLogArchivist.java
@@ -22,40 +22,33 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.backup.model.dto;
+package com.tencent.bk.job.backup.archive.impl;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import com.tencent.bk.job.backup.archive.AbstractMongoDBArchivist;
+import com.tencent.bk.job.backup.archive.ArchiveTaskLock;
+import com.tencent.bk.job.backup.config.ArchiveDBProperties;
+import com.tencent.bk.job.backup.constant.MongoDBLogTypeEnum;
+import com.tencent.bk.job.backup.metrics.ArchiveErrorTaskCounter;
+import org.springframework.data.mongodb.core.MongoTemplate;
 
-@Data
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
-@NoArgsConstructor
-public class ArchiveSummary {
-    private boolean enabled;
-    private String tableName;
-    private String archiveEndDate;
-    private boolean skip;
-    private boolean success;
+import java.util.concurrent.CountDownLatch;
 
-    private String archiveMode;
-    private Long archiveCost;
+/**
+ * mongodb 脚本日志归档
+ */
+public class MongoDBScriptLogArchivist extends AbstractMongoDBArchivist {
 
-    private Long archiveIdStart;
-    private Long archiveIdEnd;
-    private Long needArchiveRecordSize;
-
-    private Long lastBackupId;
-    private Long backupRecordSize;
-
-    private Long lastDeletedId;
-    private Long deleteRecordSize;
-
-    private Long deleteCollectionSize;
-    private Long backupCollectionSize;
-    private Long totalCollectionSize;
-
-    public ArchiveSummary(String tableName) {
-        this.tableName = tableName;
+    public MongoDBScriptLogArchivist(MongoTemplate mongoTemplate,
+                                     ArchiveDBProperties archiveDBProperties,
+                                     ArchiveTaskLock archiveTaskLock,
+                                     CountDownLatch countDownLatch,
+                                     ArchiveErrorTaskCounter archiveErrorTaskCounter,
+                                     MongoDBLogTypeEnum mongoDBLogTypeEnum) {
+        super(mongoTemplate,
+            archiveDBProperties,
+            archiveTaskLock,
+            countDownLatch,
+            archiveErrorTaskCounter,
+            mongoDBLogTypeEnum);
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfiguration.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfiguration.java
@@ -57,6 +57,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
@@ -69,7 +70,7 @@ import java.util.concurrent.ExecutorService;
 @EnableScheduling
 @Slf4j
 @EnableConfigurationProperties(ArchiveDBProperties.class)
-@Import({ExecuteDbConfiguration.class, ExecuteBackupDbConfiguration.class})
+@Import({ExecuteDbConfiguration.class, ExecuteBackupDbConfiguration.class, ExecuteMongoDBConfiguration.class})
 public class ArchiveConfiguration {
 
     /**
@@ -244,7 +245,8 @@ public class ArchiveConfiguration {
         @Qualifier("archiveExecutor") ExecutorService archiveExecutor,
         ArchiveDBProperties archiveDBProperties,
         ArchiveTaskLock archiveTaskLock,
-        ArchiveErrorTaskCounter archiveErrorTaskCounter) {
+        ArchiveErrorTaskCounter archiveErrorTaskCounter,
+        MongoTemplate mongoTemplate) {
 
         log.info("Init JobExecuteArchiveManage");
         return new JobExecuteArchiveManage(
@@ -270,6 +272,7 @@ public class ArchiveConfiguration {
             archiveDBProperties,
             archiveExecutor,
             archiveTaskLock,
-            archiveErrorTaskCounter);
+            archiveErrorTaskCounter,
+            mongoTemplate);
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ExecuteMongoDBConfiguration.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ExecuteMongoDBConfiguration.java
@@ -1,0 +1,74 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.backup.config;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.tencent.bk.job.common.service.constants.DeployModeEnum;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+@Configuration("executeMongoDBConfiguration")
+@Conditional(ExecuteMongoDBConfiguration.ExecuteMongoDBInitCondition.class)
+public class ExecuteMongoDBConfiguration {
+
+    @Value("${spring.datasource.job-execute-mongodb.uri:}")
+    private String mongoUri;
+
+    @Value("${spring.datasource.job-execute-mongodb.database:joblog}")
+    private String database;
+
+    @Bean
+    public MongoClient mongoClient() {
+        return MongoClients.create(mongoUri);
+    }
+
+    @Bean
+    public MongoTemplate mongoTemplate(MongoClient mongoClient) {
+        return new MongoTemplate(mongoClient, database);
+    }
+
+    static class ExecuteMongoDBInitCondition extends AllNestedConditions {
+        public ExecuteMongoDBInitCondition() {
+            super(ConfigurationPhase.PARSE_CONFIGURATION);
+        }
+
+        @ConditionalOnProperty(value = "job.backup.archive.execute.enabled", havingValue = "true")
+        class ArchiveEnableCondition {
+
+        }
+
+        @ConditionalOnProperty(value = "deploy.mode", havingValue = DeployModeEnum.Constants.STANDARD,
+            matchIfMissing = true)
+        class StandardDeployModeCondition {
+
+        }
+    }
+}

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/constant/MongoDBLogTypeEnum.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/constant/MongoDBLogTypeEnum.java
@@ -22,40 +22,38 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.backup.model.dto;
+package com.tencent.bk.job.backup.constant;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+public enum MongoDBLogTypeEnum {
 
-@Data
-@JsonInclude(JsonInclude.Include.NON_EMPTY)
-@NoArgsConstructor
-public class ArchiveSummary {
-    private boolean enabled;
-    private String tableName;
-    private String archiveEndDate;
-    private boolean skip;
-    private boolean success;
+    /**
+     * 脚本执行任务日志
+     */
+    SCRIPT(1),
+    /**
+     * 文件分发任务日志
+     */
+    FILE(2);
 
-    private String archiveMode;
-    private Long archiveCost;
+    private final Integer value;
 
-    private Long archiveIdStart;
-    private Long archiveIdEnd;
-    private Long needArchiveRecordSize;
+    MongoDBLogTypeEnum(Integer val) {
+        this.value = val;
+    }
 
-    private Long lastBackupId;
-    private Long backupRecordSize;
+    public static MongoDBLogTypeEnum getLogType(Integer logType) {
+        if (logType == null) {
+            throw new IllegalArgumentException("Empty logType value!");
+        }
+        for (MongoDBLogTypeEnum logTypeEnum : values()) {
+            if (logTypeEnum.getValue().equals(logType)) {
+                return logTypeEnum;
+            }
+        }
+        throw new IllegalArgumentException("Illegal logType: " + logType);
+    }
 
-    private Long lastDeletedId;
-    private Long deleteRecordSize;
-
-    private Long deleteCollectionSize;
-    private Long backupCollectionSize;
-    private Long totalCollectionSize;
-
-    public ArchiveSummary(String tableName) {
-        this.tableName = tableName;
+    public Integer getValue() {
+        return value;
     }
 }

--- a/support-files/kubernetes/charts/bk-job/templates/job-backup/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-backup/configmap.yaml
@@ -63,7 +63,11 @@ data:
           idle-timeout: 6000
           poolName: "job-execute"
           validationTimeout: 5000
-        {{- end }}  
+        {{- end }}
+        {{- if and .Values.backupConfig.archive.execute.enabled }}
+        job-execute-mongodb:
+          uri: {{ include "job.mongodb.connect.uri" . | quote }}
+        {{- end }}
         {{- if and .Values.backupConfig.archive.execute.enabled (eq .Values.backupConfig.archive.execute.mode "backupThenDelete") }}
         job-execute-archive:
           driver-class-name: {{ include "job.jdbcMysqlDriverClass" . }}

--- a/support-files/templates/#etc#job#job-backup#job-backup.yml
+++ b/support-files/templates/#etc#job#job-backup#job-backup.yml
@@ -38,6 +38,9 @@ spring:
       idle-timeout: 6000
       poolName: "job-execute"
       validationTimeout: 5000
+    # 执行日志mongodb数据源
+    job-execute-mongodb:
+      uri: __BK_JOB_LOGSVR_MONGODB_URI__
     # 执行数据归档DB配置，若需开启数据归档请去除注释并添加相应环境变量进行配置
     #job-execute-archive:
       #driver-class-name: io.opentelemetry.instrumentation.jdbc.OpenTelemetryDriver


### PR DESCRIPTION
执行日志按yyyy_MM_dd为集合名称，存在mongodb中，清理时，按集合名称删除集合，以快速删除集合数据；
沿用mysql归档中的表留天数（keep_days）、主任务；
清理：如keep_days=0，会清理当天之前的所有脚本执行、文件分发日志数据，keep_days=1，会清理昨天之前的所有脚本执行、文件分发日志数据。