### PR TITLE
perf: 作业执行历史归档优化 #3294

### DIFF
--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractJobInstanceArchiveTask.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractJobInstanceArchiveTask.java
@@ -27,7 +27,7 @@ package com.tencent.bk.job.backup.archive;
 import com.tencent.bk.job.backup.archive.dao.JobInstanceColdDAO;
 import com.tencent.bk.job.backup.archive.dao.impl.AbstractJobInstanceMainHotRecordDAO;
 import com.tencent.bk.job.backup.archive.model.ArchiveTaskContext;
-import com.tencent.bk.job.backup.archive.model.ArchiveTaskSummary;
+import com.tencent.bk.job.backup.archive.model.ArchiveTaskExecutionDetail;
 import com.tencent.bk.job.backup.archive.model.JobInstanceArchiveTaskInfo;
 import com.tencent.bk.job.backup.archive.model.TimeAndIdBasedArchiveProcess;
 import com.tencent.bk.job.backup.archive.service.ArchiveTaskService;
@@ -36,9 +36,11 @@ import com.tencent.bk.job.backup.config.ArchiveProperties;
 import com.tencent.bk.job.backup.constant.ArchiveModeEnum;
 import com.tencent.bk.job.backup.constant.ArchiveTaskStatusEnum;
 import com.tencent.bk.job.backup.metrics.ArchiveErrorTaskCounter;
+import com.tencent.bk.job.common.util.StringUtil;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jooq.TableRecord;
 import org.slf4j.helpers.MessageFormatter;
 
@@ -76,8 +78,6 @@ public abstract class AbstractJobInstanceArchiveTask<T extends TableRecord<?>> i
      * 归档进度
      */
     private TimeAndIdBasedArchiveProcess progress;
