### PR TITLE
fix: 作业使用 GSE V2 管道，当agent_id 不存在的时候，会调用 GSE V1 的 queryAgentStatus API #3013

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/TaskInstanceExecuteObjectProcessor.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/TaskInstanceExecuteObjectProcessor.java
@@ -551,7 +551,6 @@ public class TaskInstanceExecuteObjectProcessor {
     }
 
     private boolean isAgentIdValid(HostDTO host, boolean isUsingGseV2) {
-        // 如果对接GSE1.0,使用云区域+ipv4构造agentId
         return isUsingGseV2 ? AgentUtils.isGseV2AgentId(host.getAgentId()) :
             AgentUtils.isGseV1AgentId(host.getAgentId());
     }

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -614,6 +614,9 @@ job:
     gseV2:
       # 是否对接GSE2.0。 如果需要对接GSE1.0，设置job.features.gseV2.enabled=false
       enabled: true
+      # 是否支持 GSE V2 Agent状态查询。如果需要对接GSE1.0，设置job.features.agentStatusGseV2.enabled=false
+    agentStatusGseV2:
+      enabled: true
     # 是否支持执行对象。如果 Job 需要支持容器内作业的执行，需要开启该特性
     executeObject:
       enabled: true


### PR DESCRIPTION
缺陷分析见 #3013

- 修改点
1. 修复缺陷
2. 解决 agent状态查询慢的问题。（由于values.yml 中默认没有设置job.features.agentStatusGseV2.enabled=true，当页面通过主机选择器添加主机的时候，如果这个主机所在业务已经切换到 GSE V2 通道，并且这个主机没有agent_id, 会通过 gse v1 查询 agent 状态，会查询 15s直到超时)