### PR TITLE
perf: 定时任务详情数据加载方式优化 #3284

### DIFF
--- a/src/backend/job-crontab/api-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/inner/ServiceCronJobDTO.java
+++ b/src/backend/job-crontab/api-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/inner/ServiceCronJobDTO.java
@@ -30,8 +30,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
@@ -64,9 +62,6 @@ public class ServiceCronJobDTO {
 
     @ApiModelProperty("单次执行的指定执行时间戳")
     private Long executeTime;
-
-    @ApiModelProperty("变量信息")
-    private List<ServiceCronJobVariableDTO> variableValue;
 
     @ApiModelProperty("上次执行结果 0 - 未执行 1 - 成功 2 - 失败")
     private Integer lastExecuteStatus;

--- a/src/backend/job-crontab/boot-job-crontab/src/test/java/com/tencent/bk/job/crontab/dao/impl/CronJobDAOImplIntegrationTest.java
+++ b/src/backend/job-crontab/boot-job-crontab/src/test/java/com/tencent/bk/job/crontab/dao/impl/CronJobDAOImplIntegrationTest.java
@@ -53,7 +53,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -419,16 +421,18 @@ public class CronJobDAOImplIntegrationTest {
         assertThat(cronJobInfoPageData.getStart()).isEqualTo(0);
         assertThat(cronJobInfoPageData.getPageSize()).isEqualTo(2);
         assertThat(cronJobInfoPageData.getTotal()).isEqualTo(4);
-        assertThat(cronJobInfoPageData.getData()).contains(CRON_JOB_5);
-        assertThat(cronJobInfoPageData.getData()).contains(CRON_JOB_1);
+        Set<Long> ids = cronJobInfoPageData.getData().stream().map(CronJobInfoDTO::getId).collect(Collectors.toSet());
+        assertThat(ids).contains(CRON_JOB_5.getId());
+        assertThat(ids).contains(CRON_JOB_1.getId());
 
         baseSearchCondition.setStart(2);
         cronJobInfoPageData = cronJobDAO.listPageCronJobsWithoutVarsByCondition(cronJobCondition, baseSearchCondition);
         assertThat(cronJobInfoPageData.getStart()).isEqualTo(2);
         assertThat(cronJobInfoPageData.getPageSize()).isEqualTo(2);
         assertThat(cronJobInfoPageData.getTotal()).isEqualTo(4);
-        assertThat(cronJobInfoPageData.getData()).contains(CRON_JOB_9);
-        assertThat(cronJobInfoPageData.getData()).contains(CRON_JOB_3);
+        ids = cronJobInfoPageData.getData().stream().map(CronJobInfoDTO::getId).collect(Collectors.toSet());
+        assertThat(ids).contains(CRON_JOB_9.getId());
+        assertThat(ids).contains(CRON_JOB_3.getId());
         System.out.println(cronJobInfoPageData.getData());
         baseSearchCondition.setStart(0);
 
@@ -437,8 +441,9 @@ public class CronJobDAOImplIntegrationTest {
         assertThat(cronJobInfoPageData.getStart()).isEqualTo(0);
         assertThat(cronJobInfoPageData.getPageSize()).isEqualTo(2);
         assertThat(cronJobInfoPageData.getTotal()).isEqualTo(4);
-        assertThat(cronJobInfoPageData.getData()).contains(CRON_JOB_9);
-        assertThat(cronJobInfoPageData.getData()).contains(CRON_JOB_3);
+        ids = cronJobInfoPageData.getData().stream().map(CronJobInfoDTO::getId).collect(Collectors.toSet());
+        assertThat(ids).contains(CRON_JOB_9.getId());
+        assertThat(ids).contains(CRON_JOB_3.getId());
         System.out.println(cronJobInfoPageData.getData());
         baseSearchCondition.setOrder(0);
     }

--- a/src/backend/job-crontab/boot-job-crontab/src/test/java/com/tencent/bk/job/crontab/dao/impl/CronJobDAOImplIntegrationTest.java
+++ b/src/backend/job-crontab/boot-job-crontab/src/test/java/com/tencent/bk/job/crontab/dao/impl/CronJobDAOImplIntegrationTest.java
@@ -415,7 +415,7 @@ public class CronJobDAOImplIntegrationTest {
         baseSearchCondition.setOrderField("last_modify_user");
         baseSearchCondition.setCreator(CRON_JOB_1.getCreator());
         PageData<CronJobInfoDTO> cronJobInfoPageData =
-            cronJobDAO.listPageCronJobsByCondition(cronJobCondition, baseSearchCondition);
+            cronJobDAO.listPageCronJobsWithoutVarsByCondition(cronJobCondition, baseSearchCondition);
         assertThat(cronJobInfoPageData.getStart()).isEqualTo(0);
         assertThat(cronJobInfoPageData.getPageSize()).isEqualTo(2);
         assertThat(cronJobInfoPageData.getTotal()).isEqualTo(4);
@@ -423,7 +423,7 @@ public class CronJobDAOImplIntegrationTest {
         assertThat(cronJobInfoPageData.getData()).contains(CRON_JOB_1);
 
         baseSearchCondition.setStart(2);
-        cronJobInfoPageData = cronJobDAO.listPageCronJobsByCondition(cronJobCondition, baseSearchCondition);
+        cronJobInfoPageData = cronJobDAO.listPageCronJobsWithoutVarsByCondition(cronJobCondition, baseSearchCondition);
         assertThat(cronJobInfoPageData.getStart()).isEqualTo(2);
         assertThat(cronJobInfoPageData.getPageSize()).isEqualTo(2);
         assertThat(cronJobInfoPageData.getTotal()).isEqualTo(4);
@@ -433,7 +433,7 @@ public class CronJobDAOImplIntegrationTest {
         baseSearchCondition.setStart(0);
 
         baseSearchCondition.setOrder(1);
-        cronJobInfoPageData = cronJobDAO.listPageCronJobsByCondition(cronJobCondition, baseSearchCondition);
+        cronJobInfoPageData = cronJobDAO.listPageCronJobsWithoutVarsByCondition(cronJobCondition, baseSearchCondition);
         assertThat(cronJobInfoPageData.getStart()).isEqualTo(0);
         assertThat(cronJobInfoPageData.getPageSize()).isEqualTo(2);
         assertThat(cronJobInfoPageData.getTotal()).isEqualTo(4);

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/api/esb/impl/EsbCronJobResourceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/api/esb/impl/EsbCronJobResourceImpl.java
@@ -120,7 +120,7 @@ public class EsbCronJobResourceImpl implements EsbCronJobResource {
                         request.getLastModifyTimeEnd(), "yyyy-MM-dd", ChronoUnit.SECONDS, ZoneId.systemDefault()));
                 }
                 PageData<CronJobInfoDTO> cronJobInfoPageData =
-                    cronJobService.listPageCronJobInfos(cronJobCondition, baseSearchCondition);
+                    cronJobService.listPageCronJobInfosWithoutVars(cronJobCondition, baseSearchCondition);
                 return EsbResp.buildSuccessResp(cronJobInfoPageData.getData().stream()
                     .map(CronJobInfoDTO::toEsbCronInfo).collect(Collectors.toList()));
             }

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/api/esb/v3/impl/EsbCronJobV3ResourceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/api/esb/v3/impl/EsbCronJobV3ResourceImpl.java
@@ -191,7 +191,7 @@ public class EsbCronJobV3ResourceImpl implements EsbCronJobV3Resource {
                     baseSearchCondition.setLastModifyTimeStart(request.getLastModifyTimeStart());
                     baseSearchCondition.setLastModifyTimeEnd(request.getLastModifyTimeEnd());
                 }
-                PageData<CronJobInfoDTO> cronJobInfoPageData = cronJobService.listPageCronJobInfos(cronJobCondition,
+                PageData<CronJobInfoDTO> cronJobInfoPageData = cronJobService.listPageCronJobInfosWithoutVars(cronJobCondition,
                     baseSearchCondition);
                 List<EsbCronInfoV3DTO> cronInfoV3ResponseData = cronJobInfoPageData.getData().stream()
                     .peek(cronJobInfoDTO -> cronJobInfoDTO.setVariableValue(null))

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/api/iam/impl/IamCronCallbackResourceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/api/iam/impl/IamCronCallbackResourceImpl.java
@@ -100,7 +100,7 @@ public class IamCronCallbackResourceImpl extends BaseIamCallbackService implemen
 
         cronJobQuery.setName(callbackRequest.getFilter().getKeyword());
         PageData<CronJobInfoDTO> cronJobInfoPageData =
-            cronJobService.listPageCronJobInfos(cronJobQuery, baseSearchCondition);
+            cronJobService.listPageCronJobInfosWithoutVars(cronJobQuery, baseSearchCondition);
 
         return IamRespUtil.getSearchInstanceRespFromPageData(cronJobInfoPageData, this::convert);
     }
@@ -114,7 +114,7 @@ public class IamCronCallbackResourceImpl extends BaseIamCallbackService implemen
         BaseSearchCondition baseSearchCondition = basicQueryCond.getRight();
 
         PageData<CronJobInfoDTO> cronJobInfoPageData =
-            cronJobService.listPageCronJobInfos(cronJobQuery, baseSearchCondition);
+            cronJobService.listPageCronJobInfosWithoutVars(cronJobQuery, baseSearchCondition);
 
         return IamRespUtil.getListInstanceRespFromPageData(cronJobInfoPageData, this::convert);
     }

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/api/inner/impl/ServiceCronJobResourceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/api/inner/impl/ServiceCronJobResourceImpl.java
@@ -76,7 +76,7 @@ public class ServiceCronJobResourceImpl implements ServiceCronJobResource {
         BaseSearchCondition baseSearchCondition = new BaseSearchCondition();
         baseSearchCondition.setStart(0);
         baseSearchCondition.setLength(Integer.MAX_VALUE);
-        List<CronJobInfoDTO> cronJobDTOList = cronJobService.listPageCronJobInfos(cronJobInfoDTO,
+        List<CronJobInfoDTO> cronJobDTOList = cronJobService.listPageCronJobInfosWithoutVars(cronJobInfoDTO,
             baseSearchCondition).getData();
         List<ServiceCronJobDTO> resultData = cronJobDTOList.stream()
             .map(CronJobInfoDTO::toServiceCronJobDTO).collect(Collectors.toList());

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/api/web/impl/WebCronJobResourceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/api/web/impl/WebCronJobResourceImpl.java
@@ -130,7 +130,7 @@ public class WebCronJobResourceImpl implements WebCronJobResource {
         }
         baseSearchCondition.setOrder(order);
         PageData<CronJobInfoDTO> cronJobInfoPageData =
-            cronJobService.listPageCronJobInfos(cronJobCondition, baseSearchCondition);
+            cronJobService.listPageCronJobInfosWithoutVars(cronJobCondition, baseSearchCondition);
         List<CronJobVO> resultCronJobs = new ArrayList<>();
         cronJobInfoPageData.getData().forEach(cronJobInfo -> resultCronJobs.add(CronJobInfoDTO.toVO(cronJobInfo)));
 

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/dao/CronJobDAO.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/dao/CronJobDAO.java
@@ -49,14 +49,14 @@ public interface CronJobDAO {
     List<CronJobWithVarsDTO> listBasicCronJobWithHostVars(List<Long> appIdList, int start, int limit);
 
     /**
-     * 根据业务 ID 列表批量查询定时任务信息
+     * 根据业务 ID 列表批量查询定时任务信息（不含变量）
      *
      * @param cronJobCondition    查询参数
      * @param baseSearchCondition 分页信息
      * @return 分页的定时任务信息列表
      */
-    PageData<CronJobInfoDTO> listPageCronJobsByCondition(CronJobInfoDTO cronJobCondition,
-                                                         BaseSearchCondition baseSearchCondition);
+    PageData<CronJobInfoDTO> listPageCronJobsWithoutVarsByCondition(CronJobInfoDTO cronJobCondition,
+                                                                    BaseSearchCondition baseSearchCondition);
 
     /**
      * 根据定时任务 ID 查询定时任务信息

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/dao/impl/CronJobDAOImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/dao/impl/CronJobDAOImpl.java
@@ -45,6 +45,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.OrderField;
+import org.jooq.Record;
 import org.jooq.Record1;
 import org.jooq.Record21;
 import org.jooq.Record3;
@@ -117,8 +118,8 @@ public class CronJobDAOImpl implements CronJobDAO {
     }
 
     @Override
-    public PageData<CronJobInfoDTO> listPageCronJobsByCondition(CronJobInfoDTO cronJobCondition,
-                                                                BaseSearchCondition baseSearchCondition) {
+    public PageData<CronJobInfoDTO> listPageCronJobsWithoutVarsByCondition(CronJobInfoDTO cronJobCondition,
+                                                                           BaseSearchCondition baseSearchCondition) {
         List<Condition> conditions = buildConditionList(cronJobCondition, baseSearchCondition);
         long templateCount = getPageCronJobCount(conditions);
         List<OrderField<?>> orderFields = new ArrayList<>();
@@ -143,17 +144,35 @@ public class CronJobDAOImpl implements CronJobDAO {
         int start = baseSearchCondition.getStartOrDefault(0);
         int length = baseSearchCondition.getLengthOrDefault(10);
 
-        Result<Record21<ULong, ULong, String, String, ULong, ULong, String, ULong, String, ULong, String, UByte, UByte,
-            UByte, ULong, String, ULong, ULong, ULong, String, String>> records =
-            context
-                .select(TABLE.ID, TABLE.APP_ID, TABLE.NAME, TABLE.CREATOR, TABLE.TASK_TEMPLATE_ID,
-                    TABLE.TASK_PLAN_ID, TABLE.SCRIPT_ID, TABLE.SCRIPT_VERSION_ID, TABLE.CRON_EXPRESSION,
-                    TABLE.EXECUTE_TIME, TABLE.VARIABLE_VALUE, TABLE.LAST_EXECUTE_STATUS, TABLE.IS_ENABLE,
-                    TABLE.IS_DELETED, TABLE.CREATE_TIME, TABLE.LAST_MODIFY_USER, TABLE.LAST_MODIFY_TIME,
-                    TABLE.END_TIME, TABLE.NOTIFY_OFFSET, TABLE.NOTIFY_USER, TABLE.NOTIFY_CHANNEL)
-                .from(TABLE).where(conditions).orderBy(orderFields).limit(start, length).fetch();
+        Result<?> records =
+            context.select(
+                    TABLE.ID,
+                    TABLE.APP_ID,
+                    TABLE.NAME,
+                    TABLE.CREATOR,
+                    TABLE.TASK_TEMPLATE_ID,
+                    TABLE.TASK_PLAN_ID,
+                    TABLE.SCRIPT_ID,
+                    TABLE.SCRIPT_VERSION_ID,
+                    TABLE.CRON_EXPRESSION,
+                    TABLE.EXECUTE_TIME,
+                    TABLE.LAST_EXECUTE_STATUS,
+                    TABLE.IS_ENABLE,
+                    TABLE.IS_DELETED,
+                    TABLE.CREATE_TIME,
+                    TABLE.LAST_MODIFY_USER,
+                    TABLE.LAST_MODIFY_TIME,
+                    TABLE.END_TIME,
+                    TABLE.NOTIFY_OFFSET,
+                    TABLE.NOTIFY_USER,
+                    TABLE.NOTIFY_CHANNEL
+                ).from(TABLE)
+                .where(conditions)
+                .orderBy(orderFields)
+                .limit(start, length)
+                .fetch();
         List<CronJobInfoDTO> cronJobInfoList = new ArrayList<>();
-        if (records.size() >= 1) {
+        if (!records.isEmpty()) {
             records.map(record -> cronJobInfoList.add(convertToCronJobDTO(record)));
         }
         PageData<CronJobInfoDTO> cronJobInfoPageData = new PageData<>();
@@ -568,8 +587,7 @@ public class CronJobDAOImpl implements CronJobDAO {
         return cronJobIds.stream().map(ULong::longValue).collect(Collectors.toList());
     }
 
-    private CronJobInfoDTO convertToCronJobDTO(Record21<ULong, ULong, String, String, ULong, ULong, String, ULong,
-        String, ULong, String, UByte, UByte, UByte, ULong, String, ULong, ULong, ULong, String, String> record) {
+    private CronJobInfoDTO convertToCronJobDTO(Record record) {
         if (record == null) {
             return null;
         }
@@ -590,7 +608,9 @@ public class CronJobDAOImpl implements CronJobDAO {
         }
         cronJobInfoDTO.setCronExpression(record.get(TABLE.CRON_EXPRESSION));
         cronJobInfoDTO.setExecuteTime(DbUtils.convertJooqLongValue(record.get(TABLE.EXECUTE_TIME)));
-        cronJobInfoDTO.decryptAndSetVariableValue(record.get(TABLE.VARIABLE_VALUE));
+        if (record.indexOf(TABLE.VARIABLE_VALUE) != -1) {
+            cronJobInfoDTO.decryptAndSetVariableValue(record.get(TABLE.VARIABLE_VALUE));
+        }
         standardizeDynamicGroupId(cronJobInfoDTO.getVariableValue());
         cronJobInfoDTO.setLastExecuteStatus(record.get(TABLE.LAST_EXECUTE_STATUS).intValue());
         cronJobInfoDTO.setEnable(record.get(TABLE.IS_ENABLE).intValue() == 1);

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/CronJobInfoDTO.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/CronJobInfoDTO.java
@@ -202,11 +202,9 @@ public class CronJobInfoDTO extends EncryptEnableVariables {
             cronJobVO.setCronExpression(null);
         }
         cronJobVO.setExecuteTime(cronJobInfo.getExecuteTime());
-        if (CollectionUtils.isNotEmpty(cronJobInfo.getVariableValue())) {
+        if (cronJobInfo.getVariableValue() != null) {
             cronJobVO.setVariableValue(cronJobInfo.getVariableValue().stream().map(CronJobVariableDTO::toVO)
                 .collect(Collectors.toList()));
-        } else {
-            cronJobVO.setVariableValue(Collections.emptyList());
         }
         cronJobVO.setLastExecuteStatus(cronJobInfo.getLastExecuteStatus());
         cronJobVO.setLastExecuteErrorCode(cronJobInfo.getLastExecuteErrorCode());

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/CronJobInfoDTO.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/CronJobInfoDTO.java
@@ -585,12 +585,6 @@ public class CronJobInfoDTO extends EncryptEnableVariables {
         cronJob.setScriptVersionId(scriptVersionId);
         cronJob.setCronExpression(cronExpression);
         cronJob.setExecuteTime(executeTime);
-        if (CollectionUtils.isNotEmpty(variableValue)) {
-            cronJob.setVariableValue(variableValue.stream().map(CronJobVariableDTO::toServiceCronJobVariableDTO)
-                .collect(Collectors.toList()));
-        } else {
-            cronJob.setVariableValue(Collections.emptyList());
-        }
         cronJob.setLastExecuteStatus(lastExecuteStatus);
         cronJob.setEnable(enable);
         cronJob.setLastModifyUser(lastModifyUser);

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/CronJobVariableDTO.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/CronJobVariableDTO.java
@@ -31,7 +31,6 @@ import com.tencent.bk.job.common.esb.model.job.v3.EsbGlobalVarV3DTO;
 import com.tencent.bk.job.common.exception.InvalidParamException;
 import com.tencent.bk.job.crontab.model.CronJobVariableVO;
 import com.tencent.bk.job.crontab.model.inner.ServerDTO;
-import com.tencent.bk.job.crontab.model.inner.ServiceCronJobVariableDTO;
 import com.tencent.bk.job.execute.model.inner.ServiceTaskVariable;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -144,16 +143,6 @@ public class CronJobVariableDTO implements Cloneable {
         esbGlobalVar.setValue(cronJobVariableDTO.getValue());
         esbGlobalVar.setServer(ServerDTO.toEsbServerV3(cronJobVariableDTO.getServer()));
         return esbGlobalVar;
-    }
-
-    public ServiceCronJobVariableDTO toServiceCronJobVariableDTO() {
-        ServiceCronJobVariableDTO variable = new ServiceCronJobVariableDTO();
-        variable.setId(id);
-        variable.setName(name);
-        variable.setType(type);
-        variable.setValue(value);
-        variable.setServer(server);
-        return variable;
     }
 
     @SuppressWarnings("MethodDoesntCallSuperMethod")

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/CronJobService.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/CronJobService.java
@@ -41,14 +41,14 @@ import java.util.Map;
  */
 public interface CronJobService {
     /**
-     * 分页查询定时任务列表
+     * 分页查询定时任务列表（不含变量）
      *
      * @param cronJobCondition    查询条件
      * @param baseSearchCondition 搜索参数
      * @return 分页后的定时任务列表
      */
-    PageData<CronJobInfoDTO> listPageCronJobInfos(CronJobInfoDTO cronJobCondition,
-                                                  BaseSearchCondition baseSearchCondition);
+    PageData<CronJobInfoDTO> listPageCronJobInfosWithoutVars(CronJobInfoDTO cronJobCondition,
+                                                             BaseSearchCondition baseSearchCondition);
 
     /**
      * 根据 ID 查询定时任务信息

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobServiceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobServiceImpl.java
@@ -148,9 +148,9 @@ public class CronJobServiceImpl implements CronJobService {
     }
 
     @Override
-    public PageData<CronJobInfoDTO> listPageCronJobInfos(CronJobInfoDTO cronJobCondition,
-                                                         BaseSearchCondition baseSearchCondition) {
-        return cronJobDAO.listPageCronJobsByCondition(cronJobCondition, baseSearchCondition);
+    public PageData<CronJobInfoDTO> listPageCronJobInfosWithoutVars(CronJobInfoDTO cronJobCondition,
+                                                                    BaseSearchCondition baseSearchCondition) {
+        return cronJobDAO.listPageCronJobsWithoutVarsByCondition(cronJobCondition, baseSearchCondition);
     }
 
     @Override
@@ -279,7 +279,7 @@ public class CronJobServiceImpl implements CronJobService {
         return updateCron;
     }
 
-    private void authExecuteTask(CronJobInfoDTO cronJobInfo){
+    private void authExecuteTask(CronJobInfoDTO cronJobInfo) {
         try {
             List<ServiceTaskVariable> taskVariables = null;
             if (CollectionUtils.isNotEmpty(cronJobInfo.getVariableValue())) {


### PR DESCRIPTION
合入条件：依赖的前端代码改造需要同时合入。
1.列表接口去除变量信息；
2.详情接口已存在：/web/scope/{scopeType}/{scopeId}/cron/job/{cronJobId}。