-
-    private final ArchiveTaskSummary archiveTaskSummary;
 
     private boolean isAcquireLock;
     /**
@@ -122,7 +122,6 @@ public abstract class AbstractJobInstanceArchiveTask<T extends TableRecord<?>> i
         this.archiveTablePropsStorage = archiveTablePropsStorage;
         this.progress = archiveTaskInfo.getProcess();
         this.taskId = archiveTaskInfo.buildTaskUniqueId();
-        this.archiveTaskSummary = new ArchiveTaskSummary(archiveTaskInfo, archiveProperties.getMode());
     }
 
     @Override
@@ -182,12 +181,12 @@ public abstract class AbstractJobInstanceArchiveTask<T extends TableRecord<?>> i
 
             // 获取分布式锁
             if (!acquireLock()) {
-                archiveTaskSummary.setSkip(!isAcquireLock);
                 return;
             }
 
             log.info("[{}] Start archive task", taskId);
-            updateArchiveTask(ArchiveTaskStatusEnum.RUNNING, null);
+            // 更新任务信息 - 启动完成
+            updateStartedExecuteInfo();
             // 归档
             backupAndDelete();
         } catch (Throwable e) {
@@ -196,12 +195,11 @@ public abstract class AbstractJobInstanceArchiveTask<T extends TableRecord<?>> i
                 taskId
             ).getMessage();
             log.error(msg, e);
-            archiveTaskSummary.setMessage(e.getMessage());
-
+            updateArchiveTaskExecutionDetail(null, null, e.getMessage());
             archiveErrorTaskCounter.increment();
 
             // 更新归档任务状态
-            updateArchiveTask(ArchiveTaskStatusEnum.FAIL, null);
+            updateCompletedExecuteInfo(ArchiveTaskStatusEnum.FAIL, null, null);
         } finally {
             if (this.isAcquireLock) {
                 archiveTaskExecuteLock.unlock(taskId);
@@ -209,7 +207,7 @@ public abstract class AbstractJobInstanceArchiveTask<T extends TableRecord<?>> i
             log.info(
                 "[{}] Archive finished, result: {}",
                 taskId,
-                JsonUtils.toJson(archiveTaskSummary)
+                JsonUtils.toJson(archiveTaskInfo)
             );
             if (archiveTaskDoneCallback != null) {
                 archiveTaskDoneCallback.callback();
@@ -241,7 +239,7 @@ public abstract class AbstractJobInstanceArchiveTask<T extends TableRecord<?>> i
 
                 jobInstanceRecords = readJobInstanceRecords(readLimit);
                 if (CollectionUtils.isEmpty(jobInstanceRecords)) {
-                    updateArchiveTask(ArchiveTaskStatusEnum.SUCCESS, null);
+                    updateCompletedExecuteInfo(ArchiveTaskStatusEnum.SUCCESS, null, null);
                     return;
                 }
                 archivedJobInstanceCount += jobInstanceRecords.size();
@@ -268,14 +266,34 @@ public abstract class AbstractJobInstanceArchiveTask<T extends TableRecord<?>> i
                 T lastRecord = jobInstanceRecords.get(jobInstanceRecords.size() - 1);
                 Long lastTimestamp = extractJobInstanceCreateTime(lastRecord);
                 Long lastJobInstanceId = extractJobInstanceId(lastRecord);
-                progress = new TimeAndIdBasedArchiveProcess(lastTimestamp, lastJobInstanceId);
+                TimeAndIdBasedArchiveProcess progress =
+                    new TimeAndIdBasedArchiveProcess(lastTimestamp, lastJobInstanceId);
                 boolean isFinished = jobInstanceRecords.size() < readLimit;
-                updateArchiveTask(isFinished ? ArchiveTaskStatusEnum.SUCCESS : ArchiveTaskStatusEnum.RUNNING, progress);
+                if (isFinished) {
+                    // 更新任务结束信息
+                    updateCompletedExecuteInfo(ArchiveTaskStatusEnum.SUCCESS, progress, null);
+                } else {
+                    // 更新任务运行信息
+                    updateRunningExecuteInfo(progress);
+                }
             } while (jobInstanceRecords.size() == readLimit);
         } finally {
             long archiveCost = System.currentTimeMillis() - startTime;
-            archiveTaskSummary.setArchivedRecordSize(archivedJobInstanceCount);
-            archiveTaskSummary.setArchiveCost(archiveCost);
+            updateArchiveTaskExecutionDetail(archivedJobInstanceCount, archiveCost, null);
+        }
+    }
+
+    private void updateArchiveTaskExecutionDetail(Long archiveRecordSize,
+                                                  Long costTime,
+                                                  String errorMsg) {
+        if (archiveRecordSize != null) {
+            archiveTaskInfo.getDetail().setArchivedRecordSize(archiveRecordSize);
+        }
+        if (costTime != null) {
+            archiveTaskInfo.getDetail().setCostTime(costTime);
+        }
+        if (StringUtils.isNotEmpty(errorMsg)) {
+            archiveTaskInfo.getDetail().setErrorMsg(StringUtil.substring(errorMsg, 10240));
         }
     }
 
@@ -327,25 +345,77 @@ public abstract class AbstractJobInstanceArchiveTask<T extends TableRecord<?>> i
         return isAcquireLock;
     }
 
-    private void updateArchiveTask(ArchiveTaskStatusEnum status,
-                                   TimeAndIdBasedArchiveProcess progress) {
-        if (status != null) {
-            archiveTaskInfo.setStatus(status);
+
+    private void updateStartedExecuteInfo() {
+        if (!checkUpdateEnabled()) {
+            return;
         }
-        if (progress != null) {
-            archiveTaskInfo.setProcess(progress);
-        }
+        Long startTime = System.currentTimeMillis();
+        archiveTaskInfo.setTaskStartTime(startTime);
+        archiveTaskService.updateStartedExecuteInfo(
+            archiveTaskInfo.getTaskType(),
+            archiveTaskInfo.getDbDataNode(),
+            archiveTaskInfo.getDay(),
+            archiveTaskInfo.getHour(),
+            startTime
+        );
+    }
+
+    private boolean checkUpdateEnabled() {
         if (forceStoppedByScheduler.get()) {
             // 如果已经被归档任务调度强制终止了，就不能再去更新 db，引起数据不一致
             log.info("[{}] Archive task is force stopped by scheduler, do not update archive task again", taskId);
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    private void updateRunningExecuteInfo(TimeAndIdBasedArchiveProcess process) {
+        this.progress = progress;
+        archiveTaskInfo.setProcess(process);
+
+        if (!checkUpdateEnabled()) {
             return;
         }
 
-        if (archiveTaskInfo.getStatus() != ArchiveTaskStatusEnum.RUNNING) {
-            log.info("[{}] Update archive task, taskStatus: {}, process: {}",
-                taskId, archiveTaskInfo.getStatus(), progress);
+        archiveTaskService.updateRunningExecuteInfo(
+            archiveTaskInfo.getTaskType(),
+            archiveTaskInfo.getDbDataNode(),
+            archiveTaskInfo.getDay(),
+            archiveTaskInfo.getHour(),
+            process
+        );
+    }
+
+    private void updateCompletedExecuteInfo(ArchiveTaskStatusEnum status,
+                                            TimeAndIdBasedArchiveProcess process,
+                                            ArchiveTaskExecutionDetail detail) {
+        archiveTaskInfo.setStatus(status);
+        if (process != null) {
+            archiveTaskInfo.setProcess(process);
         }
-        archiveTaskService.updateTask(archiveTaskInfo);
+        archiveTaskInfo.setDetail(detail);
+        archiveTaskInfo.setTaskEndTime(System.currentTimeMillis());
+        archiveTaskInfo.setTaskCost(archiveTaskInfo.getTaskEndTime() - archiveTaskInfo.getTaskStartTime());
+
+        if (!checkUpdateEnabled()) {
+            return;
+        }
+
+        archiveTaskService.updateCompletedExecuteInfo(
+            archiveTaskInfo.getTaskType(),
+            archiveTaskInfo.getDbDataNode(),
+            archiveTaskInfo.getDay(),
+            archiveTaskInfo.getHour(),
+            archiveTaskInfo.getStatus(),
+            archiveTaskInfo.getProcess(),
+            archiveTaskInfo.getTaskEndTime(),
+            archiveTaskInfo.getTaskCost(),
+            archiveTaskInfo.getDetail()
+        );
+
+
     }
 
     @Override

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractJobInstanceArchiveTask.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractJobInstanceArchiveTask.java
@@ -148,7 +148,7 @@ public abstract class AbstractJobInstanceArchiveTask<T extends TableRecord<?>> i
             if (!isStopped) {
                 isStopped = true;
                 // 更新归档任务状态为暂停，用于后续调度
-                archiveTaskService.updateArchiveTaskSuspendedStatus(archiveTaskInfo);
+                updateArchiveTaskSuspended();
                 if (stopCallback != null) {
                     stopCallback.callback();
                 }
@@ -159,12 +159,23 @@ public abstract class AbstractJobInstanceArchiveTask<T extends TableRecord<?>> i
         }
     }
 
+    private void updateArchiveTaskSuspended() {
+        archiveTaskInfo.setStatus(ArchiveTaskStatusEnum.SUSPENDED);
+        archiveTaskService.updateArchiveTaskStatus(
+            archiveTaskInfo.getTaskType(),
+            archiveTaskInfo.getDbDataNode(),
+            archiveTaskInfo.getDay(),
+            archiveTaskInfo.getHour(),
+            ArchiveTaskStatusEnum.SUSPENDED
+        );
+    }
+
     @Override
     public void forceStopAtOnce() {
         log.info("Force stop archive task at once. taskId: {}", taskId);
         forceStoppedByScheduler.set(true);
         // 更新归档任务状态为“暂停”
-        archiveTaskService.updateArchiveTaskSuspendedStatus(archiveTaskInfo);
+        updateArchiveTaskSuspended();
         // 打断当前线程，退出执行
         archiveTaskWorker.interrupt();
     }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/FailArchiveTaskReScheduler.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/FailArchiveTaskReScheduler.java
@@ -1,0 +1,120 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.backup.archive;
+
+import com.tencent.bk.job.backup.archive.model.JobInstanceArchiveTaskInfo;
+import com.tencent.bk.job.backup.archive.service.ArchiveTaskService;
+import com.tencent.bk.job.backup.archive.util.lock.FailedArchiveTaskRescheduleLock;
+import com.tencent.bk.job.backup.constant.ArchiveTaskStatusEnum;
+import com.tencent.bk.job.backup.constant.ArchiveTaskTypeEnum;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.List;
+
+/**
+ * 失败归档任务重调度
+ */
+@Slf4j
+public class FailArchiveTaskReScheduler {
+
+    private final ArchiveTaskService archiveTaskService;
+
+    private final FailedArchiveTaskRescheduleLock failedArchiveTaskRescheduleLock;
+
+
+    public FailArchiveTaskReScheduler(ArchiveTaskService archiveTaskService,
+                                      FailedArchiveTaskRescheduleLock failedArchiveTaskRescheduleLock) {
+        this.archiveTaskService = archiveTaskService;
+        this.failedArchiveTaskRescheduleLock = failedArchiveTaskRescheduleLock;
+    }
+
+    /**
+     * 重新调度失败任务
+     */
+    public void rescheduleFailedArchiveTasks() {
+        boolean locked = false;
+        try {
+            locked = failedArchiveTaskRescheduleLock.lock();
+            if (locked) {
+                // 处理失败的任务
+                reScheduleFailedTasks();
+                // 处理超时未结束的任务
+                reScheduleTimeoutTasks();
+            }
+        } finally {
+            if (locked) {
+                failedArchiveTaskRescheduleLock.unlock();
+            }
+        }
+    }
+
+    private void reScheduleFailedTasks() {
+        int readLimit = 100;
+        List<JobInstanceArchiveTaskInfo> failedTasks;
+        do {
+            failedTasks =
+                archiveTaskService.listTasks(ArchiveTaskTypeEnum.JOB_INSTANCE, ArchiveTaskStatusEnum.FAIL,
+                    readLimit);
+            if (CollectionUtils.isEmpty(failedTasks)) {
+                return;
+            }
+            // 设置为 pending 状态，会被重新调度
+            failedTasks.forEach(failTask -> {
+                log.info("Set archive task status to pending, taskId : {}", failTask.buildTaskUniqueId());
+                archiveTaskService.updateArchiveTaskStatus(
+                    failTask.getTaskType(),
+                    failTask.getDbDataNode(),
+                    failTask.getDay(),
+                    failTask.getHour(),
+                    ArchiveTaskStatusEnum.PENDING
+                );
+            });
+        } while (failedTasks.size() == readLimit);
+    }
+
+    private void reScheduleTimeoutTasks() {
+        List<JobInstanceArchiveTaskInfo> runningTasks =
+            archiveTaskService.listRunningTasks(ArchiveTaskTypeEnum.JOB_INSTANCE);
+        if (CollectionUtils.isEmpty(runningTasks)) {
+            return;
+        }
+        runningTasks.forEach(runningTask -> {
+            // 如果归档任务没有正常结束，通过当前时间减去任务创建时间计算执行时长，判断是否超过合理的执行时长
+            if (System.currentTimeMillis() - runningTask.getCreateTime() > 3 * 86400 * 1000L) {
+                log.info("Found timeout archive task, try to reschedule. taskId: {}",
+                    runningTask.buildTaskUniqueId());
+                // 设置为 pending 状态，会被重新调度
+                archiveTaskService.updateArchiveTaskStatus(
+                    runningTask.getTaskType(),
+                    runningTask.getDbDataNode(),
+                    runningTask.getDay(),
+                    runningTask.getHour(),
+                    ArchiveTaskStatusEnum.PENDING
+                );
+            }
+        });
+    }
+}

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceArchiveCronJobs.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceArchiveCronJobs.java
@@ -51,9 +51,9 @@ public class JobInstanceArchiveCronJobs {
     }
 
     /**
-     * 定时创建归档任务,每天 0 点触发一次
+     * 定时创建归档任务,每小时 0 分钟 触发一次（正常情况一天触发一次即可；为了保障异常情况下任务有一定频率的重试机会）
      */
