### PR TITLE
feat: 定时任务兼容不合法主机 #3305

### DIFF
--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/HostDTO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/HostDTO.java
@@ -127,16 +127,16 @@ public class HostDTO implements Cloneable {
     private String cloudVendorName;
 
     /**
-     * 管控区域:IP
+     * 管控区域:IPv4
      */
     @JsonIgnore
     private String cloudIp;
 
     @Deprecated
-    public HostDTO(Long bkCloudId, String ip) {
+    public HostDTO(Long bkCloudId, String ipv4) {
         this.bkCloudId = bkCloudId;
-        this.ip = ip;
-        this.cloudIp = buildCloudIp(bkCloudId, ip);
+        this.ip = ipv4;
+        this.cloudIp = buildCloudIp(bkCloudId, ipv4);
     }
 
     public HostDTO(Long hostId) {
@@ -191,8 +191,8 @@ public class HostDTO implements Cloneable {
         }
     }
 
-    private String buildCloudIp(Long bkCloudId, String ipv4) {
-        return bkCloudId + ":" + ipv4;
+    private String buildCloudIp(Long bkCloudId, String ip) {
+        return bkCloudId + ":" + ip;
     }
 
     /**

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/HostDTO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/HostDTO.java
@@ -126,10 +126,17 @@ public class HostDTO implements Cloneable {
      */
     private String cloudVendorName;
 
+    /**
+     * 管控区域:IP
+     */
+    @JsonIgnore
+    private String cloudIp;
+
     @Deprecated
     public HostDTO(Long bkCloudId, String ip) {
         this.bkCloudId = bkCloudId;
         this.ip = ip;
+        this.cloudIp = buildCloudIp(bkCloudId, ip);
     }
 
     public HostDTO(Long hostId) {
@@ -173,11 +180,19 @@ public class HostDTO implements Cloneable {
      * 返回主机 云区域:ipv4
      */
     public String toCloudIp() {
+        if (StringUtils.isNotEmpty(cloudIp)) {
+            return cloudIp;
+        }
         if (StringUtils.isEmpty(ip)) {
             return null;
         } else {
-            return bkCloudId + ":" + ip;
+            cloudIp = buildCloudIp(bkCloudId, ip);
+            return cloudIp;
         }
+    }
+
+    private String buildCloudIp(Long bkCloudId, String ipv4) {
+        return bkCloudId + ":" + ipv4;
     }
 
     /**
@@ -187,7 +202,7 @@ public class HostDTO implements Cloneable {
         if (StringUtils.isEmpty(ipv6)) {
             return null;
         } else {
-            return bkCloudId + ":" + ipv6;
+            return buildCloudIp(bkCloudId, ipv6);
         }
     }
 

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/TaskInstanceExecuteObjectProcessor.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/TaskInstanceExecuteObjectProcessor.java
@@ -468,22 +468,20 @@ public class TaskInstanceExecuteObjectProcessor {
 
         fillHostAgent(taskInstance, taskInstanceExecuteObjects);
 
-        Map<HostCompositeKey, HostDTO> hostMap = taskInstanceExecuteObjects.getHostMap();
-
         for (StepInstanceDTO stepInstance : stepInstanceList) {
             if (!stepInstance.isStepContainsExecuteObject()) {
                 continue;
             }
             // 目标主机设置主机详情
-            fillTargetHostDetail(stepInstance, hostMap);
+            fillTargetHostDetail(stepInstance, taskInstanceExecuteObjects);
             // 文件源设置主机详情
-            fillFileSourceHostDetail(stepInstance, hostMap);
+            fillFileSourceHostDetail(stepInstance, taskInstanceExecuteObjects);
         }
 
         if (CollectionUtils.isNotEmpty(variables)) {
             variables.forEach(variable -> {
                 if (variable.getType() == TaskVariableTypeEnum.HOST_LIST.getType()) {
-                    fillHostsDetail(variable.getExecuteTarget(), hostMap);
+                    fillHostsDetail(variable.getExecuteTarget(), taskInstanceExecuteObjects);
                 }
             });
         }
@@ -528,37 +526,41 @@ public class TaskInstanceExecuteObjectProcessor {
         }
     }
 
-    private void fillTargetHostDetail(StepInstanceDTO stepInstance, Map<HostCompositeKey, HostDTO> hostMap) {
-        fillHostsDetail(stepInstance.getTargetExecuteObjects(), hostMap);
+    private void fillTargetHostDetail(StepInstanceDTO stepInstance,
+                                      TaskInstanceExecuteObjects taskInstanceExecuteObjects) {
+        fillHostsDetail(stepInstance.getTargetExecuteObjects(), taskInstanceExecuteObjects);
     }
 
-    private void fillFileSourceHostDetail(StepInstanceDTO stepInstance, Map<HostCompositeKey, HostDTO> hostMap) {
+    private void fillFileSourceHostDetail(StepInstanceDTO stepInstance,
+                                          TaskInstanceExecuteObjects taskInstanceExecuteObjects) {
         if (stepInstance.getExecuteType() == SEND_FILE) {
             List<FileSourceDTO> fileSourceList = stepInstance.getFileSourceList();
             if (fileSourceList != null) {
                 for (FileSourceDTO fileSource : fileSourceList) {
-                    fillHostsDetail(fileSource.getServers(), hostMap);
+                    fillHostsDetail(fileSource.getServers(), taskInstanceExecuteObjects);
                 }
             }
         }
     }
 
-    private void fillHostsDetail(ExecuteTargetDTO executeTargetDTO, Map<HostCompositeKey, HostDTO> hostMap) {
+    private void fillHostsDetail(ExecuteTargetDTO executeTargetDTO,
+                                 TaskInstanceExecuteObjects taskInstanceExecuteObjects) {
         if (executeTargetDTO != null) {
-            fillHostsDetail(executeTargetDTO.getStaticIpList(), hostMap);
+            fillHostsDetail(executeTargetDTO.getStaticIpList(), taskInstanceExecuteObjects);
             if (CollectionUtils.isNotEmpty(executeTargetDTO.getDynamicServerGroups())) {
                 executeTargetDTO.getDynamicServerGroups()
-                    .forEach(group -> fillHostsDetail(group.getIpList(), hostMap));
+                    .forEach(group -> fillHostsDetail(group.getIpList(), taskInstanceExecuteObjects));
             }
             if (CollectionUtils.isNotEmpty(executeTargetDTO.getTopoNodes())) {
-                executeTargetDTO.getTopoNodes().forEach(topoNode -> fillHostsDetail(topoNode.getIpList(), hostMap));
+                executeTargetDTO.getTopoNodes().forEach(
+                    topoNode -> fillHostsDetail(topoNode.getIpList(), taskInstanceExecuteObjects));
             }
         }
     }
 
-    private void fillHostsDetail(Collection<HostDTO> hosts, Map<HostCompositeKey, HostDTO> hostMap) {
+    private void fillHostsDetail(Collection<HostDTO> hosts, TaskInstanceExecuteObjects taskInstanceExecuteObjects) {
         if (CollectionUtils.isNotEmpty(hosts)) {
-            hosts.forEach(host -> host.updateByHost(hostMap.get(host.getUniqueKey())));
+            hosts.forEach(host -> host.updateByHost(taskInstanceExecuteObjects.queryByHostKey(host)));
         }
     }
 


### PR DESCRIPTION
<img width="1648" alt="image" src="https://github.com/user-attachments/assets/132d4eef-3dee-4bd5-8403-2c61f9ee5928" />

解决执行作业场景，使用管控区域 id+ip 方式指定主机（不传入 hostId），空指针问题。修复之后，会根据 hostId 或者 cloudIp 查询对应的主机信息