### PR TITLE
perf: 调整CMDB接口调用超时参数、降低版本更新过程中的CMDB事件处理延迟 #3414 #3436 

### DIFF
--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BaseCmdbApiClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BaseCmdbApiClient.java
@@ -135,7 +135,7 @@ public class BaseCmdbApiClient {
                                 CmdbConfig cmdbConfig,
                                 MeterRegistry meterRegistry,
                                 String lang) {
-        WatchableHttpHelper httpHelper = HttpHelperFactory.getRetryableHttpHelper();
+        WatchableHttpHelper httpHelper = HttpHelperFactory.getLongRetryableHttpHelper();
         this.esbCmdbApiClient = new BkApiClient(meterRegistry,
             CmdbMetricNames.CMDB_API_PREFIX,
             esbProperties.getService().getUrl(),

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/HttpHelperFactory.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/http/HttpHelperFactory.java
@@ -41,7 +41,7 @@ public class HttpHelperFactory {
         LONG_RETRYABLE_HTTP_CLIENT = JobHttpClientFactory.createHttpClient(
             15000,
             15000,
-            30000,
+            35000,
             500,
             1000,
             60,

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/AbstractCmdbResourceEventWatcher.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/sync/AbstractCmdbResourceEventWatcher.java
@@ -40,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
+import org.springframework.cloud.sleuth.annotation.NewSpan;
 import org.springframework.data.redis.core.RedisTemplate;
 
 import java.util.List;
@@ -87,6 +88,7 @@ public abstract class AbstractCmdbResourceEventWatcher<E> extends Thread {
         this.redisLockKey = "watch-cmdb-" + this.watcherResourceName + "-lock";
     }
 
+    @NewSpan
     @Override
     public final void run() {
         log.info("Watching {} event start", this.watcherResourceName);
@@ -97,8 +99,8 @@ public abstract class AbstractCmdbResourceEventWatcher<E> extends Thread {
                 HeartBeatRedisLock redisLock = new HeartBeatRedisLock(redisTemplate, redisLockKey, machineIp);
                 lockResult = redisLock.lock();
                 if (!lockResult.isLockGotten()) {
-                    // 30s之后重试
-                    ThreadUtils.sleep(30_000);
+                    // 5s之后重试
+                    ThreadUtils.sleep(5_000);
                     continue;
                 }
 


### PR DESCRIPTION
1. CMDB所有接口调用超时调整为35s；
2. 降低事件监听实例间重试等待时间；
3. 完善事件监听线程TraceId打印。