### PR TITLE
fix: 创建定时任务参数校验异常 #3245

### DIFF
--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/ExecuteTaskService.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/ExecuteTaskService.java
@@ -66,7 +66,7 @@ public interface ExecuteTaskService {
      * @throws TaskExecuteAuthFailedException 鉴权失败抛出异常
      */
     void authExecuteTask(
-        long appId, long taskId, long cronTaskId, String cronName,
+        long appId, long taskId, Long cronTaskId, String cronName,
         List<ServiceTaskVariable> variableList, String operator
     ) throws TaskExecuteAuthFailedException;
 }

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/ExecuteTaskServiceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/ExecuteTaskServiceImpl.java
@@ -106,7 +106,7 @@ public class ExecuteTaskServiceImpl implements ExecuteTaskService {
     public void authExecuteTask(
         long appId,
         long taskId,
-        long cronTaskId,
+        Long cronTaskId,
         String cronName,
         List<ServiceTaskVariable> variableList,
         String operator
@@ -115,7 +115,6 @@ public class ExecuteTaskServiceImpl implements ExecuteTaskService {
         request.setAppId(appId);
         request.setOperator(operator);
         request.setPlanId(taskId);
-        request.setCronTaskId(cronTaskId);
         request.setTaskName(cronName);
         request.setTaskVariables(variableList);
         request.setStartupMode(3);


### PR DESCRIPTION
1. 修复ESB接口调用报错，执行作业鉴权时无需传入cronTaskId，仅日志记录即可。