### PR TITLE
feat: 提供特性开关查询接口 #3056

### DIFF
--- a/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/DefaultFeatureManager.java
+++ b/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/DefaultFeatureManager.java
@@ -36,6 +36,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.List;
+
 @Slf4j
 public class DefaultFeatureManager implements FeatureManager {
     /**
@@ -133,5 +135,10 @@ public class DefaultFeatureManager implements FeatureManager {
         meterRegistry.counter(METRIC_JOB_FEATURE_TOGGLE_HIT_TOTAL,
                 Tags.of(CommonMetricTags.KEY_RESOURCE_SCOPE, resourceScope).and("feature", featureId))
             .increment();
+    }
+
+    @Override
+    public List<Feature> listFeatures() {
+        return featureStore.listFeatures();
     }
 }

--- a/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/InMemoryFeatureStore.java
+++ b/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/InMemoryFeatureStore.java
@@ -42,7 +42,9 @@ import com.tencent.bk.job.common.util.json.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -180,4 +182,17 @@ public class InMemoryFeatureStore implements FeatureStore {
         }
         return toggleStrategy;
     }
+
+    @Override
+    public List<Feature> listFeatures() {
+        if (!isInitial) {
+            synchronized (this) {
+                if (!isInitial) {
+                    load(true);
+                }
+            }
+        }
+        return new ArrayList<>(features.values());
+    }
+
 }

--- a/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/AbstractResourceScopeToggleStrategy.java
+++ b/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/AbstractResourceScopeToggleStrategy.java
@@ -26,6 +26,8 @@ package com.tencent.bk.job.common.service.feature.strategy;
 
 import com.tencent.bk.job.common.constant.ResourceScopeTypeEnum;
 import com.tencent.bk.job.common.model.dto.ResourceScope;
+import com.tencent.bk.job.common.util.feature.FeatureExecutionContext;
+import com.tencent.bk.job.common.util.feature.ToggleStrategyContextParams;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.helpers.MessageFormatter;
@@ -121,5 +123,9 @@ public abstract class AbstractResourceScopeToggleStrategy extends AbstractToggle
             checkScope = new ResourceScope(scope.getType(), scope.getId());
         }
         return this.resourceScopes.contains(checkScope);
+    }
+
+    protected boolean checkFeatureExecuteContext(FeatureExecutionContext context) {
+        return checkRequiredContextParam(context, ToggleStrategyContextParams.CTX_PARAM_RESOURCE_SCOPE);
     }
 }

--- a/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/AbstractToggleStrategy.java
+++ b/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/AbstractToggleStrategy.java
@@ -84,12 +84,15 @@ public abstract class AbstractToggleStrategy implements ToggleStrategy {
     }
 
 
-    public void assertRequiredContextParam(FeatureExecutionContext context, String paramName) {
+    public boolean checkRequiredContextParam(FeatureExecutionContext context, String paramName) {
+        boolean checkResult = true;
         if (context.getParam(paramName) == null) {
             String msg = MessageFormatter.format(
                 "Context param {} is required for evaluate", paramName).getMessage();
-            log.error(msg);
-            throw new FeatureParamMissingException(msg);
+            log.warn(msg);
+            checkResult = false;
         }
+        return checkResult;
     }
+
 }

--- a/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/JobInstanceAttrToggleStrategy.java
+++ b/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/JobInstanceAttrToggleStrategy.java
@@ -106,28 +106,40 @@ public class JobInstanceAttrToggleStrategy extends AbstractToggleStrategy {
     @Override
     public boolean evaluate(String featureId, FeatureExecutionContext ctx) {
         if (requireAllGseV2AgentAvailable != null && requireAllGseV2AgentAvailable) {
-            assertRequiredContextParam(ctx, CTX_PARAM_IS_ALL_GSE_V2_AGENT_AVAILABLE);
+            boolean checkResult = checkRequiredContextParam(ctx, CTX_PARAM_IS_ALL_GSE_V2_AGENT_AVAILABLE);
+            if (!checkResult) {
+                return false;
+            }
             boolean isAllAgentV2Available = (boolean) ctx.getParam(CTX_PARAM_IS_ALL_GSE_V2_AGENT_AVAILABLE);
             if (!isAllAgentV2Available) {
                 return false;
             }
         }
         if (requireAnyGseV2AgentAvailable != null && requireAnyGseV2AgentAvailable) {
-            assertRequiredContextParam(ctx, CTX_PARAM_IS_ANY_GSE_V2_AGENT_AVAILABLE);
+            boolean checkResult = checkRequiredContextParam(ctx, CTX_PARAM_IS_ANY_GSE_V2_AGENT_AVAILABLE);
+            if (!checkResult) {
+                return false;
+            }
             boolean isAnyAgentV2Available = (boolean) ctx.getParam(CTX_PARAM_IS_ANY_GSE_V2_AGENT_AVAILABLE);
             if (!isAnyAgentV2Available) {
                 return false;
             }
         }
         if (CollectionUtils.isNotEmpty(startupModes)) {
-            assertRequiredContextParam(ctx, CTX_PARAM_STARTUP_MODE);
+            boolean checkResult = checkRequiredContextParam(ctx, CTX_PARAM_STARTUP_MODE);
+            if (!checkResult) {
+                return false;
+            }
             String startupMode = (String) ctx.getParam(CTX_PARAM_STARTUP_MODE);
             if (!startupModes.contains(startupMode)) {
                 return false;
             }
         }
         if (CollectionUtils.isNotEmpty(operators)) {
-            assertRequiredContextParam(ctx, CTX_PARAM_OPERATOR);
+            boolean checkResult = checkRequiredContextParam(ctx, CTX_PARAM_OPERATOR);
+            if (!checkResult) {
+                return false;
+            }
             String operator = (String) ctx.getParam(CTX_PARAM_OPERATOR);
             return operators.contains(operator);
         }

--- a/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/ResourceScopeWhiteListToggleStrategy.java
+++ b/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feature/strategy/ResourceScopeWhiteListToggleStrategy.java
@@ -46,6 +46,10 @@ public class ResourceScopeWhiteListToggleStrategy extends AbstractResourceScopeT
 
     @Override
     public boolean evaluate(String featureId, FeatureExecutionContext ctx) {
+        boolean isValidContext = checkFeatureExecuteContext(ctx);
+        if (!isValidContext) {
+            return false;
+        }
         ResourceScope scope = (ResourceScope) ctx.getParam(ToggleStrategyContextParams.CTX_PARAM_RESOURCE_SCOPE);
         return hitResourceScopeList(scope);
     }

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/feature/Feature.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/feature/Feature.java
@@ -43,6 +43,4 @@ public class Feature {
      * 特性启用灰度策略
      */
     private ToggleStrategy strategy;
-
-
 }

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/feature/FeatureManager.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/feature/FeatureManager.java
@@ -24,6 +24,8 @@
 
 package com.tencent.bk.job.common.util.feature;
 
