### PR TITLE
perf: 健康检测支持检查MongoDB的密码正确性 #3663

### DIFF
--- a/src/backend/commons/common-mongodb/src/main/java/com/tencent/bk/job/common/mongodb/config/ConditionalOnMongoDBHealthCheckEnabled.java
+++ b/src/backend/commons/common-mongodb/src/main/java/com/tencent/bk/job/common/mongodb/config/ConditionalOnMongoDBHealthCheckEnabled.java
@@ -1,0 +1,49 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.mongodb.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 条件判断是否开启服务启动时 MongoDB 健康检查
+ */
+@ConditionalOnProperty(
+    value = "healthCheck.mongo.enabled",
+    havingValue = "true",
+    matchIfMissing = true
+)
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+public @interface ConditionalOnMongoDBHealthCheckEnabled {
+}

--- a/src/backend/commons/common-mongodb/src/main/java/com/tencent/bk/job/common/mongodb/exception/JobMongoAuthException.java
+++ b/src/backend/commons/common-mongodb/src/main/java/com/tencent/bk/job/common/mongodb/exception/JobMongoAuthException.java
@@ -1,0 +1,39 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.mongodb.exception;
+
+/**
+ * 连接 MongoDB 由于账号密码错误导致的认证失败
+ */
+public class JobMongoAuthException  extends RuntimeException {
+
+    public JobMongoAuthException(Throwable cause) {
+        super(cause);
+    }
+
+    public JobMongoAuthException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/backend/commons/common-mongodb/src/main/java/com/tencent/bk/job/common/mongodb/listener/CheckMongoOnStartupListener.java
+++ b/src/backend/commons/common-mongodb/src/main/java/com/tencent/bk/job/common/mongodb/listener/CheckMongoOnStartupListener.java
@@ -37,11 +37,11 @@ import org.springframework.data.mongodb.core.MongoTemplate;
  * 检查包含连通性检查，认证检查
  */
 @Slf4j
-public class JobMongoStartupIndicator implements ApplicationListener<ApplicationReadyEvent> {
+public class CheckMongoOnStartupListener implements ApplicationListener<ApplicationReadyEvent> {
 
     private final MongoTemplate mongoTemplate;
 
-    public JobMongoStartupIndicator(MongoTemplate mongoTemplate) {
+    public CheckMongoOnStartupListener(MongoTemplate mongoTemplate) {
         this.mongoTemplate = mongoTemplate;
     }
 
@@ -64,9 +64,12 @@ public class JobMongoStartupIndicator implements ApplicationListener<Application
                 log.error("fail to auth user to mongodb, please check username and password", e);
                 throw new JobMongoAuthException(e.getCause());
             } else {
-                log.error("mongodb connection failed, please check host and port", e);
+                log.error("mongodb connection failed", e);
                 throw e;
             }
+        } catch (Exception e) {
+            log.error("mongodb health check failed, not allow to start job service", e);
+            throw e;
         }
     }
 }

--- a/src/backend/commons/common-mongodb/src/main/java/com/tencent/bk/job/common/mongodb/listener/JobMongoStartupIndicator.java
+++ b/src/backend/commons/common-mongodb/src/main/java/com/tencent/bk/job/common/mongodb/listener/JobMongoStartupIndicator.java
@@ -1,0 +1,72 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.mongodb.listener;
+
+import com.mongodb.MongoSecurityException;
+import com.tencent.bk.job.common.mongodb.exception.JobMongoAuthException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.data.mongodb.UncategorizedMongoDbException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+/**
+ * MongoDB启动监听器，检查 MongoDB 是否就绪
+ * 检查包含连通性检查，认证检查
+ */
+@Slf4j
+public class JobMongoStartupIndicator implements ApplicationListener<ApplicationReadyEvent> {
+
+    private final MongoTemplate mongoTemplate;
+
+    public JobMongoStartupIndicator(MongoTemplate mongoTemplate) {
+        this.mongoTemplate = mongoTemplate;
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        log.info("start validate mongodb connection");
+        validateMongoConnection();
+    }
+
+    /**
+     * 通过 { ping: 1 } 命令检查mongodb连通性
+     */
+    private void validateMongoConnection() {
+
+        try {
+            this.mongoTemplate.executeCommand("{ ping: 1 }");
+        } catch (UncategorizedMongoDbException e) {
+            if (e.getCause() instanceof MongoSecurityException) {
+                // 账号密码错误
+                log.error("fail to auth user to mongodb, please check username and password", e);
+                throw new JobMongoAuthException(e.getCause());
+            } else {
+                log.error("mongodb connection failed, please check host and port", e);
+                throw e;
+            }
+        }
+    }
+}

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ExecuteMongoDBConfiguration.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ExecuteMongoDBConfiguration.java
@@ -32,6 +32,9 @@ import com.tencent.bk.job.backup.archive.JobLogArchivers;
 import com.tencent.bk.job.backup.archive.impl.JobFileLogArchiver;
 import com.tencent.bk.job.backup.archive.impl.JobScriptLogArchiver;
 import com.tencent.bk.job.backup.archive.service.ArchiveTaskService;
+import com.tencent.bk.job.common.mongodb.config.ConditionalOnMongoDBHealthCheckEnabled;
+import com.tencent.bk.job.common.mongodb.listener.JobMongoStartupIndicator;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.mongo.MongoClientSettingsBuilderCustomizer;
@@ -41,6 +44,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 
 import java.util.List;
 
