### PR TITLE
fix: OpenAPI接口查不到重试任务中未重试机器日志 #3575

### DIFF
--- a/src/backend/job-execute/api-job-execute/src/main/java/com/tencent/bk/job/execute/model/esb/v3/request/EsbBatchGetJobInstanceIpLogV3Request.java
+++ b/src/backend/job-execute/api-job-execute/src/main/java/com/tencent/bk/job/execute/model/esb/v3/request/EsbBatchGetJobInstanceIpLogV3Request.java
@@ -26,7 +26,7 @@ package com.tencent.bk.job.execute.model.esb.v3.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.tencent.bk.job.common.esb.model.EsbAppScopeReq;
-import com.tencent.bk.job.common.esb.model.job.EsbIpDTO;
+import com.tencent.bk.job.common.model.openapi.v4.OpenApiHostDTO;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
@@ -62,7 +62,7 @@ public class EsbBatchGetJobInstanceIpLogV3Request extends EsbAppScopeReq {
      */
     @JsonProperty("ip_list")
     @Valid
-    private List<EsbIpDTO> ipList;
+    private List<OpenApiHostDTO> ipList;
 
     /**
      * 目标主机ID列表

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/ScriptExecuteObjectTaskDAO.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/ScriptExecuteObjectTaskDAO.java
@@ -138,7 +138,7 @@ public interface ScriptExecuteObjectTaskDAO {
     List<ExecuteObjectTask> listTasksByGseTaskId(Long taskInstanceId, Long gseTaskId);
 
     /**
-     * 根据hostId查询任务
+     * 根据执行对象ID查询任务
      *
      * @param taskInstanceId  作业实例 ID
      * @param stepInstanceId  步骤实例ID
@@ -152,6 +152,22 @@ public interface ScriptExecuteObjectTaskDAO {
                                                Integer executeCount,
                                                Integer batch,
                                                String executeObjectId);
+
+    /**
+     * 根据执行对象ID批量查询任务
+     *
+     * @param taskInstanceId   作业实例 ID
+     * @param stepInstanceId   步骤实例ID
+     * @param executeCount     执行次数
+     * @param batch            滚动执行批次；传入null或者0将忽略该参数
+     * @param executeObjectIds 执行对象ID集合
+     * @return 任务
+     */
+    List<ExecuteObjectTask> getTaskByExecuteObjectIds(Long taskInstanceId,
+                                                      Long stepInstanceId,
+                                                      Integer executeCount,
+                                                      Integer batch,
+                                                      Collection<String> executeObjectIds);
 
     /**
      * 判断步骤实例的执行对象任务记录是否存在

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/ScriptExecuteObjectTaskDAOImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/ScriptExecuteObjectTaskDAOImpl.java
@@ -408,6 +408,29 @@ public class ScriptExecuteObjectTaskDAOImpl extends BaseDAO implements ScriptExe
 
     @Override
     @MySQLOperation(table = "gse_script_execute_obj_task", op = DbOperationEnum.READ)
+    public List<ExecuteObjectTask> getTaskByExecuteObjectIds(Long taskInstanceId,
+                                                             Long stepInstanceId,
+                                                             Integer executeCount,
+                                                             Integer batch,
+                                                             Collection<String> executeObjectIds) {
+        SelectConditionStep<?> selectConditionStep =
+            dsl().select(ALL_FIELDS)
+                .from(T)
+                .where(buildTaskInstanceIdQueryCondition(taskInstanceId))
+                .and(T.STEP_INSTANCE_ID.eq(stepInstanceId))
+                .and(T.EXECUTE_COUNT.eq(executeCount.shortValue()))
+                .and(T.EXECUTE_OBJ_ID.in(executeObjectIds));
+        if (batch != null && batch > 0) {
+            // 滚动执行批次，传入null或者0将忽略该参数
+            selectConditionStep.and(T.BATCH.eq(batch.shortValue()));
+        }
+        selectConditionStep.limit(1);
+        Result<?> records = selectConditionStep.fetch();
+        return records.map(this::extract);
+    }
+
+    @Override
+    @MySQLOperation(table = "gse_script_execute_obj_task", op = DbOperationEnum.READ)
     public boolean isStepInstanceRecordExist(Long taskInstanceId, long stepInstanceId) {
         return dsl().fetchExists(
             T,

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/ScriptExecuteObjectTaskService.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/ScriptExecuteObjectTaskService.java
@@ -28,6 +28,9 @@ import com.tencent.bk.job.execute.model.ExecuteObjectCompositeKey;
 import com.tencent.bk.job.execute.model.ExecuteObjectTask;
 import com.tencent.bk.job.execute.model.StepInstanceBaseDTO;
 
+import java.util.Collection;
+import java.util.List;
+
 public interface ScriptExecuteObjectTaskService extends ExecuteObjectTaskService {
     /**
      * 根据执行对象复合 KEY 获取执行对象任务
@@ -42,4 +45,18 @@ public interface ScriptExecuteObjectTaskService extends ExecuteObjectTaskService
                                                          Integer executeCount,
                                                          Integer batch,
                                                          ExecuteObjectCompositeKey executeObjectCompositeKey);
+
+    /**
+     * 根据执行对象ID批量获取执行对象任务
+     *
+     * @param stepInstance     步骤实例
+     * @param executeCount     执行次数
+     * @param batch            滚动执行批次；传入null或者0将忽略该参数
+     * @param executeObjectIds 执行对象ID列表
+     * @return 执行对象任务列表
+     */
+    List<ExecuteObjectTask> getTaskByExecuteObjectIds(StepInstanceBaseDTO stepInstance,
+                                                      Integer executeCount,
+                                                      Integer batch,
+                                                      Collection<String> executeObjectIds);
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/ScriptExecuteObjectTaskServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/ScriptExecuteObjectTaskServiceImpl.java
@@ -173,6 +173,22 @@ public class ScriptExecuteObjectTaskServiceImpl
     }
 
     @Override
