### PR TITLE
fix: 作业模版引用的脚本版本更新状态设置不准确 #3113

### DIFF
--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/template/impl/TaskTemplateScriptStepDAOImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/template/impl/TaskTemplateScriptStepDAOImpl.java
@@ -421,6 +421,8 @@ public class TaskTemplateScriptStepDAOImpl implements TaskTemplateScriptStepDAO 
             .select(TABLE.STEP_ID, TABLE.TEMPLATE_ID, TABLE.SCRIPT_ID, TABLE.SCRIPT_VERSION_ID, TABLE.STATUS)
             .from(TABLE)
             .where(TABLE.TEMPLATE_ID.eq(ULong.valueOf(templateId)))
+            .and(TABLE.SCRIPT_ID.isNotNull())
+            .and(TABLE.SCRIPT_VERSION_ID.isNotNull())
             .fetch();
         if (result.isEmpty()) {
             return Collections.emptyList();


### PR DESCRIPTION
修复新建的作业模版不包含“引用脚本”的步骤场景下，后台空指针问题。
<img width="1303" alt="image" src="https://github.com/user-attachments/assets/6589fcc4-5381-4c3e-bb64-e363c095fa43">
