### PR TITLE
feat: 执行历史归档新增模式-只备份不删除 #3037

### DIFF
--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractArchivist.java
@@ -279,8 +279,9 @@ public abstract class AbstractArchivist<T extends TableRecord<?>> {
     }
 
     protected boolean isBackupEnable(ArchiveDBProperties archiveDBProperties) {
+        ArchiveModeEnum archiveMode = ArchiveModeEnum.valOf(archiveDBProperties.getMode());
         return archiveDBProperties.isEnabled()
-            && ArchiveModeEnum.BACKUP_THEN_DELETE == ArchiveModeEnum.valOf(archiveDBProperties.getMode());
+            && (ArchiveModeEnum.BACKUP_THEN_DELETE == archiveMode || ArchiveModeEnum.BACKUP_ONLY == archiveMode);
     }
 
     protected boolean isDeleteEnable(ArchiveDBProperties archiveDBProperties) {

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractArchivist.java
@@ -287,8 +287,8 @@ public abstract class AbstractArchivist<T extends TableRecord<?>> {
                 readRows,
                 backupRows,
                 deleteRows,
-                backupEnabled ? stop : 0,
-                deleteEnabled ? stop : 0,
+                backupEnabled ? stop : null,
+                deleteEnabled ? stop : null,
                 archiveCost,
                 success,
                 backupReadRecordCost,
@@ -328,6 +328,7 @@ public abstract class AbstractArchivist<T extends TableRecord<?>> {
     private BackupResult backupRecords(long start, long stop) throws IOException {
         if (lastBackupId >= stop) {
             // 说明数据已经备份过，跳过
+            log.info("[{}] Record is already backup, skip. lastBackId: {}", tableName, lastBackupId);
             return new BackupResult(0L, 0L, 0L, 0L);
         }
         long startId = start;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractArchivist.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractArchivist.java
@@ -281,8 +281,20 @@ public abstract class AbstractArchivist<T extends TableRecord<?>> {
                 deleteRows,
                 archiveCost
             );
-            setArchiveSummary(minNeedArchiveId, maxNeedArchiveId, readRows, backupRows, deleteRows,
-                stop, archiveCost, success, backupReadRecordCost, backupWriteRecordCost, deleteCost);
+            setArchiveSummary(
+                minNeedArchiveId,
+                maxNeedArchiveId,
+                readRows,
+                backupRows,
+                deleteRows,
+                backupEnabled ? stop : 0,
+                deleteEnabled ? stop : 0,
+                archiveCost,
+                success,
+                backupReadRecordCost,
+                backupWriteRecordCost,
+                deleteCost
+            );
         }
     }
 
@@ -400,7 +412,8 @@ public abstract class AbstractArchivist<T extends TableRecord<?>> {
                                    long readRows,
                                    long backupRows,
                                    long deleteRows,
-                                   long stop,
+                                   Long lastBackupId,
+                                   Long lastDeleteId,
                                    long archiveCost,
                                    boolean success,
                                    long backupReadCost,
@@ -411,8 +424,8 @@ public abstract class AbstractArchivist<T extends TableRecord<?>> {
         archiveSummary.setNeedArchiveRecordSize(readRows);
         archiveSummary.setBackupRecordSize(backupRows);
         archiveSummary.setDeleteRecordSize(deleteRows);
-        archiveSummary.setLastBackupId(stop);
-        archiveSummary.setLastDeletedId(stop);
+        archiveSummary.setLastBackupId(lastBackupId);
+        archiveSummary.setLastDeletedId(lastDeleteId);
         archiveSummary.setArchiveCost(archiveCost);
         archiveSummary.setSuccess(success);
         archiveSummary.setBackupReadCost(backupReadCost);

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ExecuteBackupDbConfiguration.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ExecuteBackupDbConfiguration.java
@@ -33,6 +33,7 @@ import org.jooq.impl.DefaultConfiguration;
 import org.jooq.impl.DefaultDSLContext;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
@@ -80,16 +81,30 @@ public class ExecuteBackupDbConfiguration {
         }
 
         @ConditionalOnProperty(value = "job.backup.archive.execute.enabled", havingValue = "true")
-        class ArchiveEnableCondition {
+        static class ArchiveEnableCondition {
 
         }
 
-        @ConditionalOnProperty(value = "job.backup.archive.execute.mode",
-            havingValue = ArchiveModeEnum.Constants.BACKUP_THEN_DELETE)
-        class ArchiveModeBackupThenDeleteCondition {
+        static class JobExecuteBackupCondition extends AnyNestedCondition {
+            public JobExecuteBackupCondition() {
+                super(ConfigurationPhase.PARSE_CONFIGURATION);
+            }
 
+            @ConditionalOnProperty(value = "job.backup.archive.execute.mode",
+                havingValue = ArchiveModeEnum.Constants.BACKUP_THEN_DELETE)
+            static class ArchiveModeBackupThenDeleteCondition {
+
+            }
+
+            @ConditionalOnProperty(value = "job.backup.archive.execute.mode",
+                havingValue = ArchiveModeEnum.Constants.BACKUP_ONLY)
+            static class ArchiveModeBackupOnlyCondition {
+
+            }
         }
     }
+
+
 
 
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ExecuteBackupDbConfiguration.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ExecuteBackupDbConfiguration.java
@@ -85,6 +85,11 @@ public class ExecuteBackupDbConfiguration {
 
         }
 
+        @Conditional(JobExecuteBackupCondition.class)
+        static class BackupCondition {
+
+        }
+
         static class JobExecuteBackupCondition extends AnyNestedCondition {
             public JobExecuteBackupCondition() {
                 super(ConfigurationPhase.PARSE_CONFIGURATION);

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/constant/ArchiveModeEnum.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/constant/ArchiveModeEnum.java
@@ -48,7 +48,7 @@ public enum ArchiveModeEnum {
     public interface Constants {
         String DELETE_ONLY = "deleteOnly";
         String BACKUP_THEN_DELETE = "backupThenDelete";
-        String BACKUP_ONLY = " backupOnly";
+        String BACKUP_ONLY = "backupOnly";
     }
 
     private final String mode;
@@ -59,7 +59,7 @@ public enum ArchiveModeEnum {
                 return value;
             }
         }
-        return null;
+        throw new IllegalArgumentException("No ArchiveModeEnum constant: " + mode);
     }
 
     public String getMode() {

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/constant/ArchiveModeEnum.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/constant/ArchiveModeEnum.java
@@ -39,7 +39,7 @@ public enum ArchiveModeEnum {
     /**
      * 仅备份数据,不删除原始数据。该模式为开发/测试场景下使用，暂不对外开放
      */
-    BACKUP_ONLY(Constants.BACKUP_THEN_DELETE);
+    BACKUP_ONLY(Constants.BACKUP_ONLY);
 
     ArchiveModeEnum(String mode) {
         this.mode = mode;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/constant/ArchiveModeEnum.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/constant/ArchiveModeEnum.java
@@ -35,7 +35,11 @@ public enum ArchiveModeEnum {
     /**
      * 备份数据后再删除
      */
-    BACKUP_THEN_DELETE(Constants.BACKUP_THEN_DELETE);
+    BACKUP_THEN_DELETE(Constants.BACKUP_THEN_DELETE),
+    /**
+     * 仅备份数据,不删除原始数据。该模式为开发/测试场景下使用，暂不对外开放
+     */
+    BACKUP_ONLY(Constants.BACKUP_THEN_DELETE);
 
     ArchiveModeEnum(String mode) {
         this.mode = mode;
@@ -44,6 +48,7 @@ public enum ArchiveModeEnum {
     public interface Constants {
         String DELETE_ONLY = "deleteOnly";
         String BACKUP_THEN_DELETE = "backupThenDelete";
+        String BACKUP_ONLY = " backupOnly";
     }
 
     private final String mode;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/ExecuteArchiveDAOImpl.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/dao/impl/ExecuteArchiveDAOImpl.java
@@ -31,6 +31,7 @@ import org.jooq.DSLContext;
 import org.jooq.Loader;
 import org.jooq.LoaderError;
 import org.jooq.TableRecord;
+import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,11 +55,11 @@ public class ExecuteArchiveDAOImpl implements ExecuteArchiveDAO {
     public Integer batchInsert(List<? extends TableRecord<?>> recordList, int bulkSize) throws IOException {
         long start = System.currentTimeMillis();
         int successInsertedRecords = 0;
-        String table = recordList.get(0).getTable().getName();
+        String tableName = recordList.get(0).getTable().getName();
         boolean success = true;
         try {
             Loader<?> loader =
-                context.loadInto(recordList.get(0).getTable())
+                context.loadInto(DSL.table(tableName))
                     // 由于这里是批量写入，jooq 不允许使用 onDuplicateKeyIgnore/onDuplicateKeyUpdate.
                     // 否则会报错"Cannot apply bulk loading with onDuplicateKey flags"
                     // 所以这里暂时使用 onDuplicateKeyError 错误处理方式，等后续流程进一步判断是否是主键冲突错误
@@ -72,7 +73,7 @@ public class ExecuteArchiveDAOImpl implements ExecuteArchiveDAO {
             String bulkInsertResult = successInsertedRecords == recordList.size() ? "success" : "fail";
             log.info(
                 "InsertBulk: Load {} data|result|{}|executed|{}|processed|{}|stored|{}|ignored|{}|errors|{}",
-                table,
+                tableName,
                 bulkInsertResult,
                 loader.executed(),
                 loader.processed(),
@@ -82,7 +83,7 @@ public class ExecuteArchiveDAOImpl implements ExecuteArchiveDAO {
             );
             if (CollectionUtils.isNotEmpty(loader.errors())) {
                 for (LoaderError error : loader.errors()) {
-                    ARCHIVE_FAILED_LOGGER.error("Error while load {} data, exception: {}， error row: {}", table,
+                    ARCHIVE_FAILED_LOGGER.error("Error while load {} data, exception: {}， error row: {}", tableName,
                         error.exception().getMessage(), error.row());
                 }
                 if (hasDuplicateError(loader.errors())) {
@@ -91,12 +92,12 @@ public class ExecuteArchiveDAOImpl implements ExecuteArchiveDAO {
                 }
             }
         } catch (IOException e) {
-            String errorMsg = String.format("Error while loading %s data!", table);
+            String errorMsg = String.format("Error while loading %s data!", tableName);
             log.error(errorMsg, e);
             success = false;
             throw e;
         } finally {
-            log.info("Load data to {} done! success: {}, total: {}, inserted: {}, cost: {}ms", table, success,
+            log.info("Load data to {} done! success: {}, total: {}, inserted: {}, cost: {}ms", tableName, success,
                 recordList.size(), successInsertedRecords, System.currentTimeMillis() - start);
         }
 

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/model/dto/ArchiveSummary.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/model/dto/ArchiveSummary.java
@@ -67,6 +67,11 @@ public class ArchiveSummary {
     private Long lastDeletedId;
     private Long deleteRecordSize;
 
+    /**
+     * 归档详细说明信息
+     */
+    private String message;
+
     public ArchiveSummary(String tableName) {
         this.tableName = tableName;
     }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/model/dto/ArchiveSummary.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/model/dto/ArchiveSummary.java
@@ -41,9 +41,13 @@ public class ArchiveSummary {
     private String archiveMode;
 
     /**
-     * 备份数据耗时（单位毫秒)
+     * 备份数据-查询原数据耗时（单位毫秒)
      */
-    private Long backupCost;
+    private Long backupReadCost;
+    /**
+     * 备份数据-写入数据到归档 db 耗时（单位毫秒)
+     */
+    private Long backupWriteCost;
     /**
      * 删除热数据耗时（单位毫秒)
      */

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/model/dto/ArchiveSummary.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/model/dto/ArchiveSummary.java
@@ -39,6 +39,18 @@ public class ArchiveSummary {
     private boolean success;
 
     private String archiveMode;
+
+    /**
+     * 备份数据耗时（单位毫秒)
+     */
+    private Long backupCost;
+    /**
+     * 删除热数据耗时（单位毫秒)
+     */
+    private Long deleteCost;
+    /**
+     * 归档总耗时（单位毫秒)
+     */
     private Long archiveCost;
 
     private Long archiveIdStart;


### PR DESCRIPTION
1. 该模式当前仅设计为归档功能测试&性能测试使用，保证归档测试过程中不会删除原始数据。
2. 不对用户开放，文档暂时无需补充相关说明
3. 优化日志
4. 优化归档任务的执行结果输出详情