### PR TITLE
perf: 正在执行中的作业存活状态维持方案优化 #3093

### DIFF
--- a/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/exception/handler/EsbExceptionControllerAdvice.java
+++ b/src/backend/commons/common-web/src/main/java/com/tencent/bk/job/common/web/exception/handler/EsbExceptionControllerAdvice.java
@@ -199,7 +199,7 @@ public class EsbExceptionControllerAdvice extends ExceptionControllerAdviceBase 
         } else {
             log.info(errorMsg);
         }
-        return new ResponseEntity<>(EsbResp.buildCommonFailResp(ex), HttpStatus.TOO_MANY_REQUESTS);
+        return new ResponseEntity<>(EsbResp.buildCommonFailResp(ex), HttpStatus.OK);
     }
 
     @Override

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/constants/RedisKeys.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/constants/RedisKeys.java
@@ -1,0 +1,36 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.execute.constants;
+
+/**
+ * redis key 定义
+ */
+public interface RedisKeys {
+    /**
+     * 正在执行中的作业-ZSET
+     */
+    String RUNNING_JOB_ZSET_KEY = "job:execute:running:job";
+
+}

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/quota/limit/NotAliveJobDetector.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/quota/limit/NotAliveJobDetector.java
@@ -57,9 +57,9 @@ public class NotAliveJobDetector {
     }
 
     /**
-     * 兜底方案。为了防止系统异常、程序 bug 等原因导致 redis 中的作业记录没有被清理，需要定时清理。每小时触发一次
+     * 兜底方案。为了防止系统异常、程序 bug 等原因导致 redis 中的作业记录没有被清理，需要定时清理。每10min触发一次
      */
-    @Scheduled(cron = "0 0 0/1 * * ?")
+    @Scheduled(cron = "0 0/10 * * * ?")
     public void detectNotAliveJob() {
         try {
             if (LockUtils.tryGetDistributedLock("job:execute:not:alive:job:detect:lock", requestId, 60000L)) {

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/quota/limit/RunningJobKeepaliveManager.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/quota/limit/RunningJobKeepaliveManager.java
@@ -26,6 +26,7 @@ package com.tencent.bk.job.execute.engine.quota.limit;
 
 
 import com.tencent.bk.job.common.util.ThreadUtils;
+import com.tencent.bk.job.execute.constants.RedisKeys;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -56,7 +57,6 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 @EnableScheduling
 public class RunningJobKeepaliveManager {
-    private static final String RUNNING_JOB_ZSET_KEY = "job:execute:running:job";
     private final Object lock = new Object();
     private final RedisTemplate<String, String> redisTemplate;
     private final Map<Long, KeepaliveTask> runningJobKeepaliveTasks = new ConcurrentHashMap<>();
@@ -93,7 +93,7 @@ public class RunningJobKeepaliveManager {
 
     private void updateJobLatestAliveTimestamp(Long jobInstanceId, long currentTimestamp) {
         RedisSerializer<String> stringRedisSerializer = redisTemplate.getStringSerializer();
-        byte[] key = stringRedisSerializer.serialize(RUNNING_JOB_ZSET_KEY);
+        byte[] key = stringRedisSerializer.serialize(RedisKeys.RUNNING_JOB_ZSET_KEY);
         byte[] member = stringRedisSerializer.serialize(String.valueOf(jobInstanceId));
         redisTemplate.execute((RedisCallback<Object>) connection -> {
             connection.zAdd(


### PR DESCRIPTION
需求背景见 #3093 

## 修改内容
1. ZADD XX 替换 ZADD 逻辑。由于 spring data redis 无法直接支持 updateIfExist 这种逻辑，所以使用 RedisCallback 方案实现
2. ESB API 不支持 非 200 状态，所以限额情况下也返回 200；调用方使用 error code 区分错误
3. 未存活作业检测周期调整为 10min