+import java.util.List;
+
 /**
  * 特性管理
  */
@@ -44,4 +46,11 @@ public interface FeatureManager {
      * @return 是否开启
      */
     boolean checkFeature(String featureId, FeatureExecutionContext ctx);
+
+    /**
+     * 查询所有特性开关配置
+     *
+     * @return 特性开关配置列表
+     */
+    List<Feature> listFeatures();
 }

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/feature/FeatureStore.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/feature/FeatureStore.java
@@ -24,6 +24,8 @@
 
 package com.tencent.bk.job.common.util.feature;
 
+import java.util.List;
+
 /**
  * 特性开关配置存储
  */
@@ -41,5 +43,13 @@ public interface FeatureStore {
      * @param ignoreException 是否忽略加载配置异常；true - 忽略异常；false: 抛出异常
      */
     void load(boolean ignoreException);
+
+
+    /**
+     * 查询所有特性开关配置
+     *
+     * @return 特性开关配置列表
+     */
+    List<Feature> listFeatures();
 
 }

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/feature/ToggleStrategyContextParams.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/feature/ToggleStrategyContextParams.java
@@ -29,4 +29,8 @@ public interface ToggleStrategyContextParams {
      * 上下文参数-资源范围
      */
     String CTX_PARAM_RESOURCE_SCOPE = "resourceScope";
+    /**
+     * 上下文参数-用户账号
+     */
+    String CTX_PARAM_USERNAME = "username";
 }

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/WebFeatureToggleResource.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/WebFeatureToggleResource.java
@@ -26,7 +26,6 @@ package com.tencent.bk.job.manage.api.web;
 
 import com.tencent.bk.job.common.annotation.WebAPI;
 import com.tencent.bk.job.common.model.Response;
