### PR TITLE
perf: 构建打包速度优化 #3278

### DIFF
--- a/support-files/kubernetes/images/backend/backend.Dockerfile
+++ b/support-files/kubernetes/images/backend/backend.Dockerfile
@@ -1,6 +1,7 @@
 FROM bkjob/jdk:0.0.3
 
 LABEL maintainer="Tencent BlueKing Job"
+LABEL dockerfile.version="0.0.1"
 
 ENV BK_JOB_HOME=/data/job/exec
 

--- a/support-files/kubernetes/images/backend/jdk.Dockerfile
+++ b/support-files/kubernetes/images/backend/jdk.Dockerfile
@@ -11,3 +11,9 @@ RUN mkdir -p /data && \
 ENV JAVA_HOME=/data/TencentKona-8.0.3-262
 ENV PATH=${JAVA_HOME}/bin:$PATH
 ENV CLASSPATH=.:${JAVA_HOME}/lib
+## 安装Python
+RUN yum install -y epel-release
+RUN yum install -y python-pip
+RUN mkdir -p /root/.pip
+RUN echo -e "[global]\nindex-url = https://pypi.tuna.tsinghua.edu.cn/simple\n[install]\ntrusted-host=pypi.tuna.tsinghua.edu.cn" > /root/.pip/pip.conf
+RUN pip install requests==2.6.0

--- a/support-files/kubernetes/images/backend/os.Dockerfile
+++ b/support-files/kubernetes/images/backend/os.Dockerfile
@@ -1,6 +1,7 @@
 FROM centos:7
 
 LABEL maintainer="Tencent BlueKing Job"
+LABEL dockerfile.version="0.0.2"
 
 ENV LANG="en_US.UTF-8"
 

--- a/support-files/kubernetes/images/backend/tool-set.Dockerfile
+++ b/support-files/kubernetes/images/backend/tool-set.Dockerfile
@@ -1,7 +1,7 @@
 FROM bkjob/os:0.0.2
 
 LABEL maintainer="Tencent BlueKing Job"
-LABEL dockerfile.version="0.0.3"
+LABEL dockerfile.version="0.0.1"
 
 ## 安装JDK
 RUN mkdir -p /data && \
@@ -12,3 +12,9 @@ RUN mkdir -p /data && \
 ENV JAVA_HOME=/data/TencentKona-8.0.3-262
 ENV PATH=${JAVA_HOME}/bin:$PATH
 ENV CLASSPATH=.:${JAVA_HOME}/lib
+## 安装Python
+RUN yum install -y epel-release
+RUN yum install -y python-pip
+RUN mkdir -p /root/.pip
+RUN echo -e "[global]\nindex-url = https://pypi.tuna.tsinghua.edu.cn/simple\n[install]\ntrusted-host=pypi.tuna.tsinghua.edu.cn" > /root/.pip/pip.conf
+RUN pip install requests==2.6.0

--- a/support-files/kubernetes/images/migration/migration.Dockerfile
+++ b/support-files/kubernetes/images/migration/migration.Dockerfile
@@ -1,6 +1,7 @@
-FROM bkjob/jdk:0.0.4
+FROM bkjob/tool-set:0.0.1
 
 LABEL maintainer="Tencent BlueKing Job"
+LABEL dockerfile.version="0.0.1"
 
 ENV BK_JOB_HOME=/data/job/exec
 

--- a/support-files/kubernetes/images/migration/migration.Dockerfile
+++ b/support-files/kubernetes/images/migration/migration.Dockerfile
@@ -1,4 +1,4 @@
-FROM bkjob/jdk:0.0.3
+FROM bkjob/jdk:0.0.4
 
 LABEL maintainer="Tencent BlueKing Job"
 
@@ -7,11 +7,6 @@ ENV BK_JOB_HOME=/data/job/exec
 COPY ./ /data/job/exec/
 
 RUN yum -y install mysql
-RUN yum install -y epel-release
-RUN yum install -y python-pip
-RUN mkdir -p /root/.pip
-RUN echo -e "[global]\nindex-url = https://pypi.tuna.tsinghua.edu.cn/simple\n[install]\ntrusted-host=pypi.tuna.tsinghua.edu.cn" > /root/.pip/pip.conf
-RUN pip install requests==2.6.0
 RUN ln -snf /usr/share/zoneinfo/Asia/Shanghai /etc/localtime && \
     echo 'Asia/Shanghai' > /etc/timezone && \
     chmod +x /data/job/exec/runUpgrader.sh && \


### PR DESCRIPTION
1.将python安装放到基础镜像中，避免每次重复安装耗时。