### PR TITLE
fix: Redis中主机缓存数据偶现不一致 #3295

### DIFF
--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/HostService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/HostService.java
@@ -84,6 +84,8 @@ public interface HostService {
      */
     int deleteHostBeforeOrEqualLastTime(ApplicationHostDTO hostInfoDTO);
 
+    void updateDbHostToCache(Long hostId);
+
     long countHostsByOsType(String osType);
 
     Map<String, Integer> groupHostByOsType();

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/HostEventHandler.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/HostEventHandler.java
@@ -128,6 +128,10 @@ public class HostEventHandler extends EventsHandler<HostEventDetail> {
                         hostInfoDTO.setGseAgentStatus(agentStatus);
                         affectedNum = hostService.updateHostAttrsByHostId(hostInfoDTO);
                         log.info("update host attrs:{}, affectedNum={}", hostInfoDTO, affectedNum);
+                        // 更新缓存
+                        if (affectedNum > 0) {
+                            hostService.updateDbHostToCache(hostInfoDTO.getHostId());
+                        }
                     } else {
                         // 机器在CMDB中已不存在，忽略
                         log.info("host not exist in cmdb:{}, ignore", hostInfoDTO);


### PR DESCRIPTION
1.从CMDB查询最新主机数据后，不仅将主机数据更新到DB，也更新缓存；
2.主机事件数据中的lastTime更旧时，打印出当前DB中的主机lastTime进行比较。