### PR TITLE
perf: 对执行对象任务写入 db 进行分批处理 #3312

### DIFF
--- a/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/BatchUtil.java
+++ b/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/BatchUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.util;
+
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * 分批处理工具类
+ */
+public class BatchUtil {
+
+    /**
+     * 分批执行工具
+     *
+     * @param targets   执行目标列表
+     * @param batchSize 每批次大小
+     * @param execution 执行函数
+     * @param <E>       执行目标
+     */
+    public static <E> void executeBatch(Collection<E> targets,
+                                        int batchSize,
+                                        Consumer<Collection<E>> execution) {
+        if (CollectionUtils.isEmpty(targets)) {
+            return;
+        }
+        if (targets.size() <= batchSize) {
+            execution.accept(targets);
+        } else {
+            List<List<E>> targetBatches = CollectionUtil.partitionCollection(targets, batchSize);
+            targetBatches.forEach(execution);
+        }
+    }
+}

--- a/src/backend/job-execute/boot-job-execute/src/main/resources/logback-spring.xml
+++ b/src/backend/job-execute/boot-job-execute/src/main/resources/logback-spring.xml
@@ -37,7 +37,7 @@
             <cleanHistoryOnStart>${CLEAN_HISTORY_ON_START}</cleanHistoryOnStart>
         </rollingPolicy>
         <encoder>
-            <pattern>${LOG_PATTERN}</pattern>
+            <pattern>${FILE_LOG_PATTERN}</pattern>
             <charset>UTF-8</charset>
         </encoder>
     </appender>

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/TaskInstanceDAOImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/TaskInstanceDAOImpl.java
@@ -30,7 +30,7 @@ import com.tencent.bk.job.common.model.dto.HostDTO;
 import com.tencent.bk.job.common.mysql.dynamic.ds.DbOperationEnum;
 import com.tencent.bk.job.common.mysql.dynamic.ds.MySQLOperation;
 import com.tencent.bk.job.common.mysql.jooq.JooqDataTypeUtil;
-import com.tencent.bk.job.common.util.CollectionUtil;
+import com.tencent.bk.job.common.util.BatchUtil;
 import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
 import com.tencent.bk.job.execute.dao.TaskInstanceDAO;
 import com.tencent.bk.job.execute.dao.common.DSLContextProviderFactory;
