### PR TITLE
perf: 优化分库分表分片键列的更新 SQL #3346

### DIFF
--- a/support-files/sql/job-execute/0026_job_execute_20241115-1000_V3.11.2_mysql.sql
+++ b/support-files/sql/job-execute/0026_job_execute_20241115-1000_V3.11.2_mysql.sql
@@ -214,8 +214,7 @@ label:BEGIN
       FROM step_instance 
       WHERE id BETWEEN fromId AND endId)
     AS tmp ON t1.step_instance_id = tmp.id 
-    SET t1.task_instance_id = tmp.task_instance_id
-    WHERE t1.task_instance_id = 0;
+    SET t1.task_instance_id = tmp.task_instance_id;
 
     UPDATE gse_file_agent_task t1
     INNER JOIN (
@@ -223,8 +222,7 @@ label:BEGIN
       FROM step_instance 
       WHERE id BETWEEN fromId AND endId)
     AS tmp ON t1.step_instance_id = tmp.id 
-    SET t1.task_instance_id = tmp.task_instance_id
-    WHERE t1.task_instance_id = 0;
+    SET t1.task_instance_id = tmp.task_instance_id;
 
     UPDATE gse_script_agent_task t1
     INNER JOIN (
@@ -232,8 +230,7 @@ label:BEGIN
       FROM step_instance 
       WHERE id BETWEEN fromId AND endId)
     AS tmp ON t1.step_instance_id = tmp.id 
-    SET t1.task_instance_id = tmp.task_instance_id
-    WHERE t1.task_instance_id = 0;
+    SET t1.task_instance_id = tmp.task_instance_id;
 
     UPDATE gse_task t1
     INNER JOIN (
@@ -241,8 +238,7 @@ label:BEGIN
       FROM step_instance 
       WHERE id BETWEEN fromId AND endId)
     AS tmp ON t1.step_instance_id = tmp.id 
-    SET t1.task_instance_id = tmp.task_instance_id
-    WHERE t1.task_instance_id = 0;
+    SET t1.task_instance_id = tmp.task_instance_id;
 
     UPDATE step_instance_confirm t1
     INNER JOIN (
@@ -250,8 +246,7 @@ label:BEGIN
       FROM step_instance 
       WHERE id BETWEEN fromId AND endId)
     AS tmp ON t1.step_instance_id = tmp.id 
-    SET t1.task_instance_id = tmp.task_instance_id
-    WHERE t1.task_instance_id = 0;
+    SET t1.task_instance_id = tmp.task_instance_id;
 
     UPDATE step_instance_script t1
     INNER JOIN (
@@ -259,8 +254,7 @@ label:BEGIN
       FROM step_instance 
       WHERE id BETWEEN fromId AND endId)
     AS tmp ON t1.step_instance_id = tmp.id 
-    SET t1.task_instance_id = tmp.task_instance_id
-    WHERE t1.task_instance_id = 0;
+    SET t1.task_instance_id = tmp.task_instance_id;
 
     UPDATE step_instance_file t1
     INNER JOIN (
@@ -268,8 +262,7 @@ label:BEGIN
       FROM step_instance 
       WHERE id BETWEEN fromId AND endId)
     AS tmp ON t1.step_instance_id = tmp.id 
-    SET t1.task_instance_id = tmp.task_instance_id
-    WHERE t1.task_instance_id = 0;
+    SET t1.task_instance_id = tmp.task_instance_id;
 
     UPDATE step_instance_rolling_task t1
     INNER JOIN (
@@ -277,8 +270,7 @@ label:BEGIN
       FROM step_instance 
       WHERE id BETWEEN fromId AND endId)
     AS tmp ON t1.step_instance_id = tmp.id 
-    SET t1.task_instance_id = tmp.task_instance_id
-    WHERE t1.task_instance_id = 0;
+    SET t1.task_instance_id = tmp.task_instance_id;
 
     COMMIT;
 


### PR DESCRIPTION
1. 删除 WHERE t1.task_instance_id = 0 的条件，避免触发 index merge
2. 删除该条件之后，更新速度提升，一亿条记录变更时间减少到 2h43m