### PR TITLE
perf: 优化属性变化监听逻辑，过滤无需处理的属性 #3343

### DIFF
--- a/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/quota/ResourceQuotaStore.java
+++ b/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/quota/ResourceQuotaStore.java
@@ -47,6 +47,11 @@ import java.util.Set;
 public class ResourceQuotaStore implements ConfigRefreshHandler {
 
     /**
+     * 属性名称前缀
+     */
+    public static final String PROP_KEY_PREFIX = "job.resourceQuotaLimit.";
+
+    /**
      * key: QuotaResourceId; value: ResourceQuotaLimit
      */
     private volatile Map<String, ResourceQuotaLimit> resourceQuotas = new HashMap<>();

--- a/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/toggle/prop/InMemoryPropToggleStore.java
+++ b/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/toggle/prop/InMemoryPropToggleStore.java
@@ -98,6 +98,9 @@ public class InMemoryPropToggleStore implements PropToggleStore {
         Set<String> uniquePropNames = new HashSet<>();
 
         for (String changeKey : changedKeys) {
+            if (!changeKey.startsWith(PROP_KEY_PREFIX)) {
+                log.error("Invalid key : {}", changeKey);
+            }
             String[] parts = changeKey.split("\\.");
             // 格式 job.toggle.props.{propName}.others
             if (parts.length >= 4) {

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/toggle/feature/FeatureStore.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/toggle/feature/FeatureStore.java
@@ -32,6 +32,12 @@ import java.util.List;
  * 特性开关配置存储
  */
 public interface FeatureStore extends RefreshableConfigStore {
+
+    /**
+     * 属性名称前缀
+     */
+    String PROP_KEY_PREFIX = "job.features.";
+
     /**
      * 返回特性开关配置
      *

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/toggle/prop/PropToggleStore.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/toggle/prop/PropToggleStore.java
@@ -31,7 +31,7 @@ public interface PropToggleStore extends RefreshableConfigStore {
     /**
      * 属性名称前缀
      */
-    String PROP_KEY_PREFIX = "job.toggle.props";
+    String PROP_KEY_PREFIX = "job.toggle.props.";
 
     /**
      * 返回属性开关配置


### PR DESCRIPTION
1. 过滤 EnvironmentChangeEvent changeKeys, 每个属性监听者只关注需要关注的 key 变更