### PR TITLE
feat: 作业驱逐功能纳入配额管理 #3090

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/ScriptGseTaskStartCommand.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/executor/ScriptGseTaskStartCommand.java
@@ -635,7 +635,7 @@ public class ScriptGseTaskStartCommand extends AbstractGseTaskStartCommand {
                 now);
             scriptLogs.add(scriptLog);
 
-            // AgentTask 结果更新
+            // ExecuteObjectTask 结果更新
             executeObjectTask.setGseTaskId(gseTask.getId());
             executeObjectTask.setStartTime(gseTask.getStartTime());
             executeObjectTask.setEndTime(now);


### PR DESCRIPTION
1. 作业驱逐 op 操作的作业，也会从配额管理中删除配额占用
2. 优化驱逐逻辑。
- 原方案：只会更新作业/步骤状态，并且都放在 TaskEvictPolicyExecutor.updateEvictedTaskStatus() 方法中，同时更新多个事件目标（job+step)违反了执行引擎基于 job/step/gseTask 事件驱动的设计。另外，还有一个功能问题，作业状态统计、失败通知、API 回调等功能都无法触发。
- 优化方案：无论在作业执行的那个阶段，判断作业需要被驱逐之后，只更新自身的状态；同时，发送一个 refresh 事件给上层对象执行响应操作（gseTask->step->job), 这样就能完整的处理整个作业对应生命周期中应该触发的所有操作。原 StepListener/JobListener#refresh() 中已实现了对 ABANDONED 状态的处理
<img width="920" alt="image" src="https://github.com/TencentBlueKing/bk-job/assets/28581184/a257c5c8-1483-4da1-b74e-570f5e7d14e0">
<img width="1073" alt="image" src="https://github.com/TencentBlueKing/bk-job/assets/28581184/ef722c97-5663-4305-a356-2ccb18dd0870">
3. 删除部分冗余代码