### PR TITLE
fix: 重启 job-backup 导致正在执行的归档任务未无损终止 #3359

### DIFF
--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractJobInstanceArchiveTask.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractJobInstanceArchiveTask.java
@@ -205,7 +205,6 @@ public abstract class AbstractJobInstanceArchiveTask<T extends TableRecord<?>> i
             }
 
             log.info("[{}] Start archive task", taskId);
-            ThreadUtils.sleep(1000*3600L, true);
             // 更新任务信息 - 启动完成
             updateStartedExecuteInfo();
             // 归档

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractJobInstanceArchiveTask.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractJobInstanceArchiveTask.java
@@ -41,7 +41,6 @@ import com.tencent.bk.job.backup.constant.ArchiveModeEnum;
 import com.tencent.bk.job.backup.constant.ArchiveTaskStatusEnum;
 import com.tencent.bk.job.backup.metrics.ArchiveErrorTaskCounter;
 import com.tencent.bk.job.common.util.StringUtil;
-import com.tencent.bk.job.common.util.ThreadUtils;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractJobInstanceArchiveTask.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbstractJobInstanceArchiveTask.java
@@ -41,6 +41,7 @@ import com.tencent.bk.job.backup.constant.ArchiveModeEnum;
 import com.tencent.bk.job.backup.constant.ArchiveTaskStatusEnum;
 import com.tencent.bk.job.backup.metrics.ArchiveErrorTaskCounter;
 import com.tencent.bk.job.common.util.StringUtil;
+import com.tencent.bk.job.common.util.ThreadUtils;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -204,6 +205,7 @@ public abstract class AbstractJobInstanceArchiveTask<T extends TableRecord<?>> i
             }
 
             log.info("[{}] Start archive task", taskId);
+            ThreadUtils.sleep(1000*3600L, true);
             // 更新任务信息 - 启动完成
             updateStartedExecuteInfo();
             // 归档

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceArchiveTaskScheduler.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceArchiveTaskScheduler.java
@@ -135,7 +135,6 @@ public class JobInstanceArchiveTaskScheduler implements SmartLifecycle {
                         continue;
                     }
 
-
                     // 获取待调度的任务信息(按照 DB 节点计数)
                     watch.start("countScheduleTasks");
                     Map<String, Integer> scheduleTasksGroupByDb =
@@ -307,10 +306,13 @@ public class JobInstanceArchiveTaskScheduler implements SmartLifecycle {
         @Override
         public void run() {
             try {
+                log.info("[{}] Run stop task begin", task.getTaskId());
                 task.stop(() -> taskCountDownLatch.decrement(task.getTaskId()));
             } catch (Throwable e) {
-                String errorMsg = "Stop archive task caught exception, task: " + task;
+                String errorMsg = "Stop archive task caught exception, task: " + task.getTaskId();
                 log.warn(errorMsg, e);
+            } finally {
+                log.info("[{}] Run stop task end", task.getTaskId());
             }
         }
     }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceArchiveTaskScheduler.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/JobInstanceArchiveTaskScheduler.java