@@ -527,11 +527,7 @@ public class TaskInstanceDAOImpl extends BaseDAO implements TaskInstanceDAO {
     public void saveTaskInstanceHosts(long appId,
                                       long taskInstanceId,
                                       Collection<HostDTO> hosts) {
-        if (CollectionUtils.isEmpty(hosts)) {
-            return;
-        }
-        List<List<HostDTO>> hostBatches = CollectionUtil.partitionCollection(hosts, 2000);
-        hostBatches.forEach(batchHosts -> {
+        BatchUtil.executeBatch(hosts, 2000, batchHosts -> {
             BatchBindStep batchInsert = dsl().batch(
                 dsl().insertInto(
                         TASK_INSTANCE_HOST,

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/AbstractExecuteObjectTaskServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/AbstractExecuteObjectTaskServiceImpl.java
@@ -88,7 +88,7 @@ public abstract class AbstractExecuteObjectTaskServiceImpl implements ExecuteObj
      *
      * @param tasks 需要被保存的任务
      */
-    protected boolean isSaveTasksUsingExecuteObjectMode(Collection<ExecuteObjectTask> tasks) {
+    protected boolean isExecuteObjectSupported(Collection<ExecuteObjectTask> tasks) {
         // 根据执行对象任务模型中的 executeObjectId 参数判断是否支持执行对象
         ExecuteObjectTask anyTask = tasks.stream().findAny().orElse(null);
         return Objects.requireNonNull(anyTask).getExecuteObjectId() != null;

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/FileExecuteObjectTaskServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/FileExecuteObjectTaskServiceImpl.java
@@ -63,7 +63,7 @@ public class FileExecuteObjectTaskServiceImpl
     }
 
     private void executeSaveTasks(boolean executeObjectSupported,
-                                Collection<ExecuteObjectTask> tasks) {
+                                  Collection<ExecuteObjectTask> tasks) {
         if (executeObjectSupported) {
             fileExecuteObjectTaskDAO.batchSaveTasks(tasks);
         } else {

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/FileExecuteObjectTaskServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/FileExecuteObjectTaskServiceImpl.java
@@ -1,6 +1,7 @@
 package com.tencent.bk.job.execute.service.impl;
 
 import com.tencent.bk.job.common.constant.Order;
+import com.tencent.bk.job.common.util.CollectionUtil;
 import com.tencent.bk.job.execute.dao.FileAgentTaskDAO;
 import com.tencent.bk.job.execute.dao.FileExecuteObjectTaskDAO;
 import com.tencent.bk.job.execute.dao.common.IdGen;
@@ -51,11 +52,17 @@ public class FileExecuteObjectTaskServiceImpl
         }
         tasks.forEach(task -> task.setId(idGen.genGseFileExecuteObjTaskId()));
 
-        if (isSaveTasksUsingExecuteObjectMode(tasks)) {
-            fileExecuteObjectTaskDAO.batchSaveTasks(tasks);
-        } else {
-            fileAgentTaskDAO.batchSaveAgentTasks(tasks);
-        }
+        boolean executeObjectMode = isSaveTasksUsingExecuteObjectMode(tasks);
+
+        // 任务分批，避免大事务造成 db 主从延迟
+        List<List<ExecuteObjectTask>> partitionedTasks = CollectionUtil.partitionCollection(tasks, 2000);
+        partitionedTasks.forEach(partitionedTask -> {
+            if (executeObjectMode) {
+                fileExecuteObjectTaskDAO.batchSaveTasks(partitionedTask);
+            } else {
+                fileAgentTaskDAO.batchSaveAgentTasks(partitionedTask);
+            }
+        });
     }
 
     @Override
@@ -64,11 +71,17 @@ public class FileExecuteObjectTaskServiceImpl
             return;
         }
 
-        if (isSaveTasksUsingExecuteObjectMode(tasks)) {
-            fileExecuteObjectTaskDAO.batchUpdateTasks(tasks);
-        } else {
-            fileAgentTaskDAO.batchUpdateAgentTasks(tasks);
-        }
+        boolean executeObjectMode = isSaveTasksUsingExecuteObjectMode(tasks);
+
+        // 任务分批，避免大事务造成 db 主从延迟
+        List<List<ExecuteObjectTask>> partitionedTasks = CollectionUtil.partitionCollection(tasks, 2000);
+        partitionedTasks.forEach(partitionedTask -> {
+            if (executeObjectMode) {
+                fileExecuteObjectTaskDAO.batchUpdateTasks(partitionedTask);
+            } else {
+                fileAgentTaskDAO.batchUpdateAgentTasks(partitionedTask);
+            }
+        });
     }
 
     @Override

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/TaskExecuteServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/TaskExecuteServiceImpl.java
@@ -865,16 +865,16 @@ public class TaskExecuteServiceImpl implements TaskExecuteService {
                         new Integer[]{jobExecuteConfig.getFileTasksMax()});
                 }
             } else if (stepInstance.isScriptStep()) {
-                int targetServerSize = stepInstance.getTargetExecuteObjectCount();
-                if (targetServerSize > 10000) {
+                int targetExecuteObjectSize = stepInstance.getTargetExecuteObjectCount();
+                if (targetExecuteObjectSize > 10000) {
                     TASK_MONITOR_LOGGER.info("LargeTask|type:script|taskName:{}|appCode:{}|appId:{}|operator:{}"
-                            + "|targetServerSize:{}",
-                        taskName, appCode, appId, operator, targetServerSize);
+                            + "|targetExecuteObjectSize:{}",
+                        taskName, appCode, appId, operator, targetExecuteObjectSize);
                 }
-                if (targetServerSize > jobExecuteConfig.getScriptTaskMaxTargetServer()) {
+                if (targetExecuteObjectSize > jobExecuteConfig.getScriptTaskMaxTargetServer()) {
                     log.info("Reject large task|type:file|taskName:{}|appCode:{}|appId:{}|operator" +
-                            ":{}|targetServerSize:{}|maxAllowedSize:{}", taskName, appCode, appId, operator,
-                        targetServerSize, jobExecuteConfig.getScriptTaskMaxTargetServer());
+                            ":{}|targetExecuteObjectSize:{}|maxAllowedSize:{}", taskName, appCode, appId, operator,
+                        targetExecuteObjectSize, jobExecuteConfig.getScriptTaskMaxTargetServer());
                     throw new ResourceExhaustedException(ErrorCode.SCRIPT_TASK_TARGET_SERVER_EXCEEDS_LIMIT,
                         new Integer[]{jobExecuteConfig.getScriptTaskMaxTargetServer()});
                 }


### PR DESCRIPTION
1. 写 gse_script_execute_obj_task / gse_file_execute_obj_task 分批写入，避免大事务对db 主从同步的影响
2. 修复“包含大量执行对象任务”的日志打印异常