### PR TITLE
perf: 本地临时文件清理机制优化 #2951

### DIFF
--- a/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
+++ b/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
@@ -433,12 +433,12 @@ public class ArtifactoryClient {
         return resp.getData();
     }
 
-    public Boolean deleteProject(String projectId) {
+    public boolean deleteProject(String projectId) {
         log.info("deleteProject:{}", projectId);
         throw new NotImplementedException("Not support feature", ErrorCode.NOT_SUPPORT_FEATURE);
     }
 
-    public Boolean deleteRepo(String projectId, String repoName, Boolean forced) {
+    public boolean deleteRepo(String projectId, String repoName, Boolean forced) {
         DeleteRepoReq req = new DeleteRepoReq();
         req.setProjectId(projectId);
         req.setRepoName(repoName);
@@ -449,7 +449,7 @@ public class ArtifactoryClient {
         return resp.getCode() == 0;
     }
 
-    public Boolean deleteNode(String projectId, String repoName, String fullPath) {
+    public boolean deleteNode(String projectId, String repoName, String fullPath) {
         DeleteNodeReq req = new DeleteNodeReq();
         req.setProjectId(projectId);
         req.setRepoName(repoName);

--- a/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/date/DateUtils.java
+++ b/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/date/DateUtils.java
@@ -24,6 +24,7 @@
 
 package com.tencent.bk.job.common.util.date;
 
+import com.tencent.bk.job.common.util.json.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.helpers.MessageFormatter;
@@ -41,8 +42,13 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * 时间处理
@@ -213,6 +219,45 @@ public class DateUtils {
     public static LocalDateTime convertFromMillSeconds(long millSeconds) {
         return LocalDateTime.ofEpochSecond(millSeconds / 1000, (int) (millSeconds % 1000) * 1_000_000,
             ZoneOffset.systemDefault().getRules().getOffset(Instant.now()));
+    }
+
+    /**
+     * 尝试使用多种格式来解析字符串中的时间，只要有任意一种格式匹配即可成功解析
+     *
+     * @param dateTime 日期时间字符串
+     * @param patterns 多个可能的日期时间格式
+     * @return 本地日期时间对象
+     */
+    public static LocalDateTime convertFromStringDateByPatterns(String dateTime, String... patterns) {
+        if (patterns.length == 0) {
+            throw new IllegalArgumentException("patterns must not be empty");
+        }
+        LocalDateTime localDateTime = null;
+        Map<String, Exception> exceptionMap = new HashMap<>();
+        for (String pattern : patterns) {
+            try {
+                localDateTime = convertFromStringDate(dateTime, pattern);
+            } catch (Exception e) {
+                exceptionMap.put(pattern, e);
+            }
+        }
+        if (localDateTime == null) {
+            String patternsInvalidMsg = MessageFormatter.format(
+                "Fail to convertFromStringDateByPatterns: dateTime={}, patterns={}, exceptions: ",
+                dateTime,
+                patterns
+            ).getMessage();
+            log.warn(patternsInvalidMsg);
+            exceptionMap.forEach((pattern, e) -> {
+                String patternInvalidMsg = MessageFormatter.format(
+                    "pattern: {}, exception: ",
+                    pattern
+                ).getMessage();
+                log.warn(patternInvalidMsg, e);
+            });
+            throw new IllegalArgumentException(patternsInvalidMsg);
+        }
+        return localDateTime;
     }
 
     public static LocalDateTime convertFromStringDate(String dateTime, String pattern) {

--- a/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/date/DateUtils.java
+++ b/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/date/DateUtils.java
@@ -232,32 +232,32 @@ public class DateUtils {
         if (patterns.length == 0) {
             throw new IllegalArgumentException("patterns must not be empty");
         }
-        LocalDateTime localDateTime = null;
+        LocalDateTime localDateTime;
         Map<String, Exception> exceptionMap = new HashMap<>();
         for (String pattern : patterns) {
             try {
                 localDateTime = convertFromStringDate(dateTime, pattern);
+                if (localDateTime != null) {
+                    return localDateTime;
+                }
             } catch (Exception e) {
                 exceptionMap.put(pattern, e);
             }
         }
-        if (localDateTime == null) {
-            String patternsInvalidMsg = MessageFormatter.format(
-                "Fail to convertFromStringDateByPatterns: dateTime={}, patterns={}, exceptions: ",
-                dateTime,
-                patterns
+        String patternsInvalidMsg = MessageFormatter.format(
+            "Fail to convertFromStringDateByPatterns: dateTime={}, patterns={}, exceptions: ",
+            dateTime,
+            patterns
+        ).getMessage();
+        log.warn(patternsInvalidMsg);
+        exceptionMap.forEach((pattern, e) -> {
+            String patternInvalidMsg = MessageFormatter.format(
+                "pattern: {}, exception: ",
+                pattern
             ).getMessage();
-            log.warn(patternsInvalidMsg);
-            exceptionMap.forEach((pattern, e) -> {
-                String patternInvalidMsg = MessageFormatter.format(
-                    "pattern: {}, exception: ",
-                    pattern
-                ).getMessage();
-                log.warn(patternInvalidMsg, e);
-            });
-            throw new IllegalArgumentException(patternsInvalidMsg);
-        }
-        return localDateTime;
+            log.warn(patternInvalidMsg, e);
+        });
+        throw new IllegalArgumentException(patternsInvalidMsg);
     }
 
     public static LocalDateTime convertFromStringDate(String dateTime, String pattern) {

--- a/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/file/FileUtil.java
+++ b/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/file/FileUtil.java
@@ -313,11 +313,12 @@ public class FileUtil {
      * 删除空目录
      *
      * @param directory 目录文件
+     * @return 是否删除了目录
      */
-    public static void deleteEmptyDirectory(File directory) {
+    public static boolean deleteEmptyDirectory(File directory) {
         if (directory == null) {
             log.warn("Directory is null!");
-            return;
+            return false;
         }
 
         if (isEmpty(directory.toPath())) {
@@ -327,8 +328,10 @@ public class FileUtil {
             } else {
                 log.warn("Delete directory {} failed!", directory.getPath());
             }
+            return delete;
         } else {
             log.debug("Directory {} not empty!", directory.getPath());
+            return false;
         }
     }
 

--- a/src/backend/commons/common-utils/src/test/java/com/tencent/bk/job/common/util/date/DateUtilsTest.java
+++ b/src/backend/commons/common-utils/src/test/java/com/tencent/bk/job/common/util/date/DateUtilsTest.java
@@ -31,6 +31,7 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class DateUtilsTest {
 
@@ -73,5 +74,42 @@ public class DateUtilsTest {
         long endTime4 = DateUtils.getUTCDayEndTimestamp(dateTime4.toLocalDate());
         // 2023-07-14 00:00:00 UTC
         assertThat(endTime4).isEqualTo(1689292800000L);
+    }
+
+    @Test
+    void convertFromStringDateByPatterns() {
+        String[] patterns = new String[]{
+            "yyyy-MM-dd'T'HH:mm:ss.SSS",
+            "yyyy-MM-dd'T'HH:mm:ss.SS",
+            "yyyy-MM-dd'T'HH:mm:ss.S",
+            "yyyy-MM-dd'T'HH:mm:ss.",
+            "yyyy-MM-dd'T'HH:mm:ss"
+        };
+        LocalDateTime localDateTime = DateUtils.convertFromStringDateByPatterns(
+            "2022-04-21T10:55:54.655", patterns
+        );
+        assertThat(localDateTime).isNotNull();
+        localDateTime = DateUtils.convertFromStringDateByPatterns(
+            "2022-04-21T10:55:54.65", patterns
+        );
+        assertThat(localDateTime).isNotNull();
+        localDateTime = DateUtils.convertFromStringDateByPatterns(
+            "2022-04-21T10:55:54.6", patterns
+        );
+        assertThat(localDateTime).isNotNull();
+        localDateTime = DateUtils.convertFromStringDateByPatterns(
+            "2022-04-21T10:55:54.", patterns
+        );
+        assertThat(localDateTime).isNotNull();
+        localDateTime = DateUtils.convertFromStringDateByPatterns(
+            "2022-04-21T10:55:54", patterns
+        );
+        assertThat(localDateTime).isNotNull();
+        assertThatThrownBy(() -> DateUtils.convertFromStringDateByPatterns(
+            "2022-04-21T10:55:54.65"
+        )).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> DateUtils.convertFromStringDateByPatterns(
+            "2022-04-21 10:55:54.65"
+        )).isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/local/LocalFileDownloadTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/local/LocalFileDownloadTask.java
@@ -105,6 +105,12 @@ public class LocalFileDownloadTask implements Callable<Boolean> {
         localPath = PathUtil.joinFilePath(localPath, filePath);
         // 如果本地文件还未下载就已存在并且Md5正确，直接完成准备阶段
         if (currentLocalFileValid(localPath, nodeDTO)) {
+            // 将最后修改时间设置为当前时间，避免在分发过程中被清理
+            File localFile = new File(localPath);
+            boolean lastModifyTimeSet = localFile.setLastModified(System.currentTimeMillis());
+            if (!lastModifyTimeSet) {
+                log.warn("Fail to set lastModifyTime for {}", localPath);
+            }
             return true;
         }
         Pair<InputStream, HttpRequestBase> pair = artifactoryClient.getFileInputStream(

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/config/LocalFileConfigForManage.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/config/LocalFileConfigForManage.java
@@ -38,6 +38,9 @@ public class LocalFileConfigForManage {
     @Value("${local-file.artifactory.repo:localupload}")
     private String localUploadRepo;
 
+    @Value("${local-file.expire-delete:true}")
+    private boolean expireDelete = true;
+
     @Value("${local-file.expire-days:7}")
     private Integer expireDays;
 

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/task/UserUploadFileCleanTask.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/task/UserUploadFileCleanTask.java
@@ -153,12 +153,16 @@ public class UserUploadFileCleanTask {
                     continue;
                 }
                 // 从制品库删除有效日期前创建的节点
-                LocalDateTime endNodeLastDate = DateUtils.convertFromStringDate(
-                    endNode.getLastModifiedDate(), "yyyy-MM-dd'T'HH:mm:ss.SSS"
+                LocalDateTime endNodeLastDate = DateUtils.convertFromStringDateByPatterns(
+                    endNode.getLastModifiedDate(),
+                    "yyyy-MM-dd'T'HH:mm:ss.SSS",
+                    "yyyy-MM-dd'T'HH:mm:ss.SS",
+                    "yyyy-MM-dd'T'HH:mm:ss.S",
+                    "yyyy-MM-dd'T'HH:mm:ss.",
+                    "yyyy-MM-dd'T'HH:mm:ss"
                 );
                 if (endNodeLastDate
-                    .plusDays(localFileConfigForManage.getExpireDays())
-                    .compareTo(LocalDateTime.now()) < 0) {
+                    .plusDays(localFileConfigForManage.getExpireDays()).isBefore(LocalDateTime.now())) {
                     artifactoryClient.deleteNode(
                         artifactoryConfig.getArtifactoryJobProject(),
                         localFileConfigForManage.getLocalUploadRepo(),

--- a/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
@@ -147,6 +147,8 @@ data:
         download:
           concurrency: {{ .Values.localFile.artifactory.download.concurrency }}
         repo: {{ .Values.localFile.artifactory.repo }}
+      expire-delete: {{ .Values.localFile.artifactory.repo }}
+      expire-days: {{ .Values.localFile.expireDays }}
     swagger:
       url: {{ .Values.swagger.url }}
     management:

--- a/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
@@ -147,7 +147,7 @@ data:
         download:
           concurrency: {{ .Values.localFile.artifactory.download.concurrency }}
         repo: {{ .Values.localFile.artifactory.repo }}
-      expire-delete: {{ .Values.localFile.artifactory.repo }}
+      expire-delete: {{ .Values.localFile.expireDelete }}
       expire-days: {{ .Values.localFile.expireDays }}
     swagger:
       url: {{ .Values.swagger.url }}

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -552,6 +552,10 @@ localFile:
       concurrency: 10
     # 制品库中作业平台使用的本地文件仓库代码，初始化时由作业平台通过Admin账号自动创建
     repo: localupload
+  # 本地文件过期后是否删除
+  expireDelete: true
+  # 本地文件过期时间（天）
+  expireDays: 7
 
 ## Swagger配置
 swagger:


### PR DESCRIPTION
1. Issue #2771在master分支已解决过本地文件所在目录未清理的问题，cherry-pick过来，内容如下：
（1）分发时更新临时文件最后修改时间避免被清理便于复用；
（2）优化清理策略：将分发过程产生的无用上级目录一并清理，避免inode耗尽。
2. 支持对制品库多种日期时间格式的解析；
3. 优化制品库中本地文件清理逻辑，支持目录清理与子目录递归检测清理；
4. 优化带心跳Redis锁的异常打印；
5. 支持配置本地文件过期时间与是否删除。