### PR TITLE
perf: 定时任务全量加载速度优化 #3363

### DIFF
--- a/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/availability/JobApplicationAvailabilityBean.java
+++ b/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/availability/JobApplicationAvailabilityBean.java
@@ -12,8 +12,8 @@ public class JobApplicationAvailabilityBean extends ApplicationAvailabilityBean 
     public void onApplicationEvent(AvailabilityChangeEvent<?> event) {
         super.onApplicationEvent(event);
         if (ReadinessState.REFUSING_TRAFFIC == event.getState()) {
-            // SpringCloud负载均衡缓存默认为35s，等待调用方缓存刷新后再真正关闭Spring容器
-            int waitSeconds = 40;
+            // SpringCloud负载均衡缓存设置为20s，等待调用方缓存刷新后再真正关闭Spring容器
+            int waitSeconds = 30;
             while (waitSeconds > 0) {
                 ThreadUtils.sleep(1000);
                 log.info("wait for GracefulShutdown, {}s left", waitSeconds--);

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/dao/CronJobDAO.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/dao/CronJobDAO.java
@@ -72,7 +72,7 @@ public interface CronJobDAO {
      * @param cronJobIdList 定时任务 IDs
      * @return 定时任务信息
      */
-    List<CronJobInfoDTO> getCronJobByIds(List<Long> cronJobIdList);
+    List<CronJobInfoDTO> listCronJobByIds(List<Long> cronJobIdList);
 
     /**
      * 根据定时任务 ID 查询定时任务信息

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/dao/impl/CronJobDAOImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/dao/impl/CronJobDAOImpl.java
@@ -232,7 +232,7 @@ public class CronJobDAOImpl implements CronJobDAO {
     }
 
     @Override
-    public List<CronJobInfoDTO> getCronJobByIds(List<Long> cronJobIdList) {
+    public List<CronJobInfoDTO> listCronJobByIds(List<Long> cronJobIdList) {
         List<Condition> conditions = new ArrayList<>();
         conditions.add(TABLE.ID.in(cronJobIdList.stream().map(ULong::valueOf).collect(Collectors.toList())));
         conditions.add(TABLE.IS_DELETED.equal(UByte.valueOf(0)));

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/listener/CrontabEventListener.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/listener/CrontabEventListener.java
@@ -28,6 +28,7 @@ import com.tencent.bk.job.crontab.constant.CrontabActionEnum;
 import com.tencent.bk.job.crontab.listener.event.CrontabEvent;
 import com.tencent.bk.job.crontab.model.dto.CronJobInfoDTO;
 import com.tencent.bk.job.crontab.service.CronJobService;
+import com.tencent.bk.job.crontab.service.QuartzService;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.helpers.MessageFormatter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,10 +42,12 @@ import org.springframework.stereotype.Component;
 public class CrontabEventListener {
 
     private final CronJobService cronJobService;
+    private final QuartzService quartzService;
 
     @Autowired
-    public CrontabEventListener(CronJobService cronJobService) {
+    public CrontabEventListener(CronJobService cronJobService, QuartzService quartzService) {
         this.cronJobService = cronJobService;
+        this.quartzService = quartzService;
     }
 
 
@@ -86,7 +89,7 @@ public class CrontabEventListener {
         }
         if (cronJobInfoDTO.getEnable()) {
             // 开启定时任务
-            boolean result = cronJobService.addJobToQuartz(cronJobInfoDTO.getAppId(), cronJobInfoDTO.getId());
+            boolean result = cronJobService.checkAndAddJobToQuartz(cronJobInfoDTO.getAppId(), cronJobInfoDTO.getId());
             log.info(
                 "add cronJob({},{}) to quartz, result={}",
                 cronJobInfoDTO.getAppId(),
@@ -95,7 +98,7 @@ public class CrontabEventListener {
             );
         } else {
             // 关闭定时任务
-            boolean result = cronJobService.deleteJobFromQuartz(cronJobInfoDTO.getAppId(), cronJobInfoDTO.getId());
+            boolean result = quartzService.deleteJobFromQuartz(cronJobInfoDTO.getAppId(), cronJobInfoDTO.getId());
             log.info(
                 "delete cronJob({},{}) from quartz, result={}",
                 cronJobInfoDTO.getAppId(),
@@ -107,7 +110,7 @@ public class CrontabEventListener {
 
     private void deleteCronJobFromQuartz(long appId, long cronJobId) {
         // 删除定时任务
-        boolean result = cronJobService.deleteJobFromQuartz(appId, cronJobId);
+        boolean result = quartzService.deleteJobFromQuartz(appId, cronJobId);
         log.info(
             "delete cronJob({},{}) from quartz, result={}",
             appId,

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/AddJobToQuartzResult.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/AddJobToQuartzResult.java
@@ -1,0 +1,50 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.crontab.model.dto;
+
+import lombok.Data;
+
+/**
+ * 添加任务到Quartz的结果
+ */
+@Data
+public class AddJobToQuartzResult {
+    /**
+     * 定时任务基本信息
+     */
+    private CronJobBasicInfoDTO cronJobBasicInfo;
+    /**
+     * 是否成功
+     */
+    private boolean success;
+    /**
+     * 提示信息
+     */
+    private String message;
+    /**
+     * 异常信息
+     */
+    private Exception exception;
+}

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/AddJobToQuartzResult.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/AddJobToQuartzResult.java
@@ -47,4 +47,51 @@ public class AddJobToQuartzResult {
      * 异常信息
      */
     private Exception exception;
+
+    /**
+     * 构造失败结果
+     *
+     * @param cronJobBasicInfo 定时任务基本信息
+     * @param message          提示信息
+     * @return 失败结果
+     */
+    public static AddJobToQuartzResult failResult(CronJobBasicInfoDTO cronJobBasicInfo, String message) {
+        AddJobToQuartzResult result = new AddJobToQuartzResult();
+        result.setCronJobBasicInfo(cronJobBasicInfo);
+        result.setSuccess(false);
+        result.setMessage(message);
+        return result;
+    }
+
+    /**
+     * 构造失败结果
+     *
+     * @param cronJobBasicInfo 定时任务基本信息
+     * @param message          提示信息
+     * @param exception        异常信息
+     * @return 失败结果
+     */
+    public static AddJobToQuartzResult failResult(CronJobBasicInfoDTO cronJobBasicInfo,
+                                                  String message,
+                                                  Exception exception) {
+        AddJobToQuartzResult result = new AddJobToQuartzResult();
+        result.setCronJobBasicInfo(cronJobBasicInfo);
+        result.setSuccess(false);
+        result.setMessage(message);
+        result.setException(exception);
+        return result;
+    }
+
+    /**
+     * 构造成功结果
+     *
+     * @param cronJobBasicInfo 定时任务基本信息
+     * @return 成功结果
+     */
+    public static AddJobToQuartzResult successResult(CronJobBasicInfoDTO cronJobBasicInfo) {
+        AddJobToQuartzResult result = new AddJobToQuartzResult();
+        result.setCronJobBasicInfo(cronJobBasicInfo);
+        result.setSuccess(true);
+        return result;
+    }
 }

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/BatchAddResult.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/BatchAddResult.java
@@ -1,0 +1,76 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.crontab.model.dto;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 定时任务批量添加到Quartz的结果
+ */
+@Slf4j
+@Data
+public class BatchAddResult {
+    /**
+     * 添加结果Map，key为定时任务ID，value为添加结果
+     */
+    private Map<Long, AddJobToQuartzResult> resultMap;
+    /**
+     * 添加成功的任务数量
+     */
+    private int successNum = 0;
+    /**
+     * 添加失败的任务数量
+     */
+    private int failNum = 0;
+
+    /**
+     * 添加一个结果数据至批量结果
+     *
+     * @param result 单个结果数据
+     */
+    public void addResult(AddJobToQuartzResult result) {
+        if (result == null) {
+            return;
+        }
+        if (resultMap == null) {
+            resultMap = new HashMap<>();
+        }
+        CronJobBasicInfoDTO cronJobBasicInfo = result.getCronJobBasicInfo();
+        if (cronJobBasicInfo == null) {
+            log.info("cronJobBasicInfo is null, ignore");
+            return;
+        }
+        resultMap.put(cronJobBasicInfo.getId(), result);
+        if (result.isSuccess()) {
+            successNum++;
+        } else {
+            failNum++;
+        }
+    }
+}

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/BatchAddResult.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/BatchAddResult.java
@@ -26,8 +26,12 @@ package com.tencent.bk.job.crontab.model.dto;
 
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.CollectionUtils;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -72,5 +76,44 @@ public class BatchAddResult {
         } else {
             failNum++;
         }
+    }
+
+    /**
+     * 合并批量结果
+     *
+     * @param batchAddResult 待合并的批量结果
+     */
+    public void merge(BatchAddResult batchAddResult) {
+        if (batchAddResult == null) {
+            return;
+        }
+        if (CollectionUtils.isEmpty(batchAddResult.resultMap)) {
+            return;
+        }
+        if (resultMap == null) {
+            resultMap = new HashMap<>(batchAddResult.resultMap);
+        } else {
+            resultMap.putAll(batchAddResult.resultMap);
+        }
+        successNum += batchAddResult.successNum;
+        failNum += batchAddResult.failNum;
+    }
+
+    /**
+     * 获取批量添加失败的添加结果列表
+     *
+     * @return 批量添加失败的添加结果列表
+     */
+    public List<AddJobToQuartzResult> getFailedResultList() {
+        if (failNum == 0) {
+            return Collections.emptyList();
+        }
+        List<AddJobToQuartzResult> failedResultList = new ArrayList<>();
+        for (Map.Entry<Long, AddJobToQuartzResult> entry : resultMap.entrySet()) {
+            if (!entry.getValue().isSuccess()) {
+                failedResultList.add(entry.getValue());
+            }
+        }
+        return failedResultList;
     }
 }

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/CronJobInfoDTO.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/model/dto/CronJobInfoDTO.java
@@ -589,4 +589,12 @@ public class CronJobInfoDTO extends EncryptEnableVariables {
         cronJob.setLastModifyTime(lastModifyTime);
         return cronJob;
     }
+
+    public CronJobBasicInfoDTO toBasicInfoDTO() {
+        CronJobBasicInfoDTO cronJob = new CronJobBasicInfoDTO();
+        cronJob.setId(id);
+        cronJob.setAppId(appId);
+        cronJob.setName(name);
+        return cronJob;
+    }
 }

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/BatchCronJobService.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/BatchCronJobService.java
@@ -1,0 +1,55 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.crontab.service;
+
+import com.tencent.bk.job.crontab.model.BatchUpdateCronJobReq;
+import com.tencent.bk.job.crontab.model.dto.BatchAddResult;
+import com.tencent.bk.job.crontab.model.dto.CronJobBasicInfoDTO;
+import com.tencent.bk.job.crontab.model.dto.NeedScheduleCronInfo;
+
+import java.util.List;
+
+public interface BatchCronJobService {
+
+    /**
+     * 批量添加定时任务到Quartz
+     *
+     * @param cronJobBasicInfoList 定时任务列表
+     * @return 批量添加结果
+     */
+    BatchAddResult batchAddJobToQuartz(List<CronJobBasicInfoDTO> cronJobBasicInfoList);
+
+    /**
+     * 批量更新定时任务
+     *
+     * @param username              用户名
+     * @param appId                 Job业务ID
+     * @param batchUpdateCronJobReq 批量更新请求
+     * @return 更新结果数据
+     */
+    NeedScheduleCronInfo batchUpdateCronJob(String username,
+                                            Long appId,
+                                            BatchUpdateCronJobReq batchUpdateCronJobReq);
+}

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/CronJobService.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/CronJobService.java
@@ -252,9 +252,7 @@ public interface CronJobService {
 
     Integer countCronJob(Long appId, Boolean active, Boolean cron);
 
-    boolean addJobToQuartz(long appId, long cronJobId) throws ServiceException;
-
-    boolean deleteJobFromQuartz(long appId, long cronJobId);
+    boolean checkAndAddJobToQuartz(long appId, long cronJobId) throws ServiceException;
 
     List<CronJobBasicInfoDTO> listEnabledCronBasicInfoForUpdate(int start, int limit);
 

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/QuartzService.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/QuartzService.java
@@ -1,0 +1,45 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.crontab.service;
+
+import com.tencent.bk.job.crontab.model.dto.CronJobInfoDTO;
+
+public interface QuartzService {
+    /**
+     * 尝试将定时任务添加到Quartz中，若失败则删除
+     *
+     * @param cronJobInfo 定时任务信息
+     */
+    void tryToAddJobToQuartz(CronJobInfoDTO cronJobInfo);
+
+    /**
+     * 从Quartz中删除定时任务
+     *
+     * @param appId     Job业务ID
+     * @param cronJobId 定时任务ID
+     * @return 是否删除成功
+     */
+    boolean deleteJobFromQuartz(long appId, long cronJobId);
+}

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/BatchCronJobServiceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/BatchCronJobServiceImpl.java
@@ -32,6 +32,7 @@ import com.tencent.bk.job.crontab.dao.CronJobDAO;
 import com.tencent.bk.job.crontab.exception.TaskExecuteAuthFailedException;
 import com.tencent.bk.job.crontab.model.BatchUpdateCronJobReq;
 import com.tencent.bk.job.crontab.model.CronJobCreateUpdateReq;
+import com.tencent.bk.job.crontab.model.dto.AddJobToQuartzResult;
 import com.tencent.bk.job.crontab.model.dto.BatchAddResult;
 import com.tencent.bk.job.crontab.model.dto.CronJobBasicInfoDTO;
 import com.tencent.bk.job.crontab.model.dto.CronJobInfoDTO;
@@ -39,14 +40,17 @@ import com.tencent.bk.job.crontab.model.dto.CronJobVariableDTO;
 import com.tencent.bk.job.crontab.model.dto.NeedScheduleCronInfo;
 import com.tencent.bk.job.crontab.service.BatchCronJobService;
 import com.tencent.bk.job.crontab.service.ExecuteTaskService;
+import com.tencent.bk.job.crontab.service.QuartzService;
 import com.tencent.bk.job.execute.model.inner.ServiceTaskVariable;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
+import org.slf4j.helpers.MessageFormatter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -59,20 +63,110 @@ public class BatchCronJobServiceImpl implements BatchCronJobService {
     private final CronJobDAO cronJobDAO;
     private final CronAuthService cronAuthService;
     private final ExecuteTaskService executeTaskService;
+    private final QuartzService quartzService;
 
     @Autowired
     public BatchCronJobServiceImpl(CronJobDAO cronJobDAO,
                                    CronAuthService cronAuthService,
-                                   ExecuteTaskService executeTaskService) {
+                                   ExecuteTaskService executeTaskService, QuartzService quartzService) {
         this.cronJobDAO = cronJobDAO;
         this.cronAuthService = cronAuthService;
         this.executeTaskService = executeTaskService;
+        this.quartzService = quartzService;
     }
 
+    /**
+     * 批量添加定时任务到Quartz
+     *
+     * @param cronJobBasicInfoList 定时任务列表
+     * @return 批量添加结果
+     */
     @Override
     public BatchAddResult batchAddJobToQuartz(List<CronJobBasicInfoDTO> cronJobBasicInfoList) {
-        // TODO
-        return null;
+        List<Long> cronJobIdList = cronJobBasicInfoList.stream()
+            .map(CronJobBasicInfoDTO::getId)
+            .distinct()
+            .collect(Collectors.toList());
+        // 1.批量获取定时任务信息
+        List<CronJobInfoDTO> cronJobList = cronJobDAO.listCronJobByIds(cronJobIdList);
+        Map<Long, CronJobInfoDTO> cronJobMap = cronJobList.stream()
+            .collect(
+                Collectors.toMap(
+                    CronJobInfoDTO::getId,
+                    cronJobInfoDTO -> cronJobInfoDTO
+                )
+            );
+        BatchAddResult finalBatchResult = new BatchAddResult();
+        BatchAddResult notFoundBatchResult = recordNotFoundCronJobs(
+            cronJobBasicInfoList,
+            cronJobMap
+        );
+        finalBatchResult.merge(notFoundBatchResult);
+        // 2.过滤出开启的定时任务进行触发
+        BatchAddResult addToQuartzBatchResult = addEnabledCronJobToQuartz(cronJobList);
+        finalBatchResult.merge(addToQuartzBatchResult);
+        return finalBatchResult;
+    }
+
+    /**
+     * 批量添加开启的定时任务到Quartz
+     *
+     * @param cronJobList 定时任务列表
+     * @return 批量添加结果
+     */
+    private BatchAddResult addEnabledCronJobToQuartz(List<CronJobInfoDTO> cronJobList) {
+        BatchAddResult batchAddResult = new BatchAddResult();
+        for (CronJobInfoDTO cronJobInfoDTO : cronJobList) {
+            if (!cronJobInfoDTO.getEnable()) {
+                batchAddResult.addResult(AddJobToQuartzResult.failResult(
+                    cronJobInfoDTO.toBasicInfoDTO(),
+                    String.format("CronJob(id=%s) is not enabled, ignore", cronJobInfoDTO.getId())
+                ));
+                continue;
+            }
+            try {
+                quartzService.tryToAddJobToQuartz(cronJobInfoDTO);
+                batchAddResult.addResult(AddJobToQuartzResult.successResult(cronJobInfoDTO.toBasicInfoDTO()));
+            } catch (Exception e) {
+                String message = MessageFormatter.format(
+                    "Add cronJob(id={}) to quartz failed",
+                    cronJobInfoDTO.getId()
+                ).getMessage();
+                log.error(message, e);
+                batchAddResult.addResult(
+                    AddJobToQuartzResult.failResult(
+                        cronJobInfoDTO.toBasicInfoDTO(),
+                        message,
+                        e
+                    )
+                );
+            }
+        }
+        return batchAddResult;
+    }
+
+    /**
+     * 记录DB中不存在的定时任务
+     *
+     * @param cronJobBasicInfoList 需要添加到Quartz的定时任务基础信息列表
+     * @param cronJobMap           DB中存在的定时任务信息
+     * @return 批量添加失败的定时任务信息
+     */
+    private BatchAddResult recordNotFoundCronJobs(List<CronJobBasicInfoDTO> cronJobBasicInfoList,
+                                                  Map<Long, CronJobInfoDTO> cronJobMap) {
+        BatchAddResult batchAddResult = new BatchAddResult();
+        for (CronJobBasicInfoDTO cronJobBasicInfoDTO : cronJobBasicInfoList) {
+            Long cronJobId = cronJobBasicInfoDTO.getId();
+            if (!cronJobMap.containsKey(cronJobId)) {
+                batchAddResult.addResult(
+                    AddJobToQuartzResult.failResult(
+                        cronJobBasicInfoDTO,
+                        "Cannot find cronJob in DB by id: " + cronJobId
+                    )
+                );
+            }
+        }
+        return batchAddResult;
     }
 
     /**
@@ -97,9 +191,9 @@ public class BatchCronJobServiceImpl implements BatchCronJobService {
 
         List<Long> needAddCronIdList = new ArrayList<>();
         List<Long> needDeleteCronIdList = new ArrayList<>();
-        cronJobReqList.forEach(cronJobReq -> {
-            updateCronJob(username, appId, cronJobReq, needAddCronIdList, needDeleteCronIdList);
-        });
+        cronJobReqList.forEach(cronJobReq ->
+            updateCronJob(username, appId, cronJobReq, needAddCronIdList, needDeleteCronIdList)
+        );
         return new NeedScheduleCronInfo(needAddCronIdList, needDeleteCronIdList);
     }
 

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/BatchCronJobServiceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/BatchCronJobServiceImpl.java
@@ -32,9 +32,12 @@ import com.tencent.bk.job.crontab.dao.CronJobDAO;
 import com.tencent.bk.job.crontab.exception.TaskExecuteAuthFailedException;
 import com.tencent.bk.job.crontab.model.BatchUpdateCronJobReq;
 import com.tencent.bk.job.crontab.model.CronJobCreateUpdateReq;
+import com.tencent.bk.job.crontab.model.dto.BatchAddResult;
+import com.tencent.bk.job.crontab.model.dto.CronJobBasicInfoDTO;
 import com.tencent.bk.job.crontab.model.dto.CronJobInfoDTO;
 import com.tencent.bk.job.crontab.model.dto.CronJobVariableDTO;
 import com.tencent.bk.job.crontab.model.dto.NeedScheduleCronInfo;
+import com.tencent.bk.job.crontab.service.BatchCronJobService;
 import com.tencent.bk.job.crontab.service.ExecuteTaskService;
 import com.tencent.bk.job.execute.model.inner.ServiceTaskVariable;
 import lombok.extern.slf4j.Slf4j;
@@ -51,19 +54,25 @@ import java.util.stream.Collectors;
  */
 @Slf4j
 @Service
-public class BatchCronJobService {
+public class BatchCronJobServiceImpl implements BatchCronJobService {
 
     private final CronJobDAO cronJobDAO;
     private final CronAuthService cronAuthService;
     private final ExecuteTaskService executeTaskService;
 
     @Autowired
-    public BatchCronJobService(CronJobDAO cronJobDAO,
-                               CronAuthService cronAuthService,
-                               ExecuteTaskService executeTaskService) {
+    public BatchCronJobServiceImpl(CronJobDAO cronJobDAO,
+                                   CronAuthService cronAuthService,
+                                   ExecuteTaskService executeTaskService) {
         this.cronJobDAO = cronJobDAO;
         this.cronAuthService = cronAuthService;
         this.executeTaskService = executeTaskService;
+    }
+
+    @Override
+    public BatchAddResult batchAddJobToQuartz(List<CronJobBasicInfoDTO> cronJobBasicInfoList) {
+        // TODO
+        return null;
     }
 
     /**

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobBatchLoadServiceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobBatchLoadServiceImpl.java
@@ -58,7 +58,7 @@ public class CronJobBatchLoadServiceImpl implements CronJobBatchLoadService {
             checkInterrupt();
             boolean result = false;
             try {
-                result = cronJobService.addJobToQuartz(
+                result = cronJobService.checkAndAddJobToQuartz(
                     cronJobBasicInfoDTO.getAppId(),
                     cronJobBasicInfoDTO.getId()
                 );

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobBatchLoadServiceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobBatchLoadServiceImpl.java
@@ -25,7 +25,10 @@
 package com.tencent.bk.job.crontab.service.impl;
 
 import com.tencent.bk.job.common.mysql.JobTransactional;
+import com.tencent.bk.job.crontab.model.dto.AddJobToQuartzResult;
+import com.tencent.bk.job.crontab.model.dto.BatchAddResult;
 import com.tencent.bk.job.crontab.model.dto.CronJobBasicInfoDTO;
+import com.tencent.bk.job.crontab.service.BatchCronJobService;
 import com.tencent.bk.job.crontab.service.CronJobBatchLoadService;
 import com.tencent.bk.job.crontab.service.CronJobService;
 import lombok.extern.slf4j.Slf4j;
@@ -41,58 +44,60 @@ import java.util.List;
 public class CronJobBatchLoadServiceImpl implements CronJobBatchLoadService {
 
     private final CronJobService cronJobService;
+    private final BatchCronJobService batchCronJobService;
 
     @Autowired
-    public CronJobBatchLoadServiceImpl(CronJobService cronJobService) {
+    public CronJobBatchLoadServiceImpl(CronJobService cronJobService, BatchCronJobService batchCronJobService) {
         this.cronJobService = cronJobService;
+        this.batchCronJobService = batchCronJobService;
     }
 
     @Override
     @JobTransactional(transactionManager = "jobCrontabTransactionManager", timeout = 30)
     public CronLoadResult batchLoadCronToQuartz(int start, int limit) throws InterruptedException {
-        int successNum = 0;
-        int failedNum = 0;
-        List<CronJobBasicInfoDTO> failedCronList = new ArrayList<>();
+        checkInterrupt();
         List<CronJobBasicInfoDTO> cronJobBasicInfoList = cronJobService.listEnabledCronBasicInfoForUpdate(start, limit);
-        for (CronJobBasicInfoDTO cronJobBasicInfoDTO : cronJobBasicInfoList) {
-            checkInterrupt();
-            boolean result = false;
-            try {
-                result = cronJobService.checkAndAddJobToQuartz(
-                    cronJobBasicInfoDTO.getAppId(),
-                    cronJobBasicInfoDTO.getId()
-                );
-                if (result) {
-                    successNum += 1;
-                } else {
-                    failedNum += 1;
-                    failedCronList.add(cronJobBasicInfoDTO);
-                }
-            } catch (Exception e) {
-                failedNum += 1;
-                failedCronList.add(cronJobBasicInfoDTO);
-                String message = MessageFormatter.format(
-                    "Fail to addJobToQuartz, cronJob={}",
-                    cronJobBasicInfoDTO
-                ).getMessage();
-                log.warn(message, e);
-            }
-            if (log.isDebugEnabled()) {
-                log.debug(
-                    "load cronJob({},{},{}), result={}",
-                    cronJobBasicInfoDTO.getAppId(),
-                    cronJobBasicInfoDTO.getId(),
-                    cronJobBasicInfoDTO.getName(),
-                    result
-                );
-            }
-        }
+        BatchAddResult batchAddResult = batchCronJobService.batchAddJobToQuartz(cronJobBasicInfoList);
+        List<CronJobBasicInfoDTO> failedCronList = extractFailedCronList(batchAddResult);
         CronLoadResult cronLoadResult = new CronLoadResult();
         cronLoadResult.setFetchNum(cronJobBasicInfoList.size());
-        cronLoadResult.setSuccessNum(successNum);
-        cronLoadResult.setFailedNum(failedNum);
+        cronLoadResult.setSuccessNum(batchAddResult.getSuccessNum());
+        cronLoadResult.setFailedNum(batchAddResult.getFailNum());
         cronLoadResult.setFailedCronList(failedCronList);
         return cronLoadResult;
+    }
+
+    /**
+     * 从批量添加定时任务结果数据中提取失败的定时任务信息
+     *
+     * @param batchAddResult 批量添加定时任务结果
+     * @return 失败的定时任务信息
+     */
+    private List<CronJobBasicInfoDTO> extractFailedCronList(BatchAddResult batchAddResult) {
+        List<CronJobBasicInfoDTO> failedCronList = new ArrayList<>();
+        int successNum = batchAddResult.getSuccessNum();
+        int failedNum = batchAddResult.getFailNum();
+        if (failedNum > 0) {
+            log.warn("batchAddJobToQuartz result: {} failed, {} success", failedNum, successNum);
+            List<AddJobToQuartzResult> failedResultList = batchAddResult.getFailedResultList();
+            for (AddJobToQuartzResult addJobToQuartzResult : failedResultList) {
+                CronJobBasicInfoDTO cronJobBasicInfo = addJobToQuartzResult.getCronJobBasicInfo();
+                failedCronList.add(cronJobBasicInfo);
+                String message = MessageFormatter.arrayFormat(
+                    "Fail to load cronJob({},{},{}), reason={}",
+                    new Object[]{
+                        cronJobBasicInfo.getAppId(),
+                        cronJobBasicInfo.getId(),
+                        cronJobBasicInfo.getName(),
+                        addJobToQuartzResult.getMessage()
+                    }
+                ).getMessage();
+                log.warn(message, addJobToQuartzResult.getException());
+            }
+        } else {
+            log.info("batchAddJobToQuartz result: All success, num={}", successNum);
+        }
+        return failedCronList;
     }
 
     private void checkInterrupt() throws InterruptedException {

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobServiceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobServiceImpl.java
@@ -151,7 +151,7 @@ public class CronJobServiceImpl implements CronJobService {
 
     @Override
     public Map<Long, CronJobInfoDTO> getCronJobInfoMapByIds(List<Long> cronJobIdList) {
-        List<CronJobInfoDTO> cronJobInfoDTOList = cronJobDAO.getCronJobByIds(cronJobIdList);
+        List<CronJobInfoDTO> cronJobInfoDTOList = cronJobDAO.listCronJobByIds(cronJobIdList);
         Map<Long, CronJobInfoDTO> map = new HashMap<>();
         for (CronJobInfoDTO cronJobInfoDTO : cronJobInfoDTOList) {
             map.put(cronJobInfoDTO.getId(), cronJobInfoDTO);

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobServiceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/CronJobServiceImpl.java
@@ -62,9 +62,11 @@ import com.tencent.bk.job.crontab.model.inner.ServerDTO;
 import com.tencent.bk.job.crontab.model.inner.ServiceInnerCronJobInfoDTO;
 import com.tencent.bk.job.crontab.model.inner.request.ServiceAddInnerCronJobRequestDTO;
 import com.tencent.bk.job.crontab.mq.CrontabMQEventDispatcher;
+import com.tencent.bk.job.crontab.service.BatchCronJobService;
 import com.tencent.bk.job.crontab.service.CronJobService;
 import com.tencent.bk.job.crontab.service.ExecuteTaskService;
 import com.tencent.bk.job.crontab.service.HostService;
+import com.tencent.bk.job.crontab.service.QuartzService;
 import com.tencent.bk.job.crontab.service.TaskPlanService;
 import com.tencent.bk.job.crontab.timer.AbstractQuartzTaskHandler;
 import com.tencent.bk.job.crontab.timer.QuartzJob;
@@ -72,8 +74,6 @@ import com.tencent.bk.job.crontab.timer.QuartzJobBuilder;
 import com.tencent.bk.job.crontab.timer.QuartzTrigger;
 import com.tencent.bk.job.crontab.timer.QuartzTriggerBuilder;
 import com.tencent.bk.job.crontab.timer.executor.InnerJobExecutor;
-import com.tencent.bk.job.crontab.timer.executor.NotifyJobExecutor;
-import com.tencent.bk.job.crontab.timer.executor.SimpleJobExecutor;
 import com.tencent.bk.job.execute.model.inner.ServiceTaskVariable;
 import com.tencent.bk.job.manage.model.inner.ServiceTaskPlanDTO;
 import lombok.extern.slf4j.Slf4j;
@@ -109,6 +109,7 @@ public class CronJobServiceImpl implements CronJobService {
     private final CronJobDAO cronJobDAO;
 
     private final AbstractQuartzTaskHandler quartzTaskHandler;
+    private final QuartzService quartzService;
     private final TaskPlanService taskPlanService;
     private final CronAuthService cronAuthService;
     private final ExecuteTaskService executeTaskService;
@@ -119,32 +120,22 @@ public class CronJobServiceImpl implements CronJobService {
     @Autowired
     public CronJobServiceImpl(CronJobDAO cronJobDAO,
                               AbstractQuartzTaskHandler quartzTaskHandler,
+                              QuartzService quartzService,
                               TaskPlanService taskPlanService,
                               CronAuthService cronAuthService,
                               ExecuteTaskService executeTaskService,
                               HostService hostService,
                               CrontabMQEventDispatcher crontabMQEventDispatcher,
-                              BatchCronJobService batchCronJobService) {
+                              BatchCronJobServiceImpl batchCronJobService) {
         this.cronJobDAO = cronJobDAO;
         this.quartzTaskHandler = quartzTaskHandler;
+        this.quartzService = quartzService;
         this.taskPlanService = taskPlanService;
         this.cronAuthService = cronAuthService;
         this.executeTaskService = executeTaskService;
         this.hostService = hostService;
         this.crontabMQEventDispatcher = crontabMQEventDispatcher;
         this.batchCronJobService = batchCronJobService;
-    }
-
-    private static String getJobName(long appId, long cronJobId) {
-        return "job_" + cronJobId;
-    }
-
-    private static String getJobGroup(long appId, long cronJobId) {
-        return "bk_app_" + appId;
-    }
-
-    private static String getNotifyJobName(long appId, long cronJobId) {
-        return getJobName(appId, cronJobId) + "_notify";
     }
 
     @Override
@@ -727,134 +718,20 @@ public class CronJobServiceImpl implements CronJobService {
     }
 
     @Override
-    public boolean addJobToQuartz(long appId, long cronJobId) throws ServiceException {
+    public boolean checkAndAddJobToQuartz(long appId, long cronJobId) throws ServiceException {
         if (appId <= 0 || cronJobId <= 0) {
             return false;
         }
-        try {
-            CronJobInfoDTO cronJobInfo = getCronJobInfoById(appId, cronJobId);
-            if (StringUtils.isBlank(cronJobInfo.getCronExpression())
-                && cronJobInfo.getExecuteTime() < DateUtils.currentTimeSeconds()) {
-                throw new FailedPreconditionException(ErrorCode.CRON_JOB_TIME_PASSED);
-            }
-            checkCronRelatedPlan(cronJobInfo.getAppId(), cronJobInfo.getTaskPlanId());
-            QuartzTrigger trigger = null;
-            if (StringUtils.isNotBlank(cronJobInfo.getCronExpression())) {
-                QuartzTriggerBuilder cronTriggerBuilder =
-                    QuartzTriggerBuilder.newTrigger().ofType(QuartzTrigger.TriggerType.CRON)
-                        .withIdentity(getJobName(appId, cronJobId), getJobGroup(appId, cronJobId))
-                        .withCronExpression(cronJobInfo.getCronExpression())
-                        .withMisfireInstruction(CronTrigger.MISFIRE_INSTRUCTION_DO_NOTHING);
-                if (cronJobInfo.getEndTime() > 0) {
-                    if (cronJobInfo.getEndTime() < DateUtils.currentTimeSeconds()) {
-                        throw new FailedPreconditionException(ErrorCode.END_TIME_OR_NOTIFY_TIME_ALREADY_PASSED);
-                    } else {
-                        cronTriggerBuilder =
-                            cronTriggerBuilder.endAt(Date.from(Instant.ofEpochSecond(cronJobInfo.getEndTime())));
-                    }
-                }
-                trigger = cronTriggerBuilder.build();
-            } else if (cronJobInfo.getExecuteTime() > DateUtils.currentTimeSeconds()) {
-                trigger = QuartzTriggerBuilder.newTrigger().ofType(QuartzTrigger.TriggerType.SIMPLE)
-                    .withIdentity(getJobName(appId, cronJobId), getJobGroup(appId, cronJobId))
-                    .startAt(Date.from(Instant.ofEpochSecond(cronJobInfo.getExecuteTime()))).withRepeatCount(0)
-                    .withIntervalInHours(1)
-                    .withMisfireInstruction(SimpleTrigger.MISFIRE_INSTRUCTION_RESCHEDULE_NEXT_WITH_REMAINING_COUNT)
-                    .build();
-            }
-            if (trigger == null) {
-                throw new InvalidParamException(ErrorCode.ILLEGAL_PARAM);
-            }
-
-            QuartzJob job =
-                QuartzJobBuilder.newJob().withIdentity(getJobName(appId, cronJobId), getJobGroup(appId, cronJobId))
-                    .forJob(SimpleJobExecutor.class)
-                    .usingJobData(CronConstants.JOB_DATA_KEY_APP_ID_STR, String.valueOf(appId))
-                    .usingJobData(CronConstants.JOB_DATA_KEY_CRON_JOB_ID_STR, String.valueOf(cronJobId))
-                    .withTrigger(trigger)
-                    .build();
-
-            try {
-                quartzTaskHandler
-                    .deleteJob(JobKey.jobKey(getJobName(appId, cronJobId), getJobGroup(appId, cronJobId)));
-                quartzTaskHandler.addJob(job);
-            } catch (SchedulerException e) {
-                log.error("Error while add job to quartz!", e);
-                throw new InternalException("Add to quartz failed!", e, ErrorCode.INTERNAL_ERROR);
-            }
-
-            if (cronJobInfo.getNotifyOffset() > 0) {
-                long notifyTime = 0L;
-                if (StringUtils.isNotBlank(cronJobInfo.getCronExpression())) {
-                    if (cronJobInfo.getEndTime() > 0) {
-                        notifyTime = cronJobInfo.getEndTime() - cronJobInfo.getNotifyOffset();
-                    }
-                } else {
-                    notifyTime = cronJobInfo.getExecuteTime() - cronJobInfo.getNotifyOffset();
-                }
-                if (notifyTime < DateUtils.currentTimeSeconds()) {
-                    throw new FailedPreconditionException(ErrorCode.END_TIME_OR_NOTIFY_TIME_ALREADY_PASSED);
-                }
-
-                QuartzTrigger notifyTrigger = QuartzTriggerBuilder.newTrigger()
-                    .ofType(QuartzTrigger.TriggerType.SIMPLE)
-                    .withIdentity(getNotifyJobName(appId, cronJobId), getJobGroup(appId, cronJobId))
-                    .startAt(Date.from(Instant.ofEpochSecond(notifyTime))).withRepeatCount(0).withIntervalInHours(1)
-                    .withMisfireInstruction(SimpleTrigger.MISFIRE_INSTRUCTION_RESCHEDULE_NEXT_WITH_REMAINING_COUNT)
-                    .build();
-
-                QuartzJob notifyJob = QuartzJobBuilder.newJob()
-                    .withIdentity(getNotifyJobName(appId, cronJobId), getJobGroup(appId, cronJobId))
-                    .forJob(NotifyJobExecutor.class)
-                    .usingJobData(CronConstants.JOB_DATA_KEY_APP_ID_STR, String.valueOf(appId))
-                    .usingJobData(CronConstants.JOB_DATA_KEY_CRON_JOB_ID_STR, String.valueOf(cronJobId))
-                    .withTrigger(notifyTrigger)
-                    .build();
-
-                try {
-                    quartzTaskHandler.deleteJob(
-                        JobKey.jobKey(getNotifyJobName(appId, cronJobId), getJobGroup(appId, cronJobId)));
-                    quartzTaskHandler.addJob(notifyJob);
-                } catch (SchedulerException e) {
-                    log.error("Error while add job to quartz!", e);
-                    throw new InternalException("Add to quartz failed!", e, ErrorCode.INTERNAL_ERROR);
-                }
-            } else {
-                try {
-                    quartzTaskHandler.deleteJob(
-                        JobKey.jobKey(getNotifyJobName(appId, cronJobId), getJobGroup(appId, cronJobId)));
-                } catch (SchedulerException e) {
-                    log.error("Error while add job to quartz!", e);
-                    throw new InternalException("Add to quartz failed!", e, ErrorCode.INTERNAL_ERROR);
-                }
-            }
-            return true;
-        } catch (ServiceException e) {
-            deleteJobFromQuartz(appId, cronJobId);
-            log.debug("Error while schedule job", e);
-            throw e;
-        } catch (Exception e) {
-            deleteJobFromQuartz(appId, cronJobId);
-            log.error("Unknown exception while process cron status change!", e);
-            throw new InternalException(ErrorCode.UPDATE_CRON_JOB_FAILED);
+        CronJobInfoDTO cronJobInfo = getCronJobInfoById(appId, cronJobId);
+        if (StringUtils.isBlank(cronJobInfo.getCronExpression())
+            && cronJobInfo.getExecuteTime() < DateUtils.currentTimeSeconds()) {
+            throw new FailedPreconditionException(ErrorCode.CRON_JOB_TIME_PASSED);
         }
+        checkCronRelatedPlan(cronJobInfo.getAppId(), cronJobInfo.getTaskPlanId());
+        quartzService.tryToAddJobToQuartz(cronJobInfo);
+        return true;
     }
 
-    @Override
-    public boolean deleteJobFromQuartz(long appId, long cronJobId) {
-        if (appId <= 0 || cronJobId <= 0) {
-            return false;
-        }
-        try {
-            quartzTaskHandler.deleteJob(JobKey.jobKey(getJobName(appId, cronJobId), getJobGroup(appId, cronJobId)));
-            quartzTaskHandler
-                .deleteJob(JobKey.jobKey(getNotifyJobName(appId, cronJobId), getJobGroup(appId, cronJobId)));
-            return true;
-        } catch (SchedulerException e) {
-            log.error("Error while delete job!", e);
-        }
-        return false;
-    }
 
     @Override
     public List<CronJobBasicInfoDTO> listEnabledCronBasicInfoForUpdate(int start, int limit) {
@@ -867,25 +744,26 @@ public class CronJobServiceImpl implements CronJobService {
         cronJobInfoDTO.setAppId(appId);
         cronJobInfoDTO.setEnable(true);
         List<Long> cronJobIdList = cronJobDAO.listCronJobIds(cronJobInfoDTO);
+        if (CollectionUtils.isEmpty(cronJobIdList)) {
+            return true;
+        }
         List<Long> failedCronJobIds = new ArrayList<>();
-        if (CollectionUtils.isNotEmpty(cronJobIdList)) {
-            log.info("cron job will be disabled, appId:{}, cronJobIds:{}", appId, cronJobIdList);
-            for (Long cronJobId : cronJobIdList) {
-                try {
-                    Boolean disableResult = changeCronJobEnableStatus(JobConstants.DEFAULT_SYSTEM_USER_ADMIN, appId,
-                        cronJobId, false);
-                    log.debug("disable cron job, result:{}, appId:{}, cronId:{}", disableResult, appId, cronJobId);
-                    if (!disableResult) {
-                        failedCronJobIds.add(cronJobId);
-                    }
-                } catch (Exception e) {
-                    log.error("Failed to disable cron job with appId:{} and cronId:{}", appId, cronJobId, e);
+        log.info("cron job will be disabled, appId:{}, cronJobIds:{}", appId, cronJobIdList);
+        for (Long cronJobId : cronJobIdList) {
+            try {
+                Boolean disableResult = changeCronJobEnableStatus(JobConstants.DEFAULT_SYSTEM_USER_ADMIN, appId,
+                    cronJobId, false);
+                log.debug("disable cron job, result:{}, appId:{}, cronId:{}", disableResult, appId, cronJobId);
+                if (!disableResult) {
                     failedCronJobIds.add(cronJobId);
                 }
+            } catch (Exception e) {
+                log.error("Failed to disable cron job with appId:{} and cronId:{}", appId, cronJobId, e);
+                failedCronJobIds.add(cronJobId);
             }
-            if (!failedCronJobIds.isEmpty()) {
-                log.warn("Failed to disable cron jobs for appId:{} with cronJobIds:{}", appId, failedCronJobIds);
-            }
+        }
+        if (!failedCronJobIds.isEmpty()) {
+            log.warn("Failed to disable cron jobs for appId:{} with cronJobIds:{}", appId, failedCronJobIds);
         }
         return failedCronJobIds.isEmpty();
     }

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/JobCronNameUtil.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/JobCronNameUtil.java
@@ -32,32 +32,29 @@ public class JobCronNameUtil {
     /**
      * 获取Quartz Job名称
      *
-     * @param appId     Job业务ID
      * @param cronJobId 定时任务ID
      * @return Quartz Job名称
      */
-    public static String getJobName(long appId, long cronJobId) {
+    public static String getJobName(long cronJobId) {
         return "job_" + cronJobId;
     }
 
     /**
      * 获取Quartz Job分组
      *
-     * @param appId     Job业务ID
-     * @param cronJobId 定时任务ID
+     * @param appId Job业务ID
      * @return Quartz Job分组
      */
-    public static String getJobGroup(long appId, long cronJobId) {
+    public static String getJobGroup(long appId) {
         return "bk_app_" + appId;
     }
 
     /***
      * 获取通知Job名称
-     * @param appId Job业务ID
      * @param cronJobId 定时任务ID
      * @return 通知Job名称
      */
-    public static String getNotifyJobName(long appId, long cronJobId) {
-        return getJobName(appId, cronJobId) + "_notify";
+    public static String getNotifyJobName(long cronJobId) {
+        return getJobName(cronJobId) + "_notify";
     }
 }

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/JobCronNameUtil.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/JobCronNameUtil.java
@@ -1,0 +1,63 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.crontab.service.impl;
+
+/**
+ * Job定时任务名称工具类
+ */
+public class JobCronNameUtil {
+
+    /**
+     * 获取Quartz Job名称
+     *
+     * @param appId     Job业务ID
+     * @param cronJobId 定时任务ID
+     * @return Quartz Job名称
+     */
+    public static String getJobName(long appId, long cronJobId) {
+        return "job_" + cronJobId;
+    }
+
+    /**
+     * 获取Quartz Job分组
+     *
+     * @param appId     Job业务ID
+     * @param cronJobId 定时任务ID
+     * @return Quartz Job分组
+     */
+    public static String getJobGroup(long appId, long cronJobId) {
+        return "bk_app_" + appId;
+    }
+
+    /***
+     * 获取通知Job名称
+     * @param appId Job业务ID
+     * @param cronJobId 定时任务ID
+     * @return 通知Job名称
+     */
+    public static String getNotifyJobName(long appId, long cronJobId) {
+        return getJobName(appId, cronJobId) + "_notify";
+    }
+}

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/QuartzServiceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/QuartzServiceImpl.java
@@ -84,9 +84,9 @@ public class QuartzServiceImpl implements QuartzService {
         if (appId <= 0 || cronJobId <= 0) {
             return false;
         }
-        String jobName = JobCronNameUtil.getJobName(appId, cronJobId);
-        String jobGroup = JobCronNameUtil.getJobGroup(appId, cronJobId);
-        String notifyJobName = JobCronNameUtil.getNotifyJobName(appId, cronJobId);
+        String jobName = JobCronNameUtil.getJobName(cronJobId);
+        String jobGroup = JobCronNameUtil.getJobGroup(appId);
+        String notifyJobName = JobCronNameUtil.getNotifyJobName(cronJobId);
         try {
             quartzTaskHandler.deleteJob(JobKey.jobKey(jobName, jobGroup));
             quartzTaskHandler.deleteJob(JobKey.jobKey(notifyJobName, jobGroup));
@@ -106,8 +106,8 @@ public class QuartzServiceImpl implements QuartzService {
     private void addJobToQuartz(CronJobInfoDTO cronJobInfo) throws SchedulerException {
         Long appId = cronJobInfo.getAppId();
         Long cronJobId = cronJobInfo.getId();
-        String jobName = JobCronNameUtil.getJobName(appId, cronJobId);
-        String jobGroup = JobCronNameUtil.getJobGroup(appId, cronJobId);
+        String jobName = JobCronNameUtil.getJobName(cronJobId);
+        String jobGroup = JobCronNameUtil.getJobGroup(appId);
         QuartzTrigger trigger = buildTrigger(cronJobInfo);
 
         QuartzJob job = QuartzJobBuilder.newJob()
@@ -132,8 +132,8 @@ public class QuartzServiceImpl implements QuartzService {
      */
     private QuartzTrigger buildTrigger(CronJobInfoDTO cronJobInfo) {
         QuartzTrigger trigger = null;
-        String jobName = JobCronNameUtil.getJobName(cronJobInfo.getAppId(), cronJobInfo.getId());
-        String jobGroup = JobCronNameUtil.getJobGroup(cronJobInfo.getAppId(), cronJobInfo.getId());
+        String jobName = JobCronNameUtil.getJobName(cronJobInfo.getId());
+        String jobGroup = JobCronNameUtil.getJobGroup(cronJobInfo.getAppId());
         if (StringUtils.isNotBlank(cronJobInfo.getCronExpression())) {
             // 根据cron表达式执行的定时任务
             QuartzTriggerBuilder cronTriggerBuilder = QuartzTriggerBuilder.newTrigger()
@@ -171,8 +171,8 @@ public class QuartzServiceImpl implements QuartzService {
     private void addNotifyJobIfNeed(CronJobInfoDTO cronJobInfo) throws SchedulerException {
         Long appId = cronJobInfo.getAppId();
         Long cronJobId = cronJobInfo.getId();
-        String notifyJobName = JobCronNameUtil.getNotifyJobName(appId, cronJobId);
-        String jobGroup = JobCronNameUtil.getJobGroup(appId, cronJobId);
+        String notifyJobName = JobCronNameUtil.getNotifyJobName(cronJobId);
+        String jobGroup = JobCronNameUtil.getJobGroup(appId);
         if (cronJobInfo.getNotifyOffset() > 0) {
             long notifyTime = 0L;
             if (StringUtils.isNotBlank(cronJobInfo.getCronExpression())) {

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/QuartzServiceImpl.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/service/impl/QuartzServiceImpl.java
@@ -1,0 +1,210 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.crontab.service.impl;
+
+import com.tencent.bk.job.common.constant.ErrorCode;
+import com.tencent.bk.job.common.exception.FailedPreconditionException;
+import com.tencent.bk.job.common.exception.InternalException;
+import com.tencent.bk.job.common.util.date.DateUtils;
+import com.tencent.bk.job.crontab.constant.CronConstants;
+import com.tencent.bk.job.crontab.model.dto.CronJobInfoDTO;
+import com.tencent.bk.job.crontab.service.QuartzService;
+import com.tencent.bk.job.crontab.timer.AbstractQuartzTaskHandler;
+import com.tencent.bk.job.crontab.timer.QuartzJob;
+import com.tencent.bk.job.crontab.timer.QuartzJobBuilder;
+import com.tencent.bk.job.crontab.timer.QuartzTrigger;
+import com.tencent.bk.job.crontab.timer.QuartzTriggerBuilder;
+import com.tencent.bk.job.crontab.timer.executor.NotifyJobExecutor;
+import com.tencent.bk.job.crontab.timer.executor.SimpleJobExecutor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.quartz.CronTrigger;
+import org.quartz.JobKey;
+import org.quartz.SchedulerException;
+import org.quartz.SimpleTrigger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.sql.Date;
+import java.time.Instant;
+
+@Slf4j
+@Service
+public class QuartzServiceImpl implements QuartzService {
+
+    private final AbstractQuartzTaskHandler quartzTaskHandler;
+
+    @Autowired
+    public QuartzServiceImpl(AbstractQuartzTaskHandler quartzTaskHandler) {
+        this.quartzTaskHandler = quartzTaskHandler;
+    }
+
+    @Override
+    public void tryToAddJobToQuartz(CronJobInfoDTO cronJobInfo) {
+        try {
+            addJobToQuartz(cronJobInfo);
+        } catch (Exception e) {
+            deleteJobFromQuartz(cronJobInfo.getAppId(), cronJobInfo.getId());
+            log.error("Error while addJobToQuartz!", e);
+            throw new InternalException(e, ErrorCode.INTERNAL_ERROR);
+        }
+    }
+
+    /**
+     * 从Quartz引擎删除定时任务（含相关的通知任务）
+     *
+     * @param appId     Job业务ID
+     * @param cronJobId 定时任务ID
+     * @return 是否删除成功
+     */
+    @Override
+    public boolean deleteJobFromQuartz(long appId, long cronJobId) {
+        if (appId <= 0 || cronJobId <= 0) {
+            return false;
+        }
+        String jobName = JobCronNameUtil.getJobName(appId, cronJobId);
+        String jobGroup = JobCronNameUtil.getJobGroup(appId, cronJobId);
+        String notifyJobName = JobCronNameUtil.getNotifyJobName(appId, cronJobId);
+        try {
+            quartzTaskHandler.deleteJob(JobKey.jobKey(jobName, jobGroup));
+            quartzTaskHandler.deleteJob(JobKey.jobKey(notifyJobName, jobGroup));
+            return true;
+        } catch (SchedulerException e) {
+            log.error("Error while delete job!", e);
+        }
+        return false;
+    }
+
+    /**
+     * 将定时任务添加至Quartz引擎（含相关的前置通知任务）
+     *
+     * @param cronJobInfo 定时任务信息
+     * @throws SchedulerException Quartz调度异常
+     */
+    private void addJobToQuartz(CronJobInfoDTO cronJobInfo) throws SchedulerException {
+        Long appId = cronJobInfo.getAppId();
+        Long cronJobId = cronJobInfo.getId();
+        String jobName = JobCronNameUtil.getJobName(appId, cronJobId);
+        String jobGroup = JobCronNameUtil.getJobGroup(appId, cronJobId);
+        QuartzTrigger trigger = buildTrigger(cronJobInfo);
+
+        QuartzJob job = QuartzJobBuilder.newJob()
+            .withIdentity(jobName, jobGroup)
+            .forJob(SimpleJobExecutor.class)
+            .usingJobData(CronConstants.JOB_DATA_KEY_APP_ID_STR, String.valueOf(appId))
+            .usingJobData(CronConstants.JOB_DATA_KEY_CRON_JOB_ID_STR, String.valueOf(cronJobId))
+            .withTrigger(trigger)
+            .build();
+
+        quartzTaskHandler.deleteJob(JobKey.jobKey(jobName, jobGroup));
+        quartzTaskHandler.addJob(job);
+
+        addNotifyJobIfNeed(cronJobInfo);
+    }
+
+    /**
+     * 构建定时任务Quartz触发器
+     *
+     * @param cronJobInfo 定时任务信息
+     * @return 定时任务Quartz触发器
+     */
+    private QuartzTrigger buildTrigger(CronJobInfoDTO cronJobInfo) {
+        QuartzTrigger trigger = null;
+        String jobName = JobCronNameUtil.getJobName(cronJobInfo.getAppId(), cronJobInfo.getId());
+        String jobGroup = JobCronNameUtil.getJobGroup(cronJobInfo.getAppId(), cronJobInfo.getId());
+        if (StringUtils.isNotBlank(cronJobInfo.getCronExpression())) {
+            // 根据cron表达式执行的定时任务
+            QuartzTriggerBuilder cronTriggerBuilder = QuartzTriggerBuilder.newTrigger()
+                .ofType(QuartzTrigger.TriggerType.CRON)
+                .withIdentity(jobName, jobGroup)
+                .withCronExpression(cronJobInfo.getCronExpression())
+                .withMisfireInstruction(CronTrigger.MISFIRE_INSTRUCTION_DO_NOTHING);
+            if (cronJobInfo.getEndTime() > 0) {
+                if (cronJobInfo.getEndTime() < DateUtils.currentTimeSeconds()) {
+                    throw new FailedPreconditionException(ErrorCode.END_TIME_OR_NOTIFY_TIME_ALREADY_PASSED);
+                } else {
+                    cronTriggerBuilder = cronTriggerBuilder.
+                        endAt(Date.from(Instant.ofEpochSecond(cronJobInfo.getEndTime())));
+                }
+            }
+            trigger = cronTriggerBuilder.build();
+        } else if (cronJobInfo.getExecuteTime() > DateUtils.currentTimeSeconds()) {
+            // 只执行一次的定时任务
+            trigger = QuartzTriggerBuilder.newTrigger().ofType(QuartzTrigger.TriggerType.SIMPLE)
+                .withIdentity(jobName, jobGroup)
+                .startAt(Date.from(Instant.ofEpochSecond(cronJobInfo.getExecuteTime()))).withRepeatCount(0)
+                .withIntervalInHours(1)
+                .withMisfireInstruction(SimpleTrigger.MISFIRE_INSTRUCTION_RESCHEDULE_NEXT_WITH_REMAINING_COUNT)
+                .build();
+        }
+        return trigger;
+    }
+
+    /**
+     * 按需添加通知任务至Quartz引擎
+     *
+     * @param cronJobInfo 定时任务信息
+     * @throws SchedulerException Quartz调度异常
+     */
+    private void addNotifyJobIfNeed(CronJobInfoDTO cronJobInfo) throws SchedulerException {
+        Long appId = cronJobInfo.getAppId();
+        Long cronJobId = cronJobInfo.getId();
+        String notifyJobName = JobCronNameUtil.getNotifyJobName(appId, cronJobId);
+        String jobGroup = JobCronNameUtil.getJobGroup(appId, cronJobId);
+        if (cronJobInfo.getNotifyOffset() > 0) {
+            long notifyTime = 0L;
+            if (StringUtils.isNotBlank(cronJobInfo.getCronExpression())) {
+                if (cronJobInfo.getEndTime() > 0) {
+                    notifyTime = cronJobInfo.getEndTime() - cronJobInfo.getNotifyOffset();
+                }
+            } else {
+                notifyTime = cronJobInfo.getExecuteTime() - cronJobInfo.getNotifyOffset();
+            }
+            if (notifyTime < DateUtils.currentTimeSeconds()) {
+                throw new FailedPreconditionException(ErrorCode.END_TIME_OR_NOTIFY_TIME_ALREADY_PASSED);
+            }
+            QuartzTrigger notifyTrigger = QuartzTriggerBuilder.newTrigger()
+                .ofType(QuartzTrigger.TriggerType.SIMPLE)
+                .withIdentity(notifyJobName, jobGroup)
+                .startAt(Date.from(Instant.ofEpochSecond(notifyTime))).withRepeatCount(0).withIntervalInHours(1)
+                .withMisfireInstruction(SimpleTrigger.MISFIRE_INSTRUCTION_RESCHEDULE_NEXT_WITH_REMAINING_COUNT)
+                .build();
+
+            QuartzJob notifyJob = QuartzJobBuilder.newJob()
+                .withIdentity(notifyJobName, jobGroup)
+                .forJob(NotifyJobExecutor.class)
+                .usingJobData(CronConstants.JOB_DATA_KEY_APP_ID_STR, String.valueOf(appId))
+                .usingJobData(CronConstants.JOB_DATA_KEY_CRON_JOB_ID_STR, String.valueOf(cronJobId))
+                .withTrigger(notifyTrigger)
+                .build();
+
+            quartzTaskHandler.deleteJob(JobKey.jobKey(notifyJobName, jobGroup));
+            quartzTaskHandler.addJob(notifyJob);
+        } else {
+            quartzTaskHandler.deleteJob(JobKey.jobKey(notifyJobName, jobGroup));
+        }
+    }
+
+}

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/timer/handler/DefaultQuartzTaskHandler.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/timer/handler/DefaultQuartzTaskHandler.java
@@ -67,8 +67,8 @@ public class DefaultQuartzTaskHandler extends AbstractQuartzTaskHandler {
 
         Set<? extends Trigger> triggers = createTriggers(quartzJob);
 
-        if (scheduler.isShutdown()) {
-            log.info("scheduler is shutdown, ignore add job {}!", quartzJob.getKey().getName());
+        if (!scheduler.isStarted()) {
+            log.info("scheduler is not started, ignore add job {}!", quartzJob.getKey().getName());
             return;
         }
 
@@ -96,8 +96,8 @@ public class DefaultQuartzTaskHandler extends AbstractQuartzTaskHandler {
         Assert.notNull(jobKey, "jobKey cannot be empty!");
         Assert.notNull(jobKey.getName(), "jobKey name cannot be empty!");
 
-        if (scheduler.isShutdown()) {
-            log.info("scheduler is shutdown, ignore delete job {}!", jobKey.getName());
+        if (!scheduler.isStarted()) {
+            log.info("scheduler is not started, ignore delete job {}!", jobKey.getName());
             return;
         }
 
@@ -108,9 +108,9 @@ public class DefaultQuartzTaskHandler extends AbstractQuartzTaskHandler {
     public void deleteJob(List<JobKey> jobKeys) throws SchedulerException {
         Assert.notNull(jobKeys, "jobKeys cannot be empty!");
 
-        if (scheduler.isShutdown()) {
+        if (!scheduler.isStarted()) {
             log.info(
-                "scheduler is shutdown, ignore delete {} job keys: {}",
+                "scheduler is not started, ignore delete {} job keys: {}",
                 jobKeys.size(),
                 jobKeys.stream().map(JobKey::getName).collect(Collectors.toList())
             );
@@ -125,8 +125,8 @@ public class DefaultQuartzTaskHandler extends AbstractQuartzTaskHandler {
      */
     @Override
     public void pauseAll() throws SchedulerException {
-        if (scheduler.isShutdown()) {
-            log.info("scheduler is shutdown, ignore pauseAll!");
+        if (!scheduler.isStarted()) {
+            log.info("scheduler is not started, ignore pauseAll!");
             return;
         }
         this.scheduler.pauseAll();

--- a/support-files/kubernetes/charts/bk-job/templates/job-analysis/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-analysis/configmap.yaml
@@ -17,6 +17,9 @@ data:
         async:
           requestTimeout: 180s
       cloud:
+        loadbalancer:
+          cache:
+            ttl: 20s
         stream:
           function:
             definition: handleAIChatOperationEvent

--- a/support-files/kubernetes/charts/bk-job/templates/job-backup/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-backup/configmap.yaml
@@ -14,6 +14,9 @@ data:
   application.yaml: |-
     spring:
       cloud:
+        loadbalancer:
+          cache:
+            ttl: 20s
         stream:
           defaultBinder: jobCommon
           binders:

--- a/support-files/kubernetes/charts/bk-job/templates/job-crontab/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-crontab/configmap.yaml
@@ -101,6 +101,9 @@ data:
                 class: org.quartz.simpl.RAMJobStore
                 misfireThreshold: 60000
               plugin:
+                shutdownhook:
+                  class: org.quartz.plugins.management.ShutdownHookPlugin
+                  cleanShutdown: true
                 triggHistory:
                   class: org.quartz.plugins.history.LoggingJobHistoryPlugin
               scheduler:

--- a/support-files/kubernetes/charts/bk-job/templates/job-crontab/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-crontab/configmap.yaml
@@ -14,6 +14,9 @@ data:
   application.yaml: |-
     spring:
       cloud:
+        loadbalancer:
+          cache:
+            ttl: 20s
         stream:
           defaultBinder: jobCommon
           binders:

--- a/support-files/kubernetes/charts/bk-job/templates/job-execute/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-execute/configmap.yaml
@@ -14,6 +14,9 @@ data:
   application.yaml: |-
     spring:
       cloud:
+        loadbalancer:
+          cache:
+            ttl: 20s
         stream:
           defaultBinder: jobCommon
           binders:

--- a/support-files/kubernetes/charts/bk-job/templates/job-file-gateway/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-file-gateway/configmap.yaml
@@ -14,6 +14,9 @@ data:
   application.yaml: |-
     spring:
       cloud:
+        loadbalancer:
+          cache:
+            ttl: 20s
         stream:
           defaultBinder: jobCommon
           binders:

--- a/support-files/kubernetes/charts/bk-job/templates/job-gateway/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-gateway/configmap.yaml
@@ -14,6 +14,9 @@ data:
   application.yaml: |-
     spring:
       cloud:
+        loadbalancer:
+          cache:
+            ttl: 20s
         stream:
           defaultBinder: jobCommon
           binders:


### PR DESCRIPTION
1. 更准确地判断Quartz状态；
2. 加载任务前增加对Quartz状态的判断，Quartz启动完成后才开始加载任务；
3. 添加Quartz关闭插件，收到kill -15信号后立即关闭Quartz，避免后续Spring容器销毁后任务触发使用Bean异常；
4. 所有上游服务的负载均衡缓存刷新时间调整为20s（默认35s）；
5. 调整GracefulShutdown等待时间为30s；
6. 重构job-crontab部分老代码，降低圈复杂度；
7. 优化批量加载定时任务至Quartz过程的性能，避免循环DB查询。