-    @Scheduled(cron = "0 * * * * *")
+    @Scheduled(cron = "0 0 * * * *")
     public void generateArchiveTask() {
         if (!archiveProperties.isEnabled()) {
             return;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceArchiveCronJobs.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceArchiveCronJobs.java
@@ -42,12 +42,16 @@ public class JobInstanceArchiveCronJobs {
 
     private final ArchiveProperties archiveProperties;
 
+    private final FailArchiveTaskReScheduler failArchiveTaskReScheduler;
+
     public JobInstanceArchiveCronJobs(JobInstanceArchiveTaskGenerator jobInstanceArchiveTaskGenerator,
                                       JobInstanceArchiveTaskScheduler jobInstanceArchiveTaskScheduler,
-                                      ArchiveProperties archiveProperties) {
+                                      ArchiveProperties archiveProperties,
+                                      FailArchiveTaskReScheduler failArchiveTaskReScheduler) {
         this.jobInstanceArchiveTaskGenerator = jobInstanceArchiveTaskGenerator;
         this.jobInstanceArchiveTaskScheduler = jobInstanceArchiveTaskScheduler;
         this.archiveProperties = archiveProperties;
+        this.failArchiveTaskReScheduler = failArchiveTaskReScheduler;
     }
 
     /**
@@ -74,5 +78,18 @@ public class JobInstanceArchiveCronJobs {
         log.info("Schedule and execute archive task start...");
         jobInstanceArchiveTaskScheduler.schedule();
         log.info("Schedule and execute archive task done");
+    }
+
+    /**
+     * 失败归档任务重调度，每小时触发一次
+     */
+    @Scheduled(cron = "0 59 * * * *")
+    public void scheduleFailedTasks() {
+        if (!archiveProperties.isEnabled()) {
+            return;
+        }
+        log.info("ReSchedule fail/timout archive task start...");
+        failArchiveTaskReScheduler.rescheduleFailedArchiveTasks();
+        log.info("ReSchedule fail/timeout archive task done");
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceArchiveCronJobs.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceArchiveCronJobs.java
@@ -42,16 +42,16 @@ public class JobInstanceArchiveCronJobs {
 
     private final ArchiveProperties archiveProperties;
 
-    private final FailArchiveTaskReScheduler failArchiveTaskReScheduler;
+    private final AbnormalArchiveTaskReScheduler abnormalArchiveTaskReScheduler;
 
     public JobInstanceArchiveCronJobs(JobInstanceArchiveTaskGenerator jobInstanceArchiveTaskGenerator,
                                       JobInstanceArchiveTaskScheduler jobInstanceArchiveTaskScheduler,
                                       ArchiveProperties archiveProperties,
-                                      FailArchiveTaskReScheduler failArchiveTaskReScheduler) {
+                                      AbnormalArchiveTaskReScheduler abnormalArchiveTaskReScheduler) {
         this.jobInstanceArchiveTaskGenerator = jobInstanceArchiveTaskGenerator;
         this.jobInstanceArchiveTaskScheduler = jobInstanceArchiveTaskScheduler;
         this.archiveProperties = archiveProperties;
-        this.failArchiveTaskReScheduler = failArchiveTaskReScheduler;
+        this.abnormalArchiveTaskReScheduler = abnormalArchiveTaskReScheduler;
     }
 
     /**
@@ -89,7 +89,7 @@ public class JobInstanceArchiveCronJobs {
             return;
         }
         log.info("ReSchedule fail/timout archive task start...");
-        failArchiveTaskReScheduler.rescheduleFailedArchiveTasks();
+        abnormalArchiveTaskReScheduler.rescheduleFailedArchiveTasks();
         log.info("ReSchedule fail/timeout archive task done");
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceArchiveTaskScheduler.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceArchiveTaskScheduler.java
@@ -338,4 +338,5 @@ public class JobInstanceArchiveTaskScheduler implements SmartLifecycle {
         }
     }
 
+
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceMainDataArchiveTask.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceMainDataArchiveTask.java
@@ -110,7 +110,7 @@ public class JobInstanceMainDataArchiveTask extends AbstractJobInstanceArchiveTa
         String tableName = jobInstanceMainRecordDAO.getTable().getName();
         int deleteRows = jobInstanceMainRecordDAO.deleteRecords(jobInstanceIds,
             archiveTablePropsStorage.getDeleteLimitRowCount(tableName));
-        ArchiveTaskContextHolder.get().accumulateTableBackup(
+        ArchiveTaskContextHolder.get().accumulateTableDelete(
             tableName,
             deleteRows,
             System.currentTimeMillis() - startTime

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceMainDataArchiveTask.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceMainDataArchiveTask.java
@@ -31,7 +31,6 @@ import com.tencent.bk.job.backup.archive.service.ArchiveTaskService;
 import com.tencent.bk.job.backup.archive.util.lock.ArchiveTaskExecuteLock;
 import com.tencent.bk.job.backup.config.ArchiveProperties;
 import com.tencent.bk.job.backup.metrics.ArchiveErrorTaskCounter;
-import com.tencent.bk.job.execute.model.tables.TaskInstance;
 import com.tencent.bk.job.execute.model.tables.records.TaskInstanceRecord;
 import lombok.extern.slf4j.Slf4j;
 
@@ -74,25 +73,47 @@ public class JobInstanceMainDataArchiveTask extends AbstractJobInstanceArchiveTa
         List<Long> jobInstanceIds =
             jobInstanceRecords.stream().map(this::extractJobInstanceId).collect(Collectors.toList());
         // 备份主表数据
-        jobInstanceColdDAO.batchInsert(jobInstanceRecords,
-            archiveTablePropsStorage.getBatchInsertRowSize(jobInstanceMainRecordDAO.getTable().getName()));
+        backupPrimaryTableRecord(jobInstanceRecords);
         // 备份子表数据
         jobInstanceSubTableArchivers.getAll().forEach(tableArchiver -> {
             tableArchiver.backupRecords(jobInstanceIds);
         });
     }
 
+    private void backupPrimaryTableRecord(List<TaskInstanceRecord> jobInstanceRecords) {
+        // 备份主表数据
+        long startTime = System.currentTimeMillis();
+        long backupRows = jobInstanceColdDAO.batchInsert(jobInstanceRecords,
+            archiveTablePropsStorage.getBatchInsertRowSize(jobInstanceMainRecordDAO.getTable().getName()));
+        ArchiveTaskContextHolder.get().accumulateTableBackup(
+            jobInstanceMainRecordDAO.getTable().getName(),
+            backupRows,
+            System.currentTimeMillis() - startTime
+        );
+    }
+
     @Override
     protected void deleteJobInstanceHotData(List<Long> jobInstanceIds) {
+        long startTime = System.currentTimeMillis();
         // 先删除子表数据
         jobInstanceSubTableArchivers.getAll().forEach(tableArchiver -> {
             tableArchiver.deleteRecords(jobInstanceIds);
         });
         // 删除主表数据
-        long startTime = System.currentTimeMillis();
-        jobInstanceMainRecordDAO.deleteRecords(jobInstanceIds,
-            archiveTablePropsStorage.getDeleteLimitRowCount(TaskInstance.TASK_INSTANCE.getName()));
+        deletePrimaryTableRecord(jobInstanceIds);
         log.info("Delete {}, taskInstanceIdSize: {}, cost: {}ms", "task_instance",
             jobInstanceIds.size(), System.currentTimeMillis() - startTime);
+    }
+
+    private void deletePrimaryTableRecord(List<Long> jobInstanceIds) {
+        long startTime = System.currentTimeMillis();
+        String tableName = jobInstanceMainRecordDAO.getTable().getName();
+        int deleteRows = jobInstanceMainRecordDAO.deleteRecords(jobInstanceIds,
+            archiveTablePropsStorage.getDeleteLimitRowCount(tableName));
+        ArchiveTaskContextHolder.get().accumulateTableBackup(
+            tableName,
+            deleteRows,
+            System.currentTimeMillis() - startTime
+        );
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/dao/ArchiveTaskDAO.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/dao/ArchiveTaskDAO.java
@@ -132,5 +132,6 @@ public interface ArchiveTaskDAO {
                                  Integer hour,
                                  ArchiveTaskStatusEnum status);
 
-    Map<ArchiveTaskStatusEnum, Integer> countTaskByStatus(ArchiveTaskTypeEnum taskType);
+    Map<ArchiveTaskStatusEnum, Integer> countTaskByStatus(ArchiveTaskTypeEnum taskType,
+                                                          List<ArchiveTaskStatusEnum> statusList);
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/dao/ArchiveTaskDAO.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/dao/ArchiveTaskDAO.java
@@ -24,7 +24,11 @@
 
 package com.tencent.bk.job.backup.archive.dao;
 
+import com.tencent.bk.job.backup.archive.model.ArchiveTaskExecutionDetail;
+import com.tencent.bk.job.backup.archive.model.DbDataNode;
 import com.tencent.bk.job.backup.archive.model.JobInstanceArchiveTaskInfo;
+import com.tencent.bk.job.backup.archive.model.TimeAndIdBasedArchiveProcess;
+import com.tencent.bk.job.backup.constant.ArchiveTaskStatusEnum;
 import com.tencent.bk.job.backup.constant.ArchiveTaskTypeEnum;
 
 import java.util.List;
@@ -54,12 +58,59 @@ public interface ArchiveTaskDAO {
      */
     Map<String, Integer> countScheduleTasksGroupByDb(ArchiveTaskTypeEnum taskType);
 
+
     /**
-     * 更新归档任务
+     * 更新归档任务执行信息 - 启动后
      *
-     * @param archiveTask 归档任务
+     * @param taskType  任务类型
+     * @param dataNode  数据节点
+     * @param day       归档数据所在天
+     * @param hour      归档数据所在小时
+     * @param startTime 任务开始时间
      */
-    void updateTask(JobInstanceArchiveTaskInfo archiveTask);
+    void updateStartedExecuteInfo(ArchiveTaskTypeEnum taskType,
+                                  DbDataNode dataNode,
+                                  Integer day,
+                                  Integer hour,
+                                  Long startTime);
+
+    /**
+     * 更新归档任务执行信息 - 运行中
+     *
+     * @param taskType 任务类型
+     * @param dataNode 数据节点
+     * @param day      归档数据所在天
+     * @param hour     归档数据所在小时
+     * @param process  进度
+     */
+    void updateRunningExecuteInfo(ArchiveTaskTypeEnum taskType,
+                                  DbDataNode dataNode,
+                                  Integer day,
+                                  Integer hour,
+                                  TimeAndIdBasedArchiveProcess process);
+
+    /**
+     * 更新归档任务执行信息 - 结束
+     *
+     * @param taskType 任务类型
+     * @param dataNode 数据节点
+     * @param day      归档数据所在天
+     * @param hour     归档数据所在小时
+     * @param status   任务状态
+     * @param process  进度
+     * @param endTime  结束时间
+     * @param cost     任务耗时
+     * @param detail   执行详情
+     */
+    void updateCompletedExecuteInfo(ArchiveTaskTypeEnum taskType,
+                                    DbDataNode dataNode,
+                                    Integer day,
+                                    Integer hour,
+                                    ArchiveTaskStatusEnum status,
+                                    TimeAndIdBasedArchiveProcess process,
+                                    Long endTime,
+                                    Long cost,
+                                    ArchiveTaskExecutionDetail detail);
 
     JobInstanceArchiveTaskInfo getFirstScheduleArchiveTaskByDb(ArchiveTaskTypeEnum taskType, String dbNodeId);
 

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/dao/ArchiveTaskDAO.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/dao/ArchiveTaskDAO.java
@@ -51,6 +51,18 @@ public interface ArchiveTaskDAO {
     List<JobInstanceArchiveTaskInfo> listRunningTasks(ArchiveTaskTypeEnum taskType);
 
     /**
+     * 获取归档任务
+     *
+     * @param taskType 查询条件 - 任务类型
+     * @param status   查询条件 - 任务状态
+     * @param limit    查询条件 - 查询最大数量
+     * @return 归档任务列表
+     */
+    List<JobInstanceArchiveTaskInfo> listTasks(ArchiveTaskTypeEnum taskType,
+                                               ArchiveTaskStatusEnum status,
+                                               int limit);
+
+    /**
      * 返回根据 db 分组的归档任务数量
      *
      * @param taskType 归档任务类型
@@ -114,10 +126,11 @@ public interface ArchiveTaskDAO {
 
     JobInstanceArchiveTaskInfo getFirstScheduleArchiveTaskByDb(ArchiveTaskTypeEnum taskType, String dbNodeId);
 
-    /**
-     * 设置归档任务状态为暂停
-     *
-     * @param archiveTask 归档任务
-     */
-    void updateArchiveTaskSuspendedStatus(JobInstanceArchiveTaskInfo archiveTask);
+    void updateArchiveTaskStatus(ArchiveTaskTypeEnum taskType,
+                                 DbDataNode dataNode,
+                                 Integer day,
+                                 Integer hour,
+                                 ArchiveTaskStatusEnum status);
+
+    Map<ArchiveTaskStatusEnum, Integer> countTaskByStatus(ArchiveTaskTypeEnum taskType);
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/dao/impl/ArchiveTaskDAOImpl.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/dao/impl/ArchiveTaskDAOImpl.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Repository
 public class ArchiveTaskDAOImpl implements ArchiveTaskDAO {
@@ -292,10 +293,16 @@ public class ArchiveTaskDAOImpl implements ArchiveTaskDAO {
     }
 
     @Override
-    public Map<ArchiveTaskStatusEnum, Integer> countTaskByStatus(ArchiveTaskTypeEnum taskType) {
+    public Map<ArchiveTaskStatusEnum, Integer> countTaskByStatus(ArchiveTaskTypeEnum taskType,
+                                                                 List<ArchiveTaskStatusEnum> statusList) {
         Result<Record2<Byte, Integer>> result = ctx.select(T.STATUS, DSL.count().as("task_count"))
             .from(T)
             .where(T.TASK_TYPE.eq(JooqDataTypeUtil.toByte(taskType.getType())))
+            .and(T.STATUS.in(
+                statusList.stream()
+                    .map(statusEnum -> JooqDataTypeUtil.toByte(statusEnum.getStatus()))
+                    .collect(Collectors.toList()))
+            )
             .groupBy(T.STATUS)
             .fetch();
         Map<ArchiveTaskStatusEnum, Integer> taskCountGroupByStatus = new HashMap<>();

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/dao/impl/ArchiveTaskDAOImpl.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/dao/impl/ArchiveTaskDAOImpl.java
@@ -110,7 +110,7 @@ public class ArchiveTaskDAOImpl implements ArchiveTaskDAO {
         archiveTask.setTaskEndTime(record.get(T.TASK_END_TIME));
         archiveTask.setTaskCost(record.get(T.TASK_COST));
         String detail = record.get(T.DETAIL);
-        if (StringUtils.isNotEmpty(detail)) {
+        if (StringUtils.isNotBlank(detail)) {
             archiveTask.setDetail(JsonUtils.fromJson(detail, ArchiveTaskExecutionDetail.class));
         }
         return archiveTask;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/dao/impl/ArchiveTaskDAOImpl.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/dao/impl/ArchiveTaskDAOImpl.java
@@ -25,20 +25,21 @@
 package com.tencent.bk.job.backup.archive.dao.impl;
 
 import com.tencent.bk.job.backup.archive.dao.ArchiveTaskDAO;
+import com.tencent.bk.job.backup.archive.model.ArchiveTaskExecutionDetail;
 import com.tencent.bk.job.backup.archive.model.DbDataNode;
 import com.tencent.bk.job.backup.archive.model.JobInstanceArchiveTaskInfo;
 import com.tencent.bk.job.backup.archive.model.TimeAndIdBasedArchiveProcess;
 import com.tencent.bk.job.backup.constant.ArchiveTaskStatusEnum;
 import com.tencent.bk.job.backup.constant.ArchiveTaskTypeEnum;
 import com.tencent.bk.job.backup.model.tables.ArchiveTask;
-import com.tencent.bk.job.backup.model.tables.records.ArchiveTaskRecord;
 import com.tencent.bk.job.common.mysql.jooq.JooqDataTypeUtil;
+import com.tencent.bk.job.common.util.json.JsonUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.jooq.DSLContext;
 import org.jooq.Record;
 import org.jooq.Record2;
 import org.jooq.Result;
 import org.jooq.TableField;
-import org.jooq.UpdateSetMoreStep;
 import org.jooq.impl.DSL;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -66,7 +67,11 @@ public class ArchiveTaskDAOImpl implements ArchiveTaskDAO {
         T.PROCESS,
         T.STATUS,
         T.CREATE_TIME,
-        T.LAST_UPDATE_TIME
+        T.LAST_UPDATE_TIME,
+        T.TASK_START_TIME,
+        T.TASK_END_TIME,
+        T.TASK_COST,
+        T.DETAIL
     };
 
     @Autowired
@@ -101,6 +106,13 @@ public class ArchiveTaskDAOImpl implements ArchiveTaskDAO {
         archiveTask.setStatus(ArchiveTaskStatusEnum.valOf(record.get(T.STATUS)));
         archiveTask.setCreateTime(record.get(T.CREATE_TIME));
         archiveTask.setLastUpdateTime(record.get(T.LAST_UPDATE_TIME));
+        archiveTask.setTaskStartTime(record.get(T.TASK_START_TIME));
+        archiveTask.setTaskEndTime(record.get(T.TASK_END_TIME));
+        archiveTask.setTaskCost(record.get(T.TASK_COST));
+        String detail = record.get(T.DETAIL);
+        if (StringUtils.isNotEmpty(detail)) {
+            archiveTask.setDetail(JsonUtils.fromJson(detail, ArchiveTaskExecutionDetail.class));
+        }
         return archiveTask;
     }
 
@@ -119,7 +131,11 @@ public class ArchiveTaskDAOImpl implements ArchiveTaskDAO {
                 T.PROCESS,
                 T.STATUS,
                 T.CREATE_TIME,
-                T.LAST_UPDATE_TIME)
+                T.LAST_UPDATE_TIME,
+                T.TASK_START_TIME,
+                T.TASK_END_TIME,
+                T.TASK_COST,
+                T.DETAIL)
             .values(
                 JooqDataTypeUtil.toByte(jobInstanceArchiveTaskInfo.getTaskType().getType()),
                 jobInstanceArchiveTaskInfo.getDbDataNode().toDataNodeId(),
@@ -132,7 +148,11 @@ public class ArchiveTaskDAOImpl implements ArchiveTaskDAO {
                     jobInstanceArchiveTaskInfo.getProcess().toPersistentProcess() : null,
                 JooqDataTypeUtil.toByte(jobInstanceArchiveTaskInfo.getStatus().getStatus()),
                 createTime,
-                createTime
+                createTime,
+                null,
+                null,
+                null,
+                null
             )
             .execute();
     }
@@ -167,31 +187,62 @@ public class ArchiveTaskDAOImpl implements ArchiveTaskDAO {
         return dbAndTaskCount;
     }
 
+
     @Override
-    public void updateTask(JobInstanceArchiveTaskInfo archiveTask) {
-        boolean update = false;  // 按需更新
-        UpdateSetMoreStep<ArchiveTaskRecord> updateSetMoreStep;
-        updateSetMoreStep = ctx
-            .update(T)
-            .set(T.LAST_UPDATE_TIME, System.currentTimeMillis());
-        if (archiveTask.getStatus() != null) {
-            updateSetMoreStep
-                .set(T.STATUS, JooqDataTypeUtil.toByte(archiveTask.getStatus().getStatus()));
-            update = true;
-        }
-        if (archiveTask.getProcess() != null) {
-            updateSetMoreStep
-                .set(T.PROCESS, archiveTask.getProcess().toPersistentProcess());
-            update = true;
-        }
-        if (update) {
-            updateSetMoreStep
-                .where(T.TASK_TYPE.eq(JooqDataTypeUtil.toByte(archiveTask.getTaskType().getType())))
-                .and(T.DATA_NODE.eq(archiveTask.getDbDataNode().toDataNodeId()))
-                .and(T.DAY.eq(archiveTask.getDay()))
-                .and(T.HOUR.eq(archiveTask.getHour().byteValue()))
-                .execute();
-        }
+    public void updateStartedExecuteInfo(ArchiveTaskTypeEnum taskType,
+                                         DbDataNode dataNode,
+                                         Integer day,
+                                         Integer hour,
+                                         Long startTime) {
+        ctx.update(T)
+            .set(T.LAST_UPDATE_TIME, System.currentTimeMillis())
+            .set(T.STATUS, JooqDataTypeUtil.toByte(ArchiveTaskStatusEnum.RUNNING.getStatus()))
+            .set(T.TASK_START_TIME, startTime)
+            .where(T.TASK_TYPE.eq(JooqDataTypeUtil.toByte(taskType.getType())))
+            .and(T.DATA_NODE.eq(dataNode.toDataNodeId()))
+            .and(T.DAY.eq(day))
+            .and(T.HOUR.eq(hour.byteValue()))
+            .execute();
+    }
+
+    @Override
+    public void updateRunningExecuteInfo(ArchiveTaskTypeEnum taskType,
+                                         DbDataNode dataNode,
+                                         Integer day,
+                                         Integer hour,
+                                         TimeAndIdBasedArchiveProcess process) {
+        ctx.update(T)
+            .set(T.LAST_UPDATE_TIME, System.currentTimeMillis())
+            .set(T.PROCESS, process.toPersistentProcess())
+            .where(T.TASK_TYPE.eq(JooqDataTypeUtil.toByte(taskType.getType())))
+            .and(T.DATA_NODE.eq(dataNode.toDataNodeId()))
+            .and(T.DAY.eq(day))
+            .and(T.HOUR.eq(hour.byteValue()))
+            .execute();
+    }
+
+    @Override
+    public void updateCompletedExecuteInfo(ArchiveTaskTypeEnum taskType,
+                                           DbDataNode dataNode,
+                                           Integer day,
+                                           Integer hour,
+                                           ArchiveTaskStatusEnum status,
+                                           TimeAndIdBasedArchiveProcess process,
+                                           Long endTime,
+                                           Long cost,
+                                           ArchiveTaskExecutionDetail detail) {
+        ctx.update(T)
+            .set(T.LAST_UPDATE_TIME, System.currentTimeMillis())
+            .set(T.STATUS, JooqDataTypeUtil.toByte(status.getStatus()))
+            .set(T.PROCESS, process.toPersistentProcess())
+            .set(T.TASK_END_TIME, endTime)
+            .set(T.TASK_COST, cost)
+            .set(T.DETAIL, detail != null ? JsonUtils.toJson(detail) : null)
+            .where(T.TASK_TYPE.eq(JooqDataTypeUtil.toByte(taskType.getType())))
+            .and(T.DATA_NODE.eq(dataNode.toDataNodeId()))
+            .and(T.DAY.eq(day))
+            .and(T.HOUR.eq(hour.byteValue()))
+            .execute();
     }
 
     @Override

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/metrics/ArchiveTasksGauge.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/metrics/ArchiveTasksGauge.java
@@ -1,0 +1,89 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.backup.archive.metrics;
+
+import com.tencent.bk.job.backup.archive.service.ArchiveTaskService;
+import com.tencent.bk.job.backup.constant.ArchiveTaskStatusEnum;
+import com.tencent.bk.job.backup.constant.ArchiveTaskTypeEnum;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class ArchiveTasksGauge {
+
+    /**
+     * 监控指标 - 归档任务数量
+     */
+    private static final String METRIC_NAME_FAILED_ARCHIVE_TASK = "job.archive.task";
+
+    /**
+     * tag - 归档任务类型
+     */
+    private static final String TAG_TASK_TYPE = "task_type";
+
+    /**
+     * tag - 归档任务状态
+     */
+    private static final String TAG_STATUS = "status";
+
+    private volatile Map<ArchiveTaskStatusEnum, Integer> archiveTaskCountByStatus;
+
+    private final ArchiveTaskService archiveTaskService;
+
+    @Autowired
+    public ArchiveTasksGauge(MeterRegistry meterRegistry,
+                             ArchiveTaskService archiveTaskService) {
+        this.archiveTaskService = archiveTaskService;
+        this.archiveTaskCountByStatus = archiveTaskService.countTaskByStatus(ArchiveTaskTypeEnum.JOB_INSTANCE);
+        for (ArchiveTaskStatusEnum status : ArchiveTaskStatusEnum.values()) {
+            meterRegistry.gauge(
+                METRIC_NAME_FAILED_ARCHIVE_TASK,
+                Tags.of(TAG_TASK_TYPE, ArchiveTaskTypeEnum.JOB_INSTANCE.name(),
+                    TAG_STATUS, status.name()),
+                this,
+                (ArchiveTasksGauge statObject) -> statObject.countByStatus(status));
+        }
+    }
+
+    private long countByStatus(ArchiveTaskStatusEnum status) {
+        Integer count = archiveTaskCountByStatus.get(status);
+        return count == null ? 0 : count;
+    }
+
+
+    /**
+     * 触发指标查询
+     */
+    @Scheduled(cron = "0 0 0/2 * * *")
+    public void loadMetrics() {
+        this.archiveTaskCountByStatus = archiveTaskService.countTaskByStatus(ArchiveTaskTypeEnum.JOB_INSTANCE);
+    }
+
+}

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/metrics/ArchiveTasksGauge.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/metrics/ArchiveTasksGauge.java
@@ -91,7 +91,7 @@ public class ArchiveTasksGauge {
     /**
      * 触发指标查询
      */
-    @Scheduled(cron = "0 0 0/2 * * *")
+    @Scheduled(cron = "0 0/2 * * * *")
     public void loadMetrics() {
         this.archiveTaskCountByStatus = archiveTaskService.countTaskByStatus(
             ArchiveTaskTypeEnum.JOB_INSTANCE, MONITOR_STATUS_LIST);

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/metrics/ArchiveTasksGauge.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/metrics/ArchiveTasksGauge.java
@@ -29,15 +29,13 @@ import com.tencent.bk.job.backup.constant.ArchiveTaskStatusEnum;
 import com.tencent.bk.job.backup.constant.ArchiveTaskTypeEnum;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-@Component
+
 public class ArchiveTasksGauge {
 
     /**
@@ -69,7 +67,6 @@ public class ArchiveTasksGauge {
 
     private final ArchiveTaskService archiveTaskService;
 
-    @Autowired
     public ArchiveTasksGauge(MeterRegistry meterRegistry,
                              ArchiveTaskService archiveTaskService) {
         this.archiveTaskService = archiveTaskService;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/model/ArchiveTableDetail.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/model/ArchiveTableDetail.java
@@ -22,23 +22,58 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.backup.archive.impl;
+package com.tencent.bk.job.backup.archive.model;
 
-import com.tencent.bk.job.backup.archive.ArchiveTablePropsStorage;
-import com.tencent.bk.job.backup.archive.dao.JobInstanceColdDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.JobInstanceHotRecordDAO;
+import lombok.Data;
 
+/**
+ * 归档表执行性情
+ */
+@Data
+public class ArchiveTableDetail {
+    /**
+     * 写入归档冷 DB 的记录行数
+     */
+    private long backupRows;
+    /**
+     * 从热 DB 删除的记录行数
+     */
+    private long deleteRows;
+    /**
+     * 备份到冷 DB 耗时(毫秒)
+     */
+    private long backupCostTime;
+    /**
+     * 删除热数据耗时(毫秒)
+     */
+    private long deleteCostTime;
+    /**
+     * 总耗时(毫秒)
+     */
+    private long costTime;
 
-public class TaskInstanceArchiver extends AbstractJobInstanceSubTableArchiver {
-
-    public TaskInstanceArchiver(
-        JobInstanceColdDAO jobInstanceColdDAO,
-        JobInstanceHotRecordDAO jobInstanceHotRecordDAO,
-        ArchiveTablePropsStorage archiveTablePropsStorage) {
-        super(
-            jobInstanceColdDAO,
-            jobInstanceHotRecordDAO,
-            archiveTablePropsStorage
-        );
+    /**
+     * 累加统计数据 - 备份
+     *
+     * @param backupRows 已备份行数
+     * @param costTime   耗时
+     */
+    public void accumulateBackup(long backupRows, long costTime) {
+        this.backupRows += backupRows;
+        this.backupCostTime = costTime;
+        this.costTime += costTime;
     }
+
+    /**
+     * 累加统计数据 - 删除
+     *
+     * @param deleteRows 已删除行数
+     * @param costTime   耗时
+     */
+    public void accumulateDelete(long deleteRows, long costTime) {
+        this.backupRows += backupRows;
+        this.deleteCostTime += costTime;
+        this.costTime += costTime;
+    }
+
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/model/ArchiveTaskContext.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/model/ArchiveTaskContext.java
@@ -35,4 +35,12 @@ public class ArchiveTaskContext {
     public ArchiveTaskContext(JobInstanceArchiveTaskInfo archiveTaskInfo) {
         this.archiveTaskInfo = archiveTaskInfo;
     }
+
+    public void accumulateTableBackup(String tableName, long backupRows, long costTime) {
+        archiveTaskInfo.getDetail().accumulateTableBackup(tableName, backupRows, costTime);
+    }
+
+    public void accumulateTableDelete(String tableName, long deleteRows, long costTime) {
+        archiveTaskInfo.getDetail().accumulateTableDelete(tableName, deleteRows, costTime);
+    }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/model/ArchiveTaskContext.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/model/ArchiveTaskContext.java
@@ -37,10 +37,12 @@ public class ArchiveTaskContext {
     }
 
     public void accumulateTableBackup(String tableName, long backupRows, long costTime) {
-        archiveTaskInfo.getDetail().accumulateTableBackup(tableName, backupRows, costTime);
+        archiveTaskInfo.getOrInitExecutionDetail()
+            .accumulateTableBackup(tableName, backupRows, costTime);
     }
 
     public void accumulateTableDelete(String tableName, long deleteRows, long costTime) {
-        archiveTaskInfo.getDetail().accumulateTableDelete(tableName, deleteRows, costTime);
+        archiveTaskInfo.getOrInitExecutionDetail()
+            .accumulateTableDelete(tableName, deleteRows, costTime);
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/model/ArchiveTaskExecutionDetail.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/model/ArchiveTaskExecutionDetail.java
@@ -24,6 +24,7 @@
 
 package com.tencent.bk.job.backup.archive.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.tencent.bk.job.common.annotation.PersistenceObject;
 import lombok.Data;
 import lombok.ToString;
@@ -38,6 +39,7 @@ import java.util.Map;
 @Data
 @ToString
 @PersistenceObject
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class ArchiveTaskExecutionDetail {
     /**
      * 归档任务耗时（毫秒）

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/model/JobInstanceArchiveTaskInfo.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/model/JobInstanceArchiveTaskInfo.java
@@ -76,21 +76,22 @@ public class JobInstanceArchiveTaskInfo {
      * 归档任务最后更新时间
      */
     private Long lastUpdateTime;
-
-    public JobInstanceArchiveTaskInfo clone() {
-        JobInstanceArchiveTaskInfo archiveTask = new JobInstanceArchiveTaskInfo();
-        archiveTask.setTaskType(taskType);
-        archiveTask.setDbDataNode(dbDataNode.clone());
-        archiveTask.setDay(day);
-        archiveTask.setHour(hour);
-        archiveTask.setFromTimestamp(fromTimestamp);
-        archiveTask.setToTimestamp(toTimestamp);
-        archiveTask.setProcess(process.clone());
-        archiveTask.setStatus(status);
-        archiveTask.setCreateTime(createTime);
-        archiveTask.setLastUpdateTime(lastUpdateTime);
-        return archiveTask;
-    }
+    /**
+     * 归档任务启动时间
+     */
+    private Long taskStartTime;
+    /**
+     * 归档任务结束时间
+     */
+    private Long taskEndTime;
+    /**
+     * 归档任务耗时，单位毫秒
+     */
+    private Long taskCost;
+    /**
+     * 归档任务运行详情
+     */
+    private ArchiveTaskExecutionDetail detail = new ArchiveTaskExecutionDetail();
 
     public String buildTaskUniqueId() {
         return taskType.getType() + ":" + day + ":" + hour + ":" + dbDataNode.toDataNodeId();

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/model/JobInstanceArchiveTaskInfo.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/model/JobInstanceArchiveTaskInfo.java
@@ -91,9 +91,16 @@ public class JobInstanceArchiveTaskInfo {
     /**
      * 归档任务运行详情
      */
-    private ArchiveTaskExecutionDetail detail = new ArchiveTaskExecutionDetail();
+    private ArchiveTaskExecutionDetail detail;
 
     public String buildTaskUniqueId() {
         return taskType.getType() + ":" + day + ":" + hour + ":" + dbDataNode.toDataNodeId();
+    }
+
+    public ArchiveTaskExecutionDetail getOrInitExecutionDetail() {
+        if (detail == null) {
+            detail = new ArchiveTaskExecutionDetail();
+        }
+        return detail;
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/service/ArchiveTaskService.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/service/ArchiveTaskService.java
@@ -73,6 +73,20 @@ public class ArchiveTaskService {
     }
 
     /**
+     * 获取归档任务
+     *
+     * @param taskType 查询条件 - 任务类型
+     * @param status   查询条件 - 任务状态
+     * @param limit    查询条件 - 查询最大数量
+     * @return 归档任务列表
+     */
+    public List<JobInstanceArchiveTaskInfo> listTasks(ArchiveTaskTypeEnum taskType,
+                                                      ArchiveTaskStatusEnum status,
+                                                      int limit) {
+        return archiveTaskDAO.listTasks(taskType, status, limit);
+    }
+
+    /**
      * 返回根据 db 分组的归档任务数量
      *
      * @param taskType 归档任务类型
@@ -171,11 +185,29 @@ public class ArchiveTaskService {
     }
 
     /**
-     * 设置归档任务状态为暂停
+     * 更新归档任务执行状态
      *
-     * @param archiveTask 归档任务
+     * @param taskType 任务类型
+     * @param dataNode 数据节点
+     * @param day      归档数据所在天
+     * @param hour     归档数据所在小时
+     * @param status   任务状态
      */
-    public void updateArchiveTaskSuspendedStatus(JobInstanceArchiveTaskInfo archiveTask) {
-        archiveTaskDAO.updateArchiveTaskSuspendedStatus(archiveTask);
+    public void updateArchiveTaskStatus(ArchiveTaskTypeEnum taskType,
+                                        DbDataNode dataNode,
+                                        Integer day,
+                                        Integer hour,
+                                        ArchiveTaskStatusEnum status) {
+        archiveTaskDAO.updateArchiveTaskStatus(taskType, dataNode, day, hour, status);
+    }
+
+    /**
+     * 按照任务类型和状态，统计归档任务数量
+     *
+     * @param taskType 任务类型
+     * @return 数量
+     */
+    public Map<ArchiveTaskStatusEnum, Integer> countTaskByStatus(ArchiveTaskTypeEnum taskType) {
+        return archiveTaskDAO.countTaskByStatus(taskType);
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/service/ArchiveTaskService.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/service/ArchiveTaskService.java
@@ -25,7 +25,11 @@
 package com.tencent.bk.job.backup.archive.service;
 
 import com.tencent.bk.job.backup.archive.dao.ArchiveTaskDAO;
+import com.tencent.bk.job.backup.archive.model.ArchiveTaskExecutionDetail;
+import com.tencent.bk.job.backup.archive.model.DbDataNode;
 import com.tencent.bk.job.backup.archive.model.JobInstanceArchiveTaskInfo;
+import com.tencent.bk.job.backup.archive.model.TimeAndIdBasedArchiveProcess;
+import com.tencent.bk.job.backup.constant.ArchiveTaskStatusEnum;
 import com.tencent.bk.job.backup.constant.ArchiveTaskTypeEnum;
 import com.tencent.bk.job.common.mysql.JobTransactional;
 import org.apache.commons.collections4.CollectionUtils;
@@ -78,8 +82,88 @@ public class ArchiveTaskService {
         return archiveTaskDAO.countScheduleTasksGroupByDb(taskType);
     }
 
-    public void updateTask(JobInstanceArchiveTaskInfo archiveTask) {
-        archiveTaskDAO.updateTask(archiveTask);
+
+    /**
+     * 更新归档任务执行信息 - 启动后
+     *
+     * @param taskType  任务类型
+     * @param dataNode  数据节点
+     * @param day       归档数据所在天
+     * @param hour      归档数据所在小时
+     * @param startTime 任务开始时间
+     */
+    public void updateStartedExecuteInfo(ArchiveTaskTypeEnum taskType,
+                                         DbDataNode dataNode,
+                                         Integer day,
+                                         Integer hour,
+                                         Long startTime) {
+        archiveTaskDAO.updateStartedExecuteInfo(
+            taskType,
+            dataNode,
+            day,
+            hour,
+            startTime
+        );
+
+    }
+
+    /**
+     * 更新归档任务执行信息 - 运行中
+     *
+     * @param taskType 任务类型
+     * @param dataNode 数据节点
+     * @param day      归档数据所在天
+     * @param hour     归档数据所在小时
+     * @param process  进度
+     */
+    public void updateRunningExecuteInfo(ArchiveTaskTypeEnum taskType,
+                                         DbDataNode dataNode,
+                                         Integer day,
+                                         Integer hour,
+                                         TimeAndIdBasedArchiveProcess process) {
+        archiveTaskDAO.updateRunningExecuteInfo(
+            taskType,
+            dataNode,
+            day,
+            hour,
+            process
+        );
+
+    }
+
+    /**
+     * 更新归档任务执行信息 - 结束
+     *
+     * @param taskType 任务类型
+     * @param dataNode 数据节点
+     * @param day      归档数据所在天
+     * @param hour     归档数据所在小时
+     * @param status   任务状态
+     * @param process  进度
+     * @param endTime  结束时间
+     * @param cost     任务耗时
+     * @param detail   执行详情
+     */
+    public void updateCompletedExecuteInfo(ArchiveTaskTypeEnum taskType,
+                                           DbDataNode dataNode,
+                                           Integer day,
+                                           Integer hour,
+                                           ArchiveTaskStatusEnum status,
+                                           TimeAndIdBasedArchiveProcess process,
+                                           Long endTime,
+                                           Long cost,
+                                           ArchiveTaskExecutionDetail detail) {
+        archiveTaskDAO.updateCompletedExecuteInfo(
+            taskType,
+            dataNode,
+            day,
+            hour,
+            status,
+            process,
+            endTime,
+            cost,
+            detail
+        );
     }
 
     public JobInstanceArchiveTaskInfo getFirstScheduleArchiveTaskByDb(ArchiveTaskTypeEnum taskType, String dbNodeId) {

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/service/ArchiveTaskService.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/service/ArchiveTaskService.java
@@ -204,10 +204,12 @@ public class ArchiveTaskService {
     /**
      * 按照任务类型和状态，统计归档任务数量
      *
-     * @param taskType 任务类型
+     * @param taskType   任务类型
+     * @param statusList 状态列表
      * @return 数量
      */
-    public Map<ArchiveTaskStatusEnum, Integer> countTaskByStatus(ArchiveTaskTypeEnum taskType) {
-        return archiveTaskDAO.countTaskByStatus(taskType);
+    public Map<ArchiveTaskStatusEnum, Integer> countTaskByStatus(ArchiveTaskTypeEnum taskType,
+                                                                 List<ArchiveTaskStatusEnum> statusList) {
+        return archiveTaskDAO.countTaskByStatus(taskType, statusList);
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/util/lock/FailedArchiveTaskRescheduleLock.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/util/lock/FailedArchiveTaskRescheduleLock.java
@@ -29,19 +29,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
 /**
- * 归档任务创建分布式锁
+ * 失败/超时归档任务重调度分布式锁
  */
 @Slf4j
-public class JobInstanceArchiveTaskGenerateLock extends PreemptiveDistributeLock {
+public class FailedArchiveTaskRescheduleLock extends PreemptiveDistributeLock {
 
-
-    public JobInstanceArchiveTaskGenerateLock(StringRedisTemplate redisTemplate) {
+    public FailedArchiveTaskRescheduleLock(StringRedisTemplate redisTemplate) {
         super(redisTemplate,
-            "job:instance:archive:task:generate",
+            "fail:archive:task:reschedule",
             new HeartBeatRedisLockConfig(
-                "RedisKeyHeartBeatThread-job:instance:archive:task:generate",
-                60 * 1000L, // 60s 超时时间
-                10 * 1000L // 10s 续期一次
+                "RedisKeyHeartBeatThread-fail:archive:task:reschedule",
+                300 * 1000L, // 5min 超时时间
+                60 * 1000L // 1min 续期一次
             ));
     }
+
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfiguration.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfiguration.java
@@ -64,6 +64,7 @@ import com.tencent.bk.job.backup.archive.impl.StepInstanceScriptArchiver;
 import com.tencent.bk.job.backup.archive.impl.StepInstanceVariableArchiver;
 import com.tencent.bk.job.backup.archive.impl.TaskInstanceHostArchiver;
 import com.tencent.bk.job.backup.archive.impl.TaskInstanceVariableArchiver;
+import com.tencent.bk.job.backup.archive.metrics.ArchiveTasksGauge;
 import com.tencent.bk.job.backup.archive.service.ArchiveTaskService;
 import com.tencent.bk.job.backup.archive.util.lock.ArchiveTaskExecuteLock;
 import com.tencent.bk.job.backup.archive.util.lock.FailedArchiveTaskRescheduleLock;
@@ -71,6 +72,7 @@ import com.tencent.bk.job.backup.archive.util.lock.JobInstanceArchiveTaskGenerat
 import com.tencent.bk.job.backup.archive.util.lock.JobInstanceArchiveTaskScheduleLock;
 import com.tencent.bk.job.backup.metrics.ArchiveErrorTaskCounter;
 import com.tencent.bk.job.common.mysql.dynamic.ds.DSLContextProvider;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -538,5 +540,11 @@ public class ArchiveConfiguration {
         FailedArchiveTaskRescheduleLock failedArchiveTaskRescheduleLock) {
         log.info("Init FailArchiveTaskReScheduler");
         return new AbnormalArchiveTaskReScheduler(archiveTaskService, failedArchiveTaskRescheduleLock);
+    }
+
+    @Bean
+    public ArchiveTasksGauge archiveTasksGauge(MeterRegistry meterRegistry,
+                                               ArchiveTaskService archiveTaskService) {
+        return new ArchiveTasksGauge(meterRegistry, archiveTaskService);
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfiguration.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfiguration.java
@@ -61,7 +61,6 @@ import com.tencent.bk.job.backup.archive.impl.StepInstanceFileArchiver;
 import com.tencent.bk.job.backup.archive.impl.StepInstanceRollingTaskArchiver;
 import com.tencent.bk.job.backup.archive.impl.StepInstanceScriptArchiver;
 import com.tencent.bk.job.backup.archive.impl.StepInstanceVariableArchiver;
-import com.tencent.bk.job.backup.archive.impl.TaskInstanceArchiver;
 import com.tencent.bk.job.backup.archive.impl.TaskInstanceHostArchiver;
 import com.tencent.bk.job.backup.archive.impl.TaskInstanceVariableArchiver;
 import com.tencent.bk.job.backup.archive.service.ArchiveTaskService;
@@ -104,18 +103,6 @@ public class ArchiveConfiguration {
             @Qualifier("job-execute-dsl-context-provider") DSLContextProvider dslContextProvider) {
             log.info("Init TaskInstanceRecordDAO");
             return new JobInstanceHotRecordDAO(dslContextProvider);
-        }
-
-        @Bean
-        public TaskInstanceArchiver taskInstanceArchiver(
-            ObjectProvider<JobInstanceColdDAO> jobInstanceColdDAOObjectProvider,
-            JobInstanceHotRecordDAO taskInstanceRecordDAO,
-            ArchiveTablePropsStorage archiveTablePropsStorage
-        ) {
-            return new TaskInstanceArchiver(
-                jobInstanceColdDAOObjectProvider.getIfAvailable(),
-                taskInstanceRecordDAO,
-                archiveTablePropsStorage);
         }
 
         @Bean(name = "stepInstanceRecordDAO")

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfiguration.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfiguration.java
@@ -24,8 +24,8 @@
 
 package com.tencent.bk.job.backup.config;
 
+import com.tencent.bk.job.backup.archive.AbnormalArchiveTaskReScheduler;
 import com.tencent.bk.job.backup.archive.ArchiveTablePropsStorage;
-import com.tencent.bk.job.backup.archive.FailArchiveTaskReScheduler;
 import com.tencent.bk.job.backup.archive.JobInstanceArchiveCronJobs;
 import com.tencent.bk.job.backup.archive.JobInstanceArchiveTaskGenerator;
 import com.tencent.bk.job.backup.archive.JobInstanceArchiveTaskScheduler;
@@ -516,13 +516,13 @@ public class ArchiveConfiguration {
         JobInstanceArchiveTaskGenerator jobInstanceArchiveTaskGenerator,
         JobInstanceArchiveTaskScheduler jobInstanceArchiveTaskScheduler,
         ArchiveProperties archiveProperties,
-        FailArchiveTaskReScheduler failArchiveTaskReScheduler) {
+        AbnormalArchiveTaskReScheduler abnormalArchiveTaskReScheduler) {
         log.info("Init JobInstanceArchiveCronJobs");
         return new JobInstanceArchiveCronJobs(
             jobInstanceArchiveTaskGenerator,
             jobInstanceArchiveTaskScheduler,
             archiveProperties,
-            failArchiveTaskReScheduler
+            abnormalArchiveTaskReScheduler
         );
     }
 
@@ -533,10 +533,10 @@ public class ArchiveConfiguration {
     }
 
     @Bean
-    public FailArchiveTaskReScheduler failArchiveTaskReScheduler(
+    public AbnormalArchiveTaskReScheduler failArchiveTaskReScheduler(
         ArchiveTaskService archiveTaskService,
         FailedArchiveTaskRescheduleLock failedArchiveTaskRescheduleLock) {
         log.info("Init FailArchiveTaskReScheduler");
-        return new FailArchiveTaskReScheduler(archiveTaskService, failedArchiveTaskRescheduleLock);
+        return new AbnormalArchiveTaskReScheduler(archiveTaskService, failedArchiveTaskRescheduleLock);
     }
 }

--- a/support-files/sql/job-backup/0005_job_backup_20241115-1000_V3.11.2_mysql.sql
+++ b/support-files/sql/job-backup/0005_job_backup_20241115-1000_V3.11.2_mysql.sql
@@ -17,6 +17,10 @@ CREATE TABLE IF NOT EXISTS `archive_task` (
   `status` TINYINT(2) NOT NULL DEFAULT '0',
   `create_time` BIGINT(20) NOT NULL,
   `last_update_time` BIGINT(20) NOT NULL,
+  `task_start_time` BIGINT(20),
+  `task_end_time` BIGINT(20),
+  `task_cost` BIGINT(20),
+  `detail` TEXT,
   PRIMARY KEY (`id`) USING BTREE,
   UNIQUE KEY `uk_type_node_day_hour` (`task_type`,`data_node`,`day`,`hour`),
   KEY `idx_type_status_db` (`task_type`,`status`,`db_node`)


### PR DESCRIPTION
1. 归档任务表新增 task_start_time/task_end_time/cost_time/detail 4 个字段，记录归档任务的执行详情
2. 更新归档任务 DAO 层方法优化，按场景拆分
3. 归档统计信息记录优化
4. 其它代码重构
5. 归档任务监控指标（ArchiveTasksGauge）
6. 失败、超时任务重新调度 （AbnormalArchiveTaskReScheduler）