### PR TITLE
fix: OpenAPI接口查不到重试任务中未重试机器日志 #3575 

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/ScriptExecuteObjectTaskDAOImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/ScriptExecuteObjectTaskDAOImpl.java
@@ -424,7 +424,6 @@ public class ScriptExecuteObjectTaskDAOImpl extends BaseDAO implements ScriptExe
             // 滚动执行批次，传入null或者0将忽略该参数
             selectConditionStep.and(T.BATCH.eq(batch.shortValue()));
         }
-        selectConditionStep.limit(1);
         Result<?> records = selectConditionStep.fetch();
         return records.map(this::extract);
     }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/LogServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/LogServiceImpl.java
@@ -359,11 +359,6 @@ public class LogServiceImpl implements LogService {
                 batch,
                 queryExecuteObjects.stream().map(ExecuteObject::getId).collect(Collectors.toList())
             );
-        log.debug(
-            "queryExecuteObjects={},executeObjectTaskList={}",
-            queryExecuteObjects,
-            executeObjectTaskList
-        );
         long stepInstanceId = stepInstance.getId();
         // 根据真实执行次数对执行对象进行分组
         Map<Integer, List<ExecuteObjectTask>> actualExecuteCountObjMap = executeObjectTaskList.stream()
@@ -374,9 +369,9 @@ public class LogServiceImpl implements LogService {
             List<ExecuteObjectTask> executeObjectTasks = entry.getValue();
             if (log.isDebugEnabled()) {
                 log.debug(
-                    "actualExecuteCount={},executeObjectTasks={}",
+                    "actualExecuteCount={},executeObjectTasks.size={}",
                     actualExecuteCount,
-                    executeObjectTasks
+                    executeObjectTasks.size()
                 );
             }
             if (CollectionUtils.isEmpty(executeObjectTasks)) {

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/util/ExecuteObjectCompositeKeyUtils.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/util/ExecuteObjectCompositeKeyUtils.java
@@ -44,19 +44,18 @@ public class ExecuteObjectCompositeKeyUtils {
                 .map(ExecuteObjectCompositeKey::ofHostId)
                 .collect(Collectors.toList());
         } else if (CollectionUtils.isNotEmpty(openApiHostDTOList)) {
-            OpenApiHostDTO firstHost = openApiHostDTOList.get(0);
-            if (firstHost.getHostId() != null) {
-                // hostId方式作为主机标识
-                return openApiHostDTOList.stream()
-                    .map(esbIp -> ExecuteObjectCompositeKey.ofHostId(esbIp.getHostId()))
-                    .collect(Collectors.toList());
-            } else {
-                // 管控区域+ip方式作为主机标识
-                return openApiHostDTOList.stream()
-                    .map(openApiHostDTO -> ExecuteObjectCompositeKey.ofHostIp(
-                        IpUtils.buildCloudIp(openApiHostDTO.getBkCloudId(), openApiHostDTO.getIp())))
-                    .collect(Collectors.toList());
-            }
+            return openApiHostDTOList.stream()
+                .map(openApiHostDTO -> {
+                        if (openApiHostDTO.getHostId() != null) {
+                            // hostId方式作为主机标识
+                            return ExecuteObjectCompositeKey.ofHostId(openApiHostDTO.getHostId());
+                        } else {
+                            // 管控区域+ip方式作为主机标识
+                            return ExecuteObjectCompositeKey.ofHostIp(
+                                IpUtils.buildCloudIp(openApiHostDTO.getBkCloudId(), openApiHostDTO.getIp()));
+                        }
+                    }
+                ).collect(Collectors.toList());
         } else {
             throw new IllegalArgumentException("Invalid host params");
         }


### PR DESCRIPTION
1. 支持hostId与cloudIp混合传入；
2. 去除执行任务查询逻辑limit限制；
3. 增加调试日志。