### PR TITLE
perf: 第三方文件源任务支持无损更新 #3017

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/third/ThirdFilePrepareService.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/third/ThirdFilePrepareService.java
@@ -120,6 +120,12 @@ public class ThirdFilePrepareService {
             taskInfoDTO.getIpProtocol(),
             taskInfoDTO.getIp()
         );
+        log.info(
+            "[{}]: fileSourceTaskId={} start, sourceHost={}",
+            stepInstance.getUniqueKey(),
+            fileSourceTaskId,
+            hostDTO
+        );
         hostDTOList.add(hostDTO);
         fileSourceDTO.getServers().setStaticIpList(hostDTOList);
         fileSourceDTO.getServers().buildMergedExecuteObjects(stepInstance.isSupportExecuteObjectFeature());

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/third/ThirdFilePrepareTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/third/ThirdFilePrepareTask.java
@@ -367,6 +367,12 @@ public class ThirdFilePrepareTask implements ContinuousScheduledTask, JobTaskCon
                 } else {
                     sourceHost.setAgentId(sourceHost.toCloudIp());
                 }
+                log.info(
+                    "[{}]: fileSourceTaskId={} success, sourceHost={}",
+                    stepInstance.getUniqueKey(),
+                    fileSourceTaskId,
+                    sourceHost
+                );
                 List<HostDTO> hostDTOList = Collections.singletonList(sourceHost);
                 executeTargetDTO.addStaticHosts(hostDTOList);
                 executeTargetDTO.buildMergedExecuteObjects(stepInstance.isSupportExecuteObjectFeature());

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceTaskServiceImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceTaskServiceImpl.java
@@ -163,6 +163,7 @@ public class FileSourceTaskServiceImpl implements FileSourceTaskService {
             fileSourceTaskId,
             fileWorkerDTO.getId()
         );
+        fileSourceTaskId = fileSourceTaskDTO.getId();
         try {
             // 分发文件任务
             HttpReq req = fileSourceTaskReqGenService.genDownloadFilesReq(appId, fileWorkerDTO, fileSourceDTO,
@@ -175,7 +176,7 @@ public class FileSourceTaskServiceImpl implements FileSourceTaskService {
             ).getMessage();
             log.error(msg, e);
             // 清理DB中的任务数据便于外层重试
-            clearSavedFileSourceTask(fileSourceTaskDTO.getId());
+            clearSavedFileSourceTask(fileSourceTaskId);
             throw new InternalException(
                 e,
                 ErrorCode.FAIL_TO_REQUEST_FILE_WORKER_START_FILE_SOURCE_DOWNLOAD_TASK,

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceTaskServiceImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceTaskServiceImpl.java
@@ -175,7 +175,7 @@ public class FileSourceTaskServiceImpl implements FileSourceTaskService {
             ).getMessage();
             log.error(msg, e);
             // 清理DB中的任务数据便于外层重试
-            clearSavedFileSourceTask(fileSourceTaskId);
+            clearSavedFileSourceTask(fileSourceTaskDTO.getId());
             throw new InternalException(
                 e,
                 ErrorCode.FAIL_TO_REQUEST_FILE_WORKER_START_FILE_SOURCE_DOWNLOAD_TASK,

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceTaskServiceImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceTaskServiceImpl.java
@@ -30,7 +30,6 @@ import com.tencent.bk.job.common.exception.InternalException;
 import com.tencent.bk.job.common.exception.ServiceException;
 import com.tencent.bk.job.common.model.Response;
 import com.tencent.bk.job.common.model.http.HttpReq;
-import com.tencent.bk.job.common.mysql.JobTransactional;
 import com.tencent.bk.job.common.util.http.JobHttpClient;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import com.tencent.bk.job.file_gateway.consts.TaskCommandEnum;
@@ -103,7 +102,6 @@ public class FileSourceTaskServiceImpl implements FileSourceTaskService {
     }
 
     @Override
-    @JobTransactional(transactionManager = "jobFileGatewayTransactionManager")
     public TaskInfoDTO startFileSourceDownloadTask(String username,
                                                    Long appId,
                                                    Long stepInstanceId,
@@ -123,7 +121,6 @@ public class FileSourceTaskServiceImpl implements FileSourceTaskService {
         );
     }
 
-    @JobTransactional(transactionManager = "jobFileGatewayTransactionManager")
     public TaskInfoDTO startFileSourceDownloadTaskWithId(String username,
                                                          Long appId,
                                                          Long stepInstanceId,

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/RetryPolicyFileSourceTaskServiceImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/RetryPolicyFileSourceTaskServiceImpl.java
@@ -61,15 +61,14 @@ public class RetryPolicyFileSourceTaskServiceImpl implements RetryPolicyFileSour
         boolean shouldRetry;
         do {
             try {
-                return fileSourceTaskService.startFileSourceDownloadTaskWithId(
+                return fileSourceTaskService.startFileSourceDownloadTask(
                     username,
                     appId,
                     stepInstanceId,
                     executeCount,
                     batchTaskId,
                     fileSourceId,
-                    filePathList,
-                    null
+                    filePathList
                 );
             } catch (Exception e) {
                 retryCount += 1;


### PR DESCRIPTION
1. 去除启动任务过程的事务，避免任务启动日志上报时启动事务未完成导致任务找不到的问题；
2. 完善日志便于排查问题。