### PR TITLE
fix: 执行历史归档任务重调度逻辑不正确 #3364

### DIFF
--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbnormalArchiveTaskReScheduler.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/archive/AbnormalArchiveTaskReScheduler.java
@@ -113,9 +113,8 @@ public class AbnormalArchiveTaskReScheduler {
         }
         long currentTime = System.currentTimeMillis();
         runningTasks.forEach(runningTask -> {
-            // 如果归档任务没有正常结束，通过当前时间减去任务创建(修改）时间计算执行时长，判断是否超过合理的执行时长
-            if (currentTime - runningTask.getCreateTime() > TIMEOUT_MILLS ||
-                currentTime - runningTask.getLastUpdateTime() > TIMEOUT_MILLS) {
+            // 如果归档任务没有正常结束，通过当前时间减去任务最后修改时间计算执行时长，判断是否超过合理的执行时长
+            if (currentTime - runningTask.getLastUpdateTime() > TIMEOUT_MILLS) {
                 log.info("Found timeout archive task, and set archive task status to pending. taskId: {}",
                     runningTask.buildTaskUniqueId());
                 // 设置为 pending 状态，会被重新调度

--- a/support-files/kubernetes/charts/bk-job/templates/job-backup/deployment.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-backup/deployment.yaml
@@ -34,7 +34,6 @@ spec:
       annotations:
         {{ include "annotations.sha256sum.configmap" ( dict "service" "job-backup" "context" . ) | nindent 8 }}
     spec:
-      {{- include "job.podTerminationGracePeriodSeconds" . | nindent 6 }}
       {{- include "job.imagePullSecrets" . | nindent 6 }}
       hostAliases: {{- include "common.tplvalues.render" (dict "value" .Values.hostAliases "context" $) | nindent 8 }}
       {{- if .Values.backupConfig.affinity }}
@@ -104,6 +103,7 @@ spec:
             - name: redis
               mountPath: /etc/secrets/redis
               readOnly: true
+      terminationGracePeriodSeconds: 80
       volumes:
         - name: job-storage
           persistentVolumeClaim:


### PR DESCRIPTION
#3364 

1. 修复判断归档任务超时逻辑
2. 优化 JobInstanceArchiveTaskScheduler 挂起逻辑，在程序退出时主动唤醒正在挂起的线程，正常终止
3. 修改 job-backup 的 terminationGracePeriodSeconds 为 80s，避免归档任务异常退出引起不必要的问题
4. 修改归档任务终止等待时长（10s 不能保证任务被正常终止，30s 情况下基本可保证）