-import com.tencent.bk.job.manage.model.web.vo.FeatureVO;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -35,7 +34,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import springfox.documentation.annotations.ApiIgnore;
 
-import java.util.List;
+import java.util.Map;
 
 /**
  * Job 特性开关 Web API
@@ -51,7 +50,7 @@ public interface WebFeatureToggleResource {
      */
     @ApiOperation(value = "获取Job功能特性开关配置", produces = "application/json")
     @GetMapping("/list")
-    Response<List<FeatureVO>> listFeatureToggle(
+    Response<Map<String, Boolean>> listFeatureToggle(
         @ApiIgnore
         @ApiParam(value = "用户名，网关自动传入", required = true)
         @RequestHeader("username")

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/WebFeatureToggleResource.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/WebFeatureToggleResource.java
@@ -22,44 +22,39 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.common.service.feature.strategy;
+package com.tencent.bk.job.manage.api.web;
 
-import com.tencent.bk.job.common.model.dto.ResourceScope;
-import com.tencent.bk.job.common.util.feature.FeatureExecutionContext;
-import com.tencent.bk.job.common.util.feature.ToggleStrategyContextParams;
+import com.tencent.bk.job.common.annotation.WebAPI;
+import com.tencent.bk.job.common.model.Response;
+import com.tencent.bk.job.manage.model.web.vo.FeatureVO;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import springfox.documentation.annotations.ApiIgnore;
 
-import java.util.Map;
-import java.util.StringJoiner;
+import java.util.List;
 
 /**
- * 根据资源范围黑名单灰度策略
+ * Job 特性开关 Web API
  */
-public class ResourceScopeBlackListToggleStrategy extends AbstractResourceScopeToggleStrategy {
+@Api(tags = {"job-manage:web:feature"})
+@RequestMapping("/web/feature/toggle")
+@WebAPI
+public interface WebFeatureToggleResource {
+
+
     /**
-     * 特性开关开启策略ID
+     * 获取特性开关配置
      */
-    public static final String STRATEGY_ID = "ResourceScopeBlackListToggleStrategy";
-
-    public ResourceScopeBlackListToggleStrategy(Map<String, String> initParams) {
-        super(STRATEGY_ID, initParams);
-    }
-
-    @Override
-    public boolean evaluate(String featureId, FeatureExecutionContext ctx) {
-        boolean isValidContext = checkFeatureExecuteContext(ctx);
-        if (!isValidContext) {
-            return false;
-        }
-        ResourceScope scope = (ResourceScope) ctx.getParam(ToggleStrategyContextParams.CTX_PARAM_RESOURCE_SCOPE);
-        return !hitResourceScopeList(scope);
-    }
-
-    @Override
-    public String toString() {
-        return new StringJoiner(", ", ResourceScopeBlackListToggleStrategy.class.getSimpleName() + "[", "]")
-            .add("id='" + id + "'")
-            .add("initParams=" + initParams)
-            .add("resourceScopes=" + resourceScopes)
-            .toString();
-    }
+    @ApiOperation(value = "获取Job功能特性开关配置", produces = "application/json")
+    @GetMapping("/list")
+    Response<List<FeatureVO>> listFeatureToggle(
+        @ApiIgnore
+        @ApiParam(value = "用户名，网关自动传入", required = true)
+        @RequestHeader("username")
+        String username
+    );
 }

--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/vo/FeatureVO.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/web/vo/FeatureVO.java
@@ -22,44 +22,23 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.common.service.feature.strategy;
+package com.tencent.bk.job.manage.model.web.vo;
 
-import com.tencent.bk.job.common.model.dto.ResourceScope;
-import com.tencent.bk.job.common.util.feature.FeatureExecutionContext;
-import com.tencent.bk.job.common.util.feature.ToggleStrategyContextParams;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
 
-import java.util.Map;
-import java.util.StringJoiner;
-
-/**
- * 根据资源范围黑名单灰度策略
- */
-public class ResourceScopeBlackListToggleStrategy extends AbstractResourceScopeToggleStrategy {
+@ApiModel("功能特性开关")
+@Data
+public class FeatureVO {
     /**
-     * 特性开关开启策略ID
+     * 特性ID
      */
-    public static final String STRATEGY_ID = "ResourceScopeBlackListToggleStrategy";
-
-    public ResourceScopeBlackListToggleStrategy(Map<String, String> initParams) {
-        super(STRATEGY_ID, initParams);
-    }
-
-    @Override
-    public boolean evaluate(String featureId, FeatureExecutionContext ctx) {
-        boolean isValidContext = checkFeatureExecuteContext(ctx);
-        if (!isValidContext) {
-            return false;
-        }
-        ResourceScope scope = (ResourceScope) ctx.getParam(ToggleStrategyContextParams.CTX_PARAM_RESOURCE_SCOPE);
-        return !hitResourceScopeList(scope);
-    }
-
-    @Override
-    public String toString() {
-        return new StringJoiner(", ", ResourceScopeBlackListToggleStrategy.class.getSimpleName() + "[", "]")
-            .add("id='" + id + "'")
-            .add("initParams=" + initParams)
-            .add("resourceScopes=" + resourceScopes)
-            .toString();
-    }
+    @ApiModelProperty("特性ID")
+    private String id;
+    /**
+     * 是否启用特性
+     */
+    @ApiModelProperty("是否启用特性")
+    private boolean enabled;
 }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebFeatureToggleResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebFeatureToggleResourceImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.api.web.impl;
+
+import com.tencent.bk.job.common.model.Response;
+import com.tencent.bk.job.common.util.feature.Feature;
+import com.tencent.bk.job.common.util.feature.FeatureIdConstants;
+import com.tencent.bk.job.common.util.feature.FeatureManager;
+import com.tencent.bk.job.manage.api.web.WebFeatureToggleResource;
+import com.tencent.bk.job.manage.model.web.vo.FeatureVO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@RestController
+@Slf4j
+public class WebFeatureToggleResourceImpl implements WebFeatureToggleResource {
+
+    private final FeatureManager featureManager;
+
+    private static final Set<String> frontendFeatures = new HashSet<>();
+
+    static {
+        // 增强功能-容器执行
+        frontendFeatures.add(FeatureIdConstants.FEATURE_CONTAINER_EXECUTE);
+    }
+
+    @Autowired
+    public WebFeatureToggleResourceImpl(FeatureManager featureManager) {
+        this.featureManager = featureManager;
+    }
+
+    @Override
+    public Response<List<FeatureVO>> listFeatureToggle(String username) {
+        Map<String, Feature> features = featureManager.listFeatures().stream()
+            .collect(Collectors.toMap(Feature::getId, feature -> feature, (oldValue, newValue) -> newValue));
+
+        if (features.isEmpty()) {
+            return Response.buildSuccessResp(Collections.emptyList());
+        }
+
+        return Response.buildSuccessResp(
+            frontendFeatures.stream()
+                .map(frontendFeatureId -> {
+                    Feature feature = features.get(frontendFeatureId);
+                    FeatureVO featureVO = new FeatureVO();
+                    featureVO.setId(frontendFeatureId);
+                    // 产品需求-无需考虑灰度策略情况
+                    featureVO.setEnabled(feature != null && feature.isEnabled());
+                    return featureVO;
+                })
+                .collect(Collectors.toList()));
+    }
+}

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -622,7 +622,7 @@ job:
       enabled: true
     # 是否支持容器执行
     containerExecution:
-      enabled: true
+      enabled: false
   trace:
     report:
       # 是否上报Trace数据至监控平台APM应用，默认不上报


### PR DESCRIPTION
1. 提供前端增强功能的特性开关
2. 容器执行特性默认关闭
3. 修改特性灰度策略计算逻辑，如果上下文中不包含对应策略计算需要的上下文参数，该条策略返回 false，而不是抛出异常影响其它策略的判定