### PR TITLE
feat：兼容主机管控区ID为-1场景 #3437 

### DIFF
--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/impl/ApplicationHostDAOImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/impl/ApplicationHostDAOImpl.java
@@ -102,6 +102,7 @@ public class ApplicationHostDAOImpl implements ApplicationHostDAO {
         TABLE.SET_IDS,
         TABLE.MODULE_IDS,
         TABLE.CLOUD_AREA_ID,
+        TABLE.CLOUD_ID,
         TABLE.DISPLAY_IP,
         TABLE.OS,
         TABLE.OS_TYPE,
@@ -117,6 +118,7 @@ public class ApplicationHostDAOImpl implements ApplicationHostDAO {
         TABLE.IS_AGENT_ALIVE,
         TABLE.IP,
         TABLE.CLOUD_AREA_ID,
+        TABLE.CLOUD_ID,
         TABLE.AGENT_ID,
         TABLE.APP_ID,
         TABLE.IP_V6,
@@ -749,6 +751,7 @@ public class ApplicationHostDAOImpl implements ApplicationHostDAO {
             TABLE.SET_IDS,
             TABLE.MODULE_IDS,
             TABLE.CLOUD_AREA_ID,
+            TABLE.CLOUD_ID,
             TABLE.DISPLAY_IP,
             TABLE.OS,
             TABLE.OS_TYPE,
@@ -768,6 +771,7 @@ public class ApplicationHostDAOImpl implements ApplicationHostDAO {
             finalSetIdsStr,
             finalModuleIdsStr,
             cloudAreaId,
+            applicationHostDTO.getCloudAreaId(),
             displayIp,
             os,
             osType,
@@ -788,6 +792,7 @@ public class ApplicationHostDAOImpl implements ApplicationHostDAO {
                 .set(TABLE.SET_IDS, finalSetIdsStr)
                 .set(TABLE.MODULE_IDS, finalModuleIdsStr)
                 .set(TABLE.CLOUD_AREA_ID, cloudAreaId)
+                .set(TABLE.CLOUD_ID, applicationHostDTO.getCloudAreaId())
                 .set(TABLE.DISPLAY_IP, displayIp)
                 .set(TABLE.OS, os)
                 .set(TABLE.OS_TYPE, osType)
@@ -825,6 +830,7 @@ public class ApplicationHostDAOImpl implements ApplicationHostDAO {
                 TABLE.SET_IDS,
                 TABLE.MODULE_IDS,
                 TABLE.CLOUD_AREA_ID,
+                TABLE.CLOUD_ID,
                 TABLE.DISPLAY_IP,
                 TABLE.OS,
                 TABLE.OS_TYPE,
@@ -836,6 +842,7 @@ public class ApplicationHostDAOImpl implements ApplicationHostDAO {
                 TABLE.LAST_TIME
             ).values(
                 (ULong) null,
+                null,
                 null,
                 null,
                 null,
@@ -866,6 +873,7 @@ public class ApplicationHostDAOImpl implements ApplicationHostDAO {
                     applicationHostDTO.getSetIdsStr(),
                     applicationHostDTO.getModuleIdsStr(),
                     JooqDataTypeUtil.buildULong(applicationHostDTO.getCloudAreaId()),
+                    applicationHostDTO.getCloudAreaId(),
                     applicationHostDTO.getDisplayIp(),
                     applicationHostDTO.getOsName(),
                     applicationHostDTO.getOsType(),
@@ -931,6 +939,7 @@ public class ApplicationHostDAOImpl implements ApplicationHostDAO {
     public int updateHostAttrsByConditions(ApplicationHostDTO applicationHostDTO, Collection<Condition> conditions) {
         val query = context.update(TABLE)
             .set(TABLE.CLOUD_AREA_ID, ULong.valueOf(applicationHostDTO.getCloudAreaId()))
+            .set(TABLE.CLOUD_ID, applicationHostDTO.getCloudAreaId())
             .set(TABLE.IP, applicationHostDTO.getIp())
             .set(TABLE.IP_V6, applicationHostDTO.preferFullIpv6())
             .set(TABLE.AGENT_ID, applicationHostDTO.getAgentId())
@@ -963,6 +972,7 @@ public class ApplicationHostDAOImpl implements ApplicationHostDAO {
             .set(TABLE.SET_IDS, applicationHostDTO.getSetIdsStr())
             .set(TABLE.MODULE_IDS, applicationHostDTO.getModuleIdsStr())
             .set(TABLE.CLOUD_AREA_ID, JooqDataTypeUtil.buildULong(applicationHostDTO.getCloudAreaId()))
+            .set(TABLE.CLOUD_ID, applicationHostDTO.getCloudAreaId())
             .set(TABLE.DISPLAY_IP, applicationHostDTO.getDisplayIp())
             .set(TABLE.OS, applicationHostDTO.getOsName())
             .set(TABLE.OS_TYPE, applicationHostDTO.getOsType())

--- a/support-files/sql/job-manage/0033_job_manage_20250317-1000_V3.11.4_mysql.sql
+++ b/support-files/sql/job-manage/0033_job_manage_20250317-1000_V3.11.4_mysql.sql
@@ -1,0 +1,85 @@
+USE job_manage;
+
+SET NAMES utf8mb4;
+
+DROP PROCEDURE IF EXISTS job_schema_update;
+
+DELIMITER <JOB_UBF>
+
+CREATE PROCEDURE job_schema_update()
+BEGIN
+
+  DECLARE db VARCHAR(100);
+  SET AUTOCOMMIT = 0;
+  SELECT DATABASE() INTO db;
+  
+  -- Update `host` schema
+  IF EXISTS(SELECT 1
+            FROM information_schema.COLUMNS
+            WHERE TABLE_SCHEMA = db
+            AND TABLE_NAME = 'host'
+            AND COLUMN_NAME = 'cloud_area_id') THEN
+  ALTER TABLE host MODIFY COLUMN `cloud_area_id` BIGINT(20) UNSIGNED NULL DEFAULT NULL;
+  END IF;
+
+  IF NOT EXISTS(SELECT 1
+                FROM information_schema.COLUMNS
+                WHERE TABLE_SCHEMA = db
+                AND TABLE_NAME = 'host'
+                AND COLUMN_NAME = 'cloud_id') THEN
+  ALTER TABLE host ADD COLUMN `cloud_id` BIGINT(20) NULL DEFAULT NULL AFTER `cloud_area_id`;
+  END IF;
+
+COMMIT;
+END <JOB_UBF>
+DELIMITER ;
+CALL job_schema_update();
+DROP PROCEDURE IF EXISTS job_schema_update;
+
+-- 更新 cloud_id 列
+DROP PROCEDURE IF EXISTS job_add_cloud_id;
+
+DELIMITER <JOB_UBF>
+
+CREATE PROCEDURE job_add_cloud_id()
+label:BEGIN
+  DECLARE minHostId BIGINT;
+  DECLARE maxHostId BIGINT;
+  DECLARE fromHostId BIGINT;
+  DECLARE endHostId BIGINT;
+
+  SET AUTOCOMMIT = 0;
+
+  -- 如果 host 表为空，无需变更
+  IF NOT EXISTS (SELECT 1 FROM host LIMIT 1) THEN
+      LEAVE label;
+  END IF;
+
+  -- 如果 host 表中不存在cloud_id = 0，说明已经执行过该变更
+  IF NOT EXISTS (SELECT 1 FROM host WHERE cloud_id IS NULL LIMIT 1) THEN
+      LEAVE label;
+  END IF;
+
+  SELECT MIN(host_id), MAX(host_id) INTO minHostId, maxHostId FROM host;
+
+  SET fromHostId = minHostId - 1;
+
+  WHILE fromHostId <= maxHostId DO
+    SELECT MIN(t.host_id),MAX(t.host_id) INTO fromHostId,endHostId FROM (SELECT host_id FROM host WHERE host_id > fromHostId AND host_id <= maxHostId ORDER BY host_id asc LIMIT 1000) t;
+
+    UPDATE host t1
+      SET t1.cloud_id = t1.cloud_area_id
+      WHERE host_id BETWEEN fromHostId AND endHostId;
+
+    COMMIT;
+
+    SET fromHostId = endHostId;
+  END WHILE;
+
+END <JOB_UBF>
+DELIMITER ;
+COMMIT;
+
+CALL job_add_cloud_id();
+DROP PROCEDURE IF EXISTS job_add_cloud_id;
+


### PR DESCRIPTION
一、新增变更SQL：
1.旧字段cloud_area_id变更为可为NULL，为后续删除该字段做准备；
2.增加新字段：cloud_id；
3.迁移旧字段数据到新字段。
二、程序同时写入cloud_area_id与cloud_id字段。