+    public List<ExecuteObjectTask> getTaskByExecuteObjectIds(StepInstanceBaseDTO stepInstance,
+                                                             Integer executeCount,
+                                                             Integer batch,
+                                                             Collection<String> executeObjectIds) {
+        long stepInstanceId = stepInstance.getId();
+        List<ExecuteObjectTask> executeObjectTaskList = scriptExecuteObjectTaskDAO.getTaskByExecuteObjectIds(
+            stepInstance.getTaskInstanceId(),
+            stepInstanceId, executeCount,
+            batch,
+            executeObjectIds
+        );
+        fillExecuteObjectForExecuteObjectTasks(stepInstance, executeObjectTaskList);
+        return executeObjectTaskList;
+    }
+
+    @Override
     public List<ResultGroupDTO> listAndGroupTasks(StepInstanceBaseDTO stepInstance,
                                                   int executeCount,
                                                   Integer batch) {

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/util/ExecuteObjectCompositeKeyUtils.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/util/ExecuteObjectCompositeKeyUtils.java
@@ -53,8 +53,8 @@ public class ExecuteObjectCompositeKeyUtils {
             } else {
                 // 管控区域+ip方式作为主机标识
                 return openApiHostDTOList.stream()
-                    .map(esbIp -> ExecuteObjectCompositeKey.ofHostIp(
-                        IpUtils.buildCloudIp(esbIp.getBkCloudId(), esbIp.getIp())))
+                    .map(openApiHostDTO -> ExecuteObjectCompositeKey.ofHostIp(
+                        IpUtils.buildCloudIp(openApiHostDTO.getBkCloudId(), openApiHostDTO.getIp())))
                     .collect(Collectors.toList());
             }
         } else {

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/util/ExecuteObjectCompositeKeyUtils.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/util/ExecuteObjectCompositeKeyUtils.java
@@ -25,8 +25,8 @@
 package com.tencent.bk.job.execute.util;
 
 import com.tencent.bk.job.common.constant.ExecuteObjectTypeEnum;
-import com.tencent.bk.job.common.esb.model.job.EsbIpDTO;
 import com.tencent.bk.job.common.model.openapi.v4.OpenApiExecuteObjectDTO;
+import com.tencent.bk.job.common.model.openapi.v4.OpenApiHostDTO;
 import com.tencent.bk.job.common.util.ip.IpUtils;
 import com.tencent.bk.job.execute.model.ExecuteObjectCompositeKey;
 import org.apache.commons.collections4.CollectionUtils;
@@ -36,22 +36,23 @@ import java.util.stream.Collectors;
 
 public class ExecuteObjectCompositeKeyUtils {
 
-    public static List<ExecuteObjectCompositeKey> fromEsbHostParams(List<Long> hostIds, List<EsbIpDTO> esbIps) {
+    public static List<ExecuteObjectCompositeKey> fromEsbHostParams(List<Long> hostIds,
+                                                                    List<OpenApiHostDTO> openApiHostDTOList) {
         if (CollectionUtils.isNotEmpty(hostIds)) {
             // hostId方式作为主机标识
             return hostIds.stream()
                 .map(ExecuteObjectCompositeKey::ofHostId)
                 .collect(Collectors.toList());
-        } else if (CollectionUtils.isNotEmpty(esbIps)) {
-            EsbIpDTO anyEsbIp = esbIps.get(0);
-            if (anyEsbIp.getHostId() != null) {
+        } else if (CollectionUtils.isNotEmpty(openApiHostDTOList)) {
+            OpenApiHostDTO firstHost = openApiHostDTOList.get(0);
+            if (firstHost.getHostId() != null) {
                 // hostId方式作为主机标识
-                return esbIps.stream()
+                return openApiHostDTOList.stream()
                     .map(esbIp -> ExecuteObjectCompositeKey.ofHostId(esbIp.getHostId()))
                     .collect(Collectors.toList());
             } else {
                 // 管控区域+ip方式作为主机标识
-                return esbIps.stream()
+                return openApiHostDTOList.stream()
                     .map(esbIp -> ExecuteObjectCompositeKey.ofHostIp(
                         IpUtils.buildCloudIp(esbIp.getBkCloudId(), esbIp.getIp())))
                     .collect(Collectors.toList());


### PR DESCRIPTION
1. 使用OpenApiHostDTO替换EsbIpDTO，更正bk_cloud_id校验逻辑；
2. 修复重试任务日志获取逻辑。