@@ -161,12 +161,12 @@ public class JobInstanceArchiveTaskScheduler implements SmartLifecycle {
                     watch.stop();
                     int taskConcurrent = archiveProperties.getTasks().getJobInstance().getConcurrent();
                     if (highestPriorityDbNodeTasksInfo.getRunningTaskCount() >= taskConcurrent) {
-                        // 休眠5分钟，等待并行任务减少
-                        log.info("Running archive task count exceed concurrent limit : {}, wait 300s", taskConcurrent);
+                        // 休眠1分钟，等待并行任务减少
+                        log.info("Running archive task count exceed concurrent limit : {}, wait 60s", taskConcurrent);
                         // 释放锁
                         jobInstanceArchiveTaskScheduleLock.unlock();
                         locked = false;
-                        ThreadUtils.sleep(1000 * 300L);
+                        ThreadUtils.sleep(1000 * 60L);
                         continue;
                     }
 
@@ -279,8 +279,8 @@ public class JobInstanceArchiveTaskScheduler implements SmartLifecycle {
         }
         try {
             if (taskCountDownLatch != null) {
-                // 等待任务结束，最多等待 2min
-                boolean isAllTaskStopped = taskCountDownLatch.waitingForAllTasksDone(120);
+                // 等待任务结束，最多等待 10s(等待时间太长进程会被k8s kill掉)
+                boolean isAllTaskStopped = taskCountDownLatch.waitingForAllTasksDone(10);
                 if (!isAllTaskStopped) {
                     for (JobInstanceArchiveTask task : scheduledTasks.values()) {
                         task.forceStopAtOnce();

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfiguration.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ArchiveConfiguration.java
@@ -32,39 +32,7 @@ import com.tencent.bk.job.backup.archive.JobInstanceArchiveTaskGenerator;
 import com.tencent.bk.job.backup.archive.JobInstanceArchiveTaskScheduler;
 import com.tencent.bk.job.backup.archive.JobInstanceSubTableArchivers;
 import com.tencent.bk.job.backup.archive.dao.JobInstanceColdDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.FileSourceTaskLogRecordDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.GseFileAgentTaskRecordDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.GseFileExecuteObjTaskRecordDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.GseScriptAgentTaskRecordDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.GseScriptExecuteObjTaskRecordDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.GseTaskRecordDAO;
 import com.tencent.bk.job.backup.archive.dao.impl.JobInstanceHotRecordDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.OperationLogRecordDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.RollingConfigRecordDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.StepInstanceConfirmRecordDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.StepInstanceFileRecordDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.StepInstanceRecordDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.StepInstanceRollingTaskRecordDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.StepInstanceScriptRecordDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.StepInstanceVariableRecordDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.TaskInstanceHostRecordDAO;
-import com.tencent.bk.job.backup.archive.dao.impl.TaskInstanceVariableRecordDAO;
-import com.tencent.bk.job.backup.archive.impl.FileSourceTaskLogArchiver;
-import com.tencent.bk.job.backup.archive.impl.GseFileAgentTaskArchiver;
-import com.tencent.bk.job.backup.archive.impl.GseFileExecuteObjTaskArchiver;
-import com.tencent.bk.job.backup.archive.impl.GseScriptAgentTaskArchiver;
-import com.tencent.bk.job.backup.archive.impl.GseScriptExecuteObjTaskArchiver;
-import com.tencent.bk.job.backup.archive.impl.GseTaskArchiver;
-import com.tencent.bk.job.backup.archive.impl.OperationLogArchiver;
-import com.tencent.bk.job.backup.archive.impl.RollingConfigArchiver;
-import com.tencent.bk.job.backup.archive.impl.StepInstanceArchiver;
-import com.tencent.bk.job.backup.archive.impl.StepInstanceConfirmArchiver;
-import com.tencent.bk.job.backup.archive.impl.StepInstanceFileArchiver;
-import com.tencent.bk.job.backup.archive.impl.StepInstanceRollingTaskArchiver;
-import com.tencent.bk.job.backup.archive.impl.StepInstanceScriptArchiver;
-import com.tencent.bk.job.backup.archive.impl.StepInstanceVariableArchiver;
-import com.tencent.bk.job.backup.archive.impl.TaskInstanceHostArchiver;
-import com.tencent.bk.job.backup.archive.impl.TaskInstanceVariableArchiver;
 import com.tencent.bk.job.backup.archive.metrics.ArchiveTasksGauge;
 import com.tencent.bk.job.backup.archive.service.ArchiveTaskService;
 import com.tencent.bk.job.backup.archive.util.lock.ArchiveTaskExecuteLock;
@@ -73,7 +41,6 @@ import com.tencent.bk.job.backup.archive.util.lock.JobInstanceArchiveTaskGenerat
 import com.tencent.bk.job.backup.archive.util.lock.JobInstanceArchiveTaskScheduleLock;
 import com.tencent.bk.job.backup.metrics.ArchiveErrorTaskCounter;
 import com.tencent.bk.job.common.WatchableThreadPoolExecutor;
-import com.tencent.bk.job.common.mysql.dynamic.ds.DSLContextProvider;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
@@ -144,7 +111,7 @@ public class ArchiveConfiguration {
             5,
             20,
             120L,
-            TimeUnit.MILLISECONDS,
+            TimeUnit.SECONDS,
             new LinkedBlockingQueue<>(),
             new ThreadFactoryBuilder().setNameFormat("archive-task-stop-thread-pool-%d").build()
         );

--- a/support-files/kubernetes/charts/bk-job/VALUES_LOG.md
+++ b/support-files/kubernetes/charts/bk-job/VALUES_LOG.md
@@ -10,6 +10,12 @@ analysisConfig:
     model: hunyuan
 ```
 
+2. 调整pod删除时等待优雅关闭的最大时间，从 40s -> 60s
+```yaml
+# pod删除时等待优雅关闭的最大时间，单位为秒（超出后强制删除）
+podTerminationGracePeriodSeconds: 60
+```
+
 ## 0.8.0
 1. 增加按主机拓扑路径鉴权相关配置
 ```yaml

--- a/support-files/kubernetes/charts/bk-job/templates/job-execute/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-execute/deployment.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         {{ include "annotations.sha256sum.configmap" ( dict "service" "job-execute" "context" . ) | nindent 8 }}
     spec:
-      {{- include "job.podTerminationGracePeriodSeconds" . | nindent 6 }}
       {{- include "job.imagePullSecrets" . | nindent 6 }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- if .Values.executeConfig.affinity }}

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -1807,4 +1807,4 @@ assembleConfig:
           readTimeout: 300000
 
 # pod删除时等待优雅关闭的最大时间，单位为秒（超出后强制删除）
-podTerminationGracePeriodSeconds: 40
+podTerminationGracePeriodSeconds: 60


### PR DESCRIPTION
1. 修改 Values.podTerminationGracePeriodSeconds 默认值，从 40s -> 60s, 避免pod 关闭被k8s 直接 kill
2. job-execute 使用固定的 terminationGracePeriodSeconds=120s
3. 优化日志
4. 调整终止归档任务等待时间，从 120s调整为 10s
5. 减少归档任务调度休眠时间，提升调度效率