### PR TITLE
perf: 定时任务服务支持优雅停机 #2852 

### DIFF
--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/runner/LoadCronJobRunner.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/runner/LoadCronJobRunner.java
@@ -64,6 +64,7 @@ public class LoadCronJobRunner implements CommandLineRunner {
 
     @PreDestroy
     public void destroy() {
+        log.info("destroy LoadCronJobRunner");
         if (loadCronJobFuture != null) {
             boolean result = loadCronJobFuture.cancel(true);
             log.info("loadCronJobFuture cancel result:{}", result);

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/runner/LoadCronJobRunner.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/runner/LoadCronJobRunner.java
@@ -31,6 +31,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.stereotype.Component;
 
+import javax.annotation.PreDestroy;
+import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 
 /**
@@ -43,6 +45,8 @@ public class LoadCronJobRunner implements CommandLineRunner {
     private final CronJobLoadingService cronJobLoadingService;
     private final ThreadPoolExecutor crontabInitRunnerExecutor;
 
+    private Future<?> loadCronJobFuture;
+
     @Autowired
     public LoadCronJobRunner(CronJobLoadingService cronJobLoadingService,
                              @Qualifier("crontabInitRunnerExecutor") ThreadPoolExecutor crontabInitRunnerExecutor) {
@@ -52,9 +56,17 @@ public class LoadCronJobRunner implements CommandLineRunner {
 
     @Override
     public void run(String... args) {
-        crontabInitRunnerExecutor.submit(() -> {
+        loadCronJobFuture = crontabInitRunnerExecutor.submit(() -> {
             log.info("loadCronToQuartzOnStartup");
             cronJobLoadingService.loadAllCronJob();
         });
+    }
+
+    @PreDestroy
+    public void destroy() {
+        if (loadCronJobFuture != null) {
+            boolean result = loadCronJobFuture.cancel(true);
+            log.info("loadCronJobFuture cancel result:{}", result);
+        }
     }
 }

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/CronJobBatchLoadService.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/CronJobBatchLoadService.java
@@ -38,7 +38,7 @@ public interface CronJobBatchLoadService {
      * @param limit 一批定时任务的数量
      * @return 加载结果数据
      */
-    CronLoadResult batchLoadCronToQuartz(int start, int limit);
+    CronLoadResult batchLoadCronToQuartz(int start, int limit) throws InterruptedException;
 
     @Data
     class CronLoadResult {

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobLoadingServiceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobLoadingServiceImpl.java
@@ -57,6 +57,8 @@ public class CronJobLoadingServiceImpl implements CronJobLoadingService {
             }
             loadingCronToQuartz = true;
             loadAllCronJobToQuartz();
+        } catch (InterruptedException e) {
+            log.info("loadAllCronJob interrupted, application may be closing");
         } catch (Exception e) {
             log.warn("Fail to loadAllCronJob", e);
         } finally {
@@ -65,7 +67,7 @@ public class CronJobLoadingServiceImpl implements CronJobLoadingService {
         }
     }
 
-    private void loadAllCronJobToQuartz() {
+    private void loadAllCronJobToQuartz() throws InterruptedException {
         int start = 0;
         int limit = 100;
         int currentFetchNum;

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/timer/handler/DefaultQuartzTaskHandler.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/timer/handler/DefaultQuartzTaskHandler.java
@@ -26,18 +26,25 @@ package com.tencent.bk.job.crontab.timer.handler;
 
 import com.tencent.bk.job.crontab.timer.AbstractQuartzTaskHandler;
 import com.tencent.bk.job.crontab.timer.QuartzJob;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
-import org.quartz.*;
+import org.quartz.JobDetail;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.quartz.Trigger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * QuartzTaskHandler 的默认实现
  **/
+@Slf4j
 @Component
 public class DefaultQuartzTaskHandler extends AbstractQuartzTaskHandler {
 
@@ -59,6 +66,11 @@ public class DefaultQuartzTaskHandler extends AbstractQuartzTaskHandler {
         JobDetail jobDetail = createJobDetail(quartzJob);
 
         Set<? extends Trigger> triggers = createTriggers(quartzJob);
+
+        if (scheduler.isShutdown()) {
+            log.info("scheduler is shutdown, ignore add job {}!", quartzJob.getKey().getName());
+            return;
+        }
 
         if (CollectionUtils.isEmpty(triggers)) {
             this.scheduler.addJob(jobDetail, false);
@@ -84,12 +96,26 @@ public class DefaultQuartzTaskHandler extends AbstractQuartzTaskHandler {
         Assert.notNull(jobKey, "jobKey cannot be empty!");
         Assert.notNull(jobKey.getName(), "jobKey name cannot be empty!");
 
+        if (scheduler.isShutdown()) {
+            log.info("scheduler is shutdown, ignore delete job {}!", jobKey.getName());
+            return;
+        }
+
         this.scheduler.deleteJob(jobKey);
     }
 
     @Override
     public void deleteJob(List<JobKey> jobKeys) throws SchedulerException {
         Assert.notNull(jobKeys, "jobKeys cannot be empty!");
+
+        if (scheduler.isShutdown()) {
+            log.info(
+                "scheduler is shutdown, ignore delete {} job keys: {}",
+                jobKeys.size(),
+                jobKeys.stream().map(JobKey::getName).collect(Collectors.toList())
+            );
+            return;
+        }
 
         this.scheduler.deleteJobs(jobKeys);
     }
@@ -99,6 +125,10 @@ public class DefaultQuartzTaskHandler extends AbstractQuartzTaskHandler {
      */
     @Override
     public void pauseAll() throws SchedulerException {
+        if (scheduler.isShutdown()) {
+            log.info("scheduler is shutdown, ignore pauseAll!");
+            return;
+        }
         this.scheduler.pauseAll();
     }
 }

--- a/support-files/kubernetes/charts/bk-job/templates/job-crontab/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-crontab/configmap.yaml
@@ -93,6 +93,7 @@ data:
           shutdown-timeout: 100ms
       quartz:
         job-store-type: MEMORY
+        waitForJobsToCompleteOnShutdown: true
         properties:
           org:
             quartz:
@@ -100,9 +101,6 @@ data:
                 class: org.quartz.simpl.RAMJobStore
                 misfireThreshold: 60000
               plugin:
-                shutdownhook:
-                  class: org.quartz.plugins.management.ShutdownHookPlugin
-                  cleanShutdown: true
                 triggHistory:
                   class: org.quartz.plugins.history.LoggingJobHistoryPlugin
               scheduler:


### PR DESCRIPTION
1. 操作Quartz引擎前先检查其关闭状态；
2. 批量加载定时任务到Quartz支持被中断；
3. 进程关闭时取消批量加载任务；
4. 使用Spring Bean的关闭机制替代Quartz插件关闭钩子，避免Quartz过早关闭。