### PR TITLE
feat: 解决部分 db 查询未使用 task_instance_id 作为查询条件，导致分片键无法命中的问题 #3357

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v2/impl/EsbGetStepInstanceStatusResourceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v2/impl/EsbGetStepInstanceStatusResourceImpl.java
@@ -93,7 +93,9 @@ public class EsbGetStepInstanceStatusResourceImpl implements EsbGetStepInstanceS
         EsbStepInstanceStatusDTO resultData = new EsbStepInstanceStatusDTO();
 
         StepExecutionResultQuery query = StepExecutionResultQuery.builder()
-            .stepInstanceId(request.getStepInstanceId()).build();
+            .taskInstanceId(request.getTaskInstanceId())
+            .stepInstanceId(request.getStepInstanceId())
+            .build();
         StepExecutionDetailDTO stepExecutionDetail = taskResultService.getStepExecutionResult(username,
             request.getAppId(), query);
 

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v3/EsbGetStepInstanceStatusV3ResourceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/esb/v3/EsbGetStepInstanceStatusV3ResourceImpl.java
@@ -140,6 +140,7 @@ public class EsbGetStepInstanceStatusV3ResourceImpl implements EsbGetStepInstanc
         long appId = appScopeMappingService.getAppIdByScope(scopeType, scopeId);
 
         StepExecutionResultQuery query = StepExecutionResultQuery.builder()
+            .taskInstanceId(taskInstanceId)
             .stepInstanceId(stepInstanceId)
             .executeCount(executeCount)
             .batch(batch == null ? null : (batch == 0 ? null : batch))

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/TaskInstanceIdDynamicCondition.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/TaskInstanceIdDynamicCondition.java
@@ -71,6 +71,8 @@ public class TaskInstanceIdDynamicCondition {
         if (FeatureToggle.checkFeature(FeatureIdConstants.DAO_ADD_TASK_INSTANCE_ID, toggleEvaluateContext)) {
             if (taskInstanceId == null || taskInstanceId <= 0L) {
                 log.info("TaskInstanceIdDynamicCondition : InvalidTaskInstanceId : {}", taskInstanceId);
+                // 输出堆栈信息，便于发现问题；后续功能稳定之后需要删除
+                safePrintStackTrace();
                 // 为了不影响兼容性，忽略错误
                 return DSL.trueCondition();
             } else {
@@ -82,6 +84,18 @@ public class TaskInstanceIdDynamicCondition {
             // 为了便于观察和排查，暂时设定为 INFO 级别，等后续正式交付再改成 DEBUG
             log.info("TaskInstanceIdDynamicCondition: IgnoreTaskInstanceIdCondition");
             return DSL.trueCondition();
+        }
+    }
+
+    private static void safePrintStackTrace() {
+        try {
+            StringBuilder message = new StringBuilder();
+            for (StackTraceElement stackTraceElement : Thread.currentThread().getStackTrace()) {
+                message.append(System.lineSeparator()).append(stackTraceElement.toString());
+            }
+            log.info("InvalidTaskInstanceIdConditionStackTrace: {}", message);
+        } catch (Throwable e) {
+            // ignore
         }
     }
 }


### PR DESCRIPTION
1. 修复 部分请求未传入 task_instance_id 作为dao 查询条件的问题
2. 打印堆栈信息，便于线上排查（后续版本稳定之后需要删除）