### PR TITLE
fix: 3.9.x 版本执行历史归档读取数据重复，导致归档数据写入冲突 #2962

### DIFF
--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/GseFileExecuteObjTaskRecordDAO.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/GseFileExecuteObjTaskRecordDAO.java
@@ -3,8 +3,13 @@ package com.tencent.bk.job.backup.dao.impl;
 import com.tencent.bk.job.execute.model.tables.GseFileExecuteObjTask;
 import com.tencent.bk.job.execute.model.tables.records.GseFileExecuteObjTaskRecord;
 import org.jooq.DSLContext;
+import org.jooq.OrderField;
 import org.jooq.Table;
 import org.jooq.TableField;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * gse_file_execute_obj_task DAO
@@ -12,6 +17,15 @@ import org.jooq.TableField;
 public class GseFileExecuteObjTaskRecordDAO extends AbstractExecuteRecordDAO<GseFileExecuteObjTaskRecord> {
 
     private static final GseFileExecuteObjTask TABLE = GseFileExecuteObjTask.GSE_FILE_EXECUTE_OBJ_TASK;
+    private static final List<OrderField<?>> ORDER_FIELDS = new ArrayList<>();
+
+    static {
+        ORDER_FIELDS.add(GseFileExecuteObjTask.GSE_FILE_EXECUTE_OBJ_TASK.STEP_INSTANCE_ID.asc());
+        ORDER_FIELDS.add(GseFileExecuteObjTask.GSE_FILE_EXECUTE_OBJ_TASK.EXECUTE_COUNT.asc());
+        ORDER_FIELDS.add(GseFileExecuteObjTask.GSE_FILE_EXECUTE_OBJ_TASK.BATCH.asc());
+        ORDER_FIELDS.add(GseFileExecuteObjTask.GSE_FILE_EXECUTE_OBJ_TASK.MODE.asc());
+        ORDER_FIELDS.add(GseFileExecuteObjTask.GSE_FILE_EXECUTE_OBJ_TASK.EXECUTE_OBJ_ID.asc());
+    }
 
     public GseFileExecuteObjTaskRecordDAO(DSLContext context) {
         super(context);
@@ -25,5 +39,10 @@ public class GseFileExecuteObjTaskRecordDAO extends AbstractExecuteRecordDAO<Gse
     @Override
     public TableField<GseFileExecuteObjTaskRecord, Long> getArchiveIdField() {
         return TABLE.TASK_INSTANCE_ID;
+    }
+
+    @Override
+    protected Collection<? extends OrderField<?>> getListRecordsOrderFields() {
+        return ORDER_FIELDS;
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/GseScriptExecuteObjTaskRecordDAO.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/GseScriptExecuteObjTaskRecordDAO.java
@@ -3,8 +3,13 @@ package com.tencent.bk.job.backup.dao.impl;
 import com.tencent.bk.job.execute.model.tables.GseScriptExecuteObjTask;
 import com.tencent.bk.job.execute.model.tables.records.GseScriptExecuteObjTaskRecord;
 import org.jooq.DSLContext;
+import org.jooq.OrderField;
 import org.jooq.Table;
 import org.jooq.TableField;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * gse_script_execute_obj_task DAO
@@ -12,6 +17,14 @@ import org.jooq.TableField;
 public class GseScriptExecuteObjTaskRecordDAO extends AbstractExecuteRecordDAO<GseScriptExecuteObjTaskRecord> {
 
     private static final GseScriptExecuteObjTask TABLE = GseScriptExecuteObjTask.GSE_SCRIPT_EXECUTE_OBJ_TASK;
+    private static final List<OrderField<?>> ORDER_FIELDS = new ArrayList<>();
+
+    static {
+        ORDER_FIELDS.add(GseScriptExecuteObjTask.GSE_SCRIPT_EXECUTE_OBJ_TASK.STEP_INSTANCE_ID.asc());
+        ORDER_FIELDS.add(GseScriptExecuteObjTask.GSE_SCRIPT_EXECUTE_OBJ_TASK.EXECUTE_COUNT.asc());
+        ORDER_FIELDS.add(GseScriptExecuteObjTask.GSE_SCRIPT_EXECUTE_OBJ_TASK.BATCH.asc());
+        ORDER_FIELDS.add(GseScriptExecuteObjTask.GSE_SCRIPT_EXECUTE_OBJ_TASK.EXECUTE_OBJ_ID.asc());
+    }
 
     public GseScriptExecuteObjTaskRecordDAO(DSLContext context) {
         super(context);
@@ -25,5 +38,10 @@ public class GseScriptExecuteObjTaskRecordDAO extends AbstractExecuteRecordDAO<G
     @Override
     public TableField<GseScriptExecuteObjTaskRecord, Long> getArchiveIdField() {
         return TABLE.TASK_INSTANCE_ID;
+    }
+
+    @Override
+    protected Collection<? extends OrderField<?>> getListRecordsOrderFields() {
+        return ORDER_FIELDS;
     }
 }


### PR DESCRIPTION
3.8.x 已处理，见 #2953 。这里对新增的两张表应用同样的方案