+@Slf4j
 @Configuration("executeMongoDBConfiguration")
 @ConditionalOnExpression("${job.backup.archive.execute-log.enabled:false}")
 public class ExecuteMongoDBConfiguration {
@@ -89,5 +93,15 @@ public class ExecuteMongoDBConfiguration {
                                                   JobScriptLogArchiver jobScriptLogArchiver) {
         return new JobLogArchivers(jobFileLogArchiver,
             jobScriptLogArchiver);
+    }
+
+    /**
+     * 开启执行结果日志归档情况下，是否开启mongoDB健康检查
+     */
+    @Bean
+    @ConditionalOnMongoDBHealthCheckEnabled
+    public JobMongoStartupIndicator jobMongoStartupIndicator(MongoTemplate mongoTemplate) {
+        log.info("enable mongodb health check");
+        return new JobMongoStartupIndicator(mongoTemplate);
     }
 }

--- a/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ExecuteMongoDBConfiguration.java
+++ b/src/backend/job-backup/service-job-backup/src/main/java/com/tencent/bk/job/backup/config/ExecuteMongoDBConfiguration.java
@@ -33,7 +33,7 @@ import com.tencent.bk.job.backup.archive.impl.JobFileLogArchiver;
 import com.tencent.bk.job.backup.archive.impl.JobScriptLogArchiver;
 import com.tencent.bk.job.backup.archive.service.ArchiveTaskService;
 import com.tencent.bk.job.common.mongodb.config.ConditionalOnMongoDBHealthCheckEnabled;
-import com.tencent.bk.job.common.mongodb.listener.JobMongoStartupIndicator;
+import com.tencent.bk.job.common.mongodb.listener.CheckMongoOnStartupListener;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -100,8 +100,8 @@ public class ExecuteMongoDBConfiguration {
      */
     @Bean
     @ConditionalOnMongoDBHealthCheckEnabled
-    public JobMongoStartupIndicator jobMongoStartupIndicator(MongoTemplate mongoTemplate) {
+    public CheckMongoOnStartupListener jobMongoStartupIndicator(MongoTemplate mongoTemplate) {
         log.info("enable mongodb health check");
-        return new JobMongoStartupIndicator(mongoTemplate);
+        return new CheckMongoOnStartupListener(mongoTemplate);
     }
 }

--- a/src/backend/job-logsvr/service-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/config/LogsvrMongoDbHealthCheckConfiguration.java
+++ b/src/backend/job-logsvr/service-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/config/LogsvrMongoDbHealthCheckConfiguration.java
@@ -25,7 +25,7 @@
 package com.tencent.bk.job.logsvr.config;
 
 import com.tencent.bk.job.common.mongodb.config.ConditionalOnMongoDBHealthCheckEnabled;
-import com.tencent.bk.job.common.mongodb.listener.JobMongoStartupIndicator;
+import com.tencent.bk.job.common.mongodb.listener.CheckMongoOnStartupListener;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -40,8 +40,8 @@ public class LogsvrMongoDbHealthCheckConfiguration {
      */
     @ConditionalOnMongoDBHealthCheckEnabled
     @Bean
-    public JobMongoStartupIndicator jobMongoStartupIndicator(MongoTemplate mongoTemplate) {
+    public CheckMongoOnStartupListener jobMongoStartupIndicator(MongoTemplate mongoTemplate) {
         log.info("enable mongodb health check");
-        return new JobMongoStartupIndicator(mongoTemplate);
+        return new CheckMongoOnStartupListener(mongoTemplate);
     }
 }

--- a/src/backend/job-logsvr/service-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/config/LogsvrMongoDbHealthCheckConfiguration.java
+++ b/src/backend/job-logsvr/service-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/config/LogsvrMongoDbHealthCheckConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.logsvr.config;
+
+import com.tencent.bk.job.common.mongodb.config.ConditionalOnMongoDBHealthCheckEnabled;
+import com.tencent.bk.job.common.mongodb.listener.JobMongoStartupIndicator;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+@Slf4j
+@Configuration
+public class LogsvrMongoDbHealthCheckConfiguration {
+
+    /**
+     * Logsvr 启动时，检查MongoDB的连通性和认证信息
+     */
+    @ConditionalOnMongoDBHealthCheckEnabled
+    @Bean
+    public JobMongoStartupIndicator jobMongoStartupIndicator(MongoTemplate mongoTemplate) {
+        log.info("enable mongodb health check");
+        return new JobMongoStartupIndicator(mongoTemplate);
+    }
+}

--- a/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
@@ -186,3 +186,6 @@ data:
         enabled: {{ .Values.jvmDiagnosticFile.clearByLastModifyTime.enabled }}
         # JVM诊断文件保留的小时数，默认168小时（7天）
         keep-hours: {{ .Values.jvmDiagnosticFile.clearByLastModifyTime.keepHours }}
+    # 服务启动时 依赖组件的健康检查
+    healthCheck:
+      {{- toYaml .Values.healthCheck | nindent 6 }}

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -2044,3 +2044,9 @@ assembleConfig:
 
 # pod删除时等待优雅关闭的最大时间，单位为秒（超出后强制删除）
 podTerminationGracePeriodSeconds: 60
+
+# 服务启动时，组件的健康检查
+healthCheck:
+  # 默认开启 启动时检查mongodb是否可达且账号密码正确
+  mongo:
+    enabled: true


### PR DESCRIPTION
可通过配置决定是否开启服务启动时检查MongoDB连通性和认证信息。
检查两个维度：
1. 连通性
2. 是否认证成功