### PR TITLE
fix: 第三方源文件下载过程中查看上传日志报错 #2980

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/third/FileWorkerHostService.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/third/FileWorkerHostService.java
@@ -56,7 +56,6 @@ public class FileWorkerHostService {
         this.hostService = hostService;
     }
 
-
     // 查询file-worker对应主机信息使用60s缓存，避免短时间内多次重复查询
     private final LoadingCache<Triple<Long, String, String>, HostDTO> fileWorkerHostCache = CacheBuilder.newBuilder()
         .maximumSize(1).expireAfterWrite(60, TimeUnit.SECONDS).
@@ -93,7 +92,9 @@ public class FileWorkerHostService {
         } else {
             hostDTO = ServiceHostDTO.toHostDTO(hostService.getHost(new HostDTO(cloudAreaId, ip)));
         }
-        log.debug("host get by ({},{},{}) is {}", ipProtocol, cloudAreaId, ip, hostDTO);
+        if (log.isDebugEnabled()) {
+            log.debug("host get by ({},{},{}) is {}", ipProtocol, cloudAreaId, ip, hostDTO);
+        }
         return hostDTO;
     }
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/third/FileWorkerHostService.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/third/FileWorkerHostService.java
@@ -1,0 +1,99 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.execute.engine.prepare.third;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.tencent.bk.job.common.model.dto.HostDTO;
+import com.tencent.bk.job.common.util.ip.IpUtils;
+import com.tencent.bk.job.execute.service.HostService;
+import com.tencent.bk.job.manage.model.inner.ServiceHostDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Triple;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 第三方源文件File-Worker的主机解析服务
+ */
+@Slf4j
+@Primary
+@Component
+public class FileWorkerHostService {
+
+    private final HostService hostService;
+
+    @Autowired
+    public FileWorkerHostService(HostService hostService) {
+        this.hostService = hostService;
+    }
+
+
+    // 查询file-worker对应主机信息使用60s缓存，避免短时间内多次重复查询
+    private final LoadingCache<Triple<Long, String, String>, HostDTO> fileWorkerHostCache = CacheBuilder.newBuilder()
+        .maximumSize(1).expireAfterWrite(60, TimeUnit.SECONDS).
+        build(new CacheLoader<Triple<Long, String, String>, HostDTO>() {
+                  @SuppressWarnings("all")
+                  @Override
+                  public HostDTO load(Triple<Long, String, String> triple) {
+                      return parseFileWorkerHost(triple.getLeft(), triple.getMiddle(), triple.getRight());
+                  }
+              }
+        );
+
+    public HostDTO parseFileWorkerHostWithCache(Long cloudAreaId, String ipProtocol, String ip) {
+        try {
+            return fileWorkerHostCache.get(buildCacheKey(cloudAreaId, ipProtocol, ip));
+        } catch (ExecutionException e) {
+            log.error("Fail to parseFileWorkerHostWithCache", e);
+            return null;
+        }
+    }
+
+    private Triple<Long, String, String> buildCacheKey(Long cloudAreaId, String ipProtocol, String ip) {
+        return Triple.of(cloudAreaId, ipProtocol, ip);
+    }
+
+    private HostDTO parseFileWorkerHost(Long cloudAreaId, String ipProtocol, String ip) {
+        if (StringUtils.isBlank(ipProtocol)) {
+            ipProtocol = IpUtils.inferProtocolByIp(ip);
+            log.info("ipProtocol is null or blank, use {} inferred by ip {}", ipProtocol, ip);
+        }
+        HostDTO hostDTO;
+        if (IpUtils.PROTOCOL_IP_V6.equalsIgnoreCase(ipProtocol)) {
+            hostDTO = ServiceHostDTO.toHostDTO(hostService.getHostByCloudIpv6(cloudAreaId, ip));
+        } else {
+            hostDTO = ServiceHostDTO.toHostDTO(hostService.getHost(new HostDTO(cloudAreaId, ip)));
+        }
+        log.debug("host get by ({},{},{}) is {}", ipProtocol, cloudAreaId, ip, hostDTO);
+        return hostDTO;
+    }
+}

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/third/ThirdFilePrepareService.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/third/ThirdFilePrepareService.java
@@ -40,7 +40,6 @@ import com.tencent.bk.job.execute.model.FileSourceTaskLogDTO;
 import com.tencent.bk.job.execute.model.StepInstanceBaseDTO;
 import com.tencent.bk.job.execute.model.StepInstanceDTO;
 import com.tencent.bk.job.execute.service.AccountService;
-import com.tencent.bk.job.execute.service.HostService;
 import com.tencent.bk.job.execute.service.LogService;
 import com.tencent.bk.job.execute.service.StepInstanceService;
 import com.tencent.bk.job.file_gateway.api.inner.ServiceFileSourceTaskResource;
@@ -76,7 +75,7 @@ public class ThirdFilePrepareService {
     private final StepInstanceService stepInstanceService;
     private final FileSourceTaskLogDAO fileSourceTaskLogDAO;
     private final AccountService accountService;
-    private final HostService hostService;
+    private final FileWorkerHostService fileWorkerHostService;
     private final LogService logService;
     private final TaskExecuteMQEventDispatcher taskExecuteMQEventDispatcher;
     // 记录第三方文件准备任务信息，用于在需要时查找并终止任务
@@ -88,7 +87,7 @@ public class ThirdFilePrepareService {
                                    StepInstanceService stepInstanceService,
                                    FileSourceTaskLogDAO fileSourceTaskLogDAO,
                                    AccountService accountService,
-                                   HostService hostService,
+                                   FileWorkerHostService fileWorkerHostService,
                                    LogService logService,
                                    TaskExecuteMQEventDispatcher taskExecuteMQEventDispatcher) {
         this.resultHandleManager = resultHandleManager;
@@ -96,7 +95,7 @@ public class ThirdFilePrepareService {
         this.stepInstanceService = stepInstanceService;
         this.fileSourceTaskLogDAO = fileSourceTaskLogDAO;
         this.accountService = accountService;
-        this.hostService = hostService;
+        this.fileWorkerHostService = fileWorkerHostService;
         this.logService = logService;
         this.taskExecuteMQEventDispatcher = taskExecuteMQEventDispatcher;
     }
@@ -115,7 +114,12 @@ public class ThirdFilePrepareService {
             fileSourceDTO.setServers(new ExecuteTargetDTO());
         }
         List<HostDTO> hostDTOList = new ArrayList<>();
-        hostDTOList.add(new HostDTO(taskInfoDTO.getCloudId(), taskInfoDTO.getIp()));
+        HostDTO hostDTO = fileWorkerHostService.parseFileWorkerHostWithCache(
+            taskInfoDTO.getCloudId(),
+            taskInfoDTO.getIpProtocol(),
+            taskInfoDTO.getIp()
+        );
+        hostDTOList.add(hostDTO);
         fileSourceDTO.getServers().setStaticIpList(hostDTOList);
         fileSourceDTO.getServers().buildMergedExecuteObjects(stepInstance.isSupportExecuteObjectFeature());
         fileSourceDTO.setFileSourceTaskId(fileSourceTaskId);
@@ -360,7 +364,7 @@ public class ThirdFilePrepareService {
                 new RecordableThirdFilePrepareTaskResultHandler(stepInstance, resultHandler));
         batchResultHandleTask.initDependentService(
             fileSourceTaskResource, stepInstanceService, accountService,
-            hostService, logService, taskExecuteMQEventDispatcher, fileSourceTaskLogDAO
+            fileWorkerHostService, logService, taskExecuteMQEventDispatcher, fileSourceTaskLogDAO
         );
         resultHandleManager.handleDeliveredTask(batchResultHandleTask);
         return batchResultHandleTask;

--- a/src/backend/job-file-gateway/api-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/model/resp/inner/TaskInfoDTO.java
+++ b/src/backend/job-file-gateway/api-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/model/resp/inner/TaskInfoDTO.java
@@ -36,5 +36,6 @@ public class TaskInfoDTO {
     String fileSourceName;
     boolean fileSourcePublic;
     Long cloudId;
+    String ipProtocol;
     String ip;
 }

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceTaskServiceImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceTaskServiceImpl.java
@@ -171,11 +171,20 @@ public class FileSourceTaskServiceImpl implements FileSourceTaskService {
             if (affectedCount != 1) {
                 log.error("Fail to update status of FileSourceTask={}", JsonUtils.toJson(fileSourceTaskDTO));
             }
-            throw new InternalException(e, ErrorCode.FAIL_TO_REQUEST_FILE_WORKER_START_FILE_SOURCE_DOWNLOAD_TASK,
-                new String[]{e.getMessage()});
+            throw new InternalException(
+                e,
+                ErrorCode.FAIL_TO_REQUEST_FILE_WORKER_START_FILE_SOURCE_DOWNLOAD_TASK,
+                new String[]{e.getMessage()}
+            );
         }
-        return new TaskInfoDTO(fileSourceTaskId, fileSourceDTO.getAlias(), fileSourceDTO.getPublicFlag(),
-            fileWorkerDTO.getCloudAreaId(), fileWorkerDTO.getInnerIp());
+        return new TaskInfoDTO(
+            fileSourceTaskId,
+            fileSourceDTO.getAlias(),
+            fileSourceDTO.getPublicFlag(),
+            fileWorkerDTO.getCloudAreaId(),
+            fileWorkerDTO.getInnerIpProtocol(),
+            fileWorkerDTO.getInnerIp()
+        );
     }
 
     @Override

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/task/dispatch/ReDispatchTimeoutTask.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/task/dispatch/ReDispatchTimeoutTask.java
@@ -68,6 +68,11 @@ public class ReDispatchTimeoutTask {
             0,
             -1
         );
+        log.info(
+            "find {} fileSourceTask to reDispatch: {}",
+            timeoutFileSourceTaskIdList.size(),
+            timeoutFileSourceTaskIdList
+        );
         // 进行超时重调度
         for (String fileSourceTaskId : timeoutFileSourceTaskIdList) {
             boolean result = reDispatchService.reDispatchByGateway(fileSourceTaskId, 0L, 5000L);

--- a/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/config/ExecutorConfiguration.java
+++ b/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/config/ExecutorConfiguration.java
@@ -47,7 +47,7 @@ public class ExecutorConfiguration {
             40,
             1,
             TimeUnit.MINUTES,
-            new LinkedBlockingQueue<>(1000), (r, executor) -> {
+            new LinkedBlockingQueue<>(10000), (r, executor) -> {
             log.error("fileTaskWorkerPool rejected a task, use current thread now, plz add more threads");
             r.run();
         });
@@ -62,7 +62,7 @@ public class ExecutorConfiguration {
             40,
             1,
             TimeUnit.MINUTES
-            , new LinkedBlockingQueue<>(1000), (r, executor) ->
+            , new LinkedBlockingQueue<>(10000), (r, executor) ->
             log.error("watchingTaskExecutor rejected a task, ignore, plz add more threads")
         );
     }


### PR DESCRIPTION
1. 修复启动第三方源文件下载时对file-worker主机的解析；
2. 调整file-worker任务队列大小。