### PR TITLE
perf: 运行集成测试时不加载kubernetes相关配置 #3409

### DIFF
--- a/src/backend/job-analysis/boot-job-analysis/src/test/resources/bootstrap.yml
+++ b/src/backend/job-analysis/boot-job-analysis/src/test/resources/bootstrap.yml
@@ -3,3 +3,6 @@ spring:
     name: job-analysis
   profiles:
     active: test
+  cloud:
+    kubernetes:
+      enabled: false

--- a/src/backend/job-assemble/src/test/resources/bootstrap.yml
+++ b/src/backend/job-assemble/src/test/resources/bootstrap.yml
@@ -3,3 +3,6 @@ spring:
     name: job-assemble
   profiles:
     active: test
+  cloud:
+    kubernetes:
+      enabled: false

--- a/src/backend/job-backup/boot-job-backup/src/test/resources/bootstrap.yml
+++ b/src/backend/job-backup/boot-job-backup/src/test/resources/bootstrap.yml
@@ -1,3 +1,6 @@
 spring:
   application:
     name: job-backup
+  cloud:
+    kubernetes:
+      enabled: false

--- a/src/backend/job-crontab/boot-job-crontab/src/test/resources/bootstrap.yml
+++ b/src/backend/job-crontab/boot-job-crontab/src/test/resources/bootstrap.yml
@@ -3,3 +3,6 @@ spring:
     name: job-crontab
   profiles:
     active: test
+  cloud:
+    kubernetes:
+      enabled: false

--- a/src/backend/job-execute/boot-job-execute/src/test/resources/bootstrap.yml
+++ b/src/backend/job-execute/boot-job-execute/src/test/resources/bootstrap.yml
@@ -1,3 +1,6 @@
 spring:
   application:
     name: job-execute
+  cloud:
+    kubernetes:
+      enabled: false

--- a/src/backend/job-logsvr/boot-job-logsvr/src/test/resources/bootstrap.yml
+++ b/src/backend/job-logsvr/boot-job-logsvr/src/test/resources/bootstrap.yml
@@ -1,5 +1,9 @@
 spring:
   application:
     name: job-logsvr
+  cloud:
+    kubernetes:
+      enabled: false
+
 server:
   port: 19806

--- a/src/backend/job-manage/boot-job-manage/src/test/resources/bootstrap.yml
+++ b/src/backend/job-manage/boot-job-manage/src/test/resources/bootstrap.yml
@@ -3,3 +3,6 @@ spring:
     name: job-manage
   profiles:
     active: test
+  cloud:
+    kubernetes:
+      enabled: false


### PR DESCRIPTION
运行集成测试时由于未处于K8S环境中，明确指定不加载相关配置。