### PR TITLE
perf: 兼容单租户环境改造 #3733 

### DIFF
--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/constant/ErrorCode.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/constant/ErrorCode.java
@@ -68,6 +68,8 @@ public class ErrorCode {
 
     // CMSI接口访问异常
     public static final int CMSI_API_ACCESS_ERROR = 1213001;
+    // 用户管理接口访问异常
+    public static final int USER_MANAGE_API_ACCESS_ERROR = 1213002;
     // 调用CMSI接口获取通知渠道数据异常
     public static final int CMSI_MSG_CHANNEL_DATA_ERROR = 1213003;
     // 调用CMSI接口发送通知失败，错误码：{0}，错误信息：{1}

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/ApplicationDTO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/ApplicationDTO.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.tencent.bk.job.common.constant.ResourceScopeTypeEnum;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.Collections;
@@ -160,5 +159,10 @@ public class ApplicationDTO {
     @JsonIgnore
     public boolean isBuiltInResource() {
         return this.deFault != null && this.deFault == 1;
+    }
+
+    @JsonIgnore
+    public Integer getDeFaultOrDefaultValue(){
+        return this.deFault == null ? 0 : deFault;
     }
 }

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/BkUserDTO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/BkUserDTO.java
@@ -76,14 +76,19 @@ public class BkUserDTO {
     private String wxUserId;
 
     /**
-     * 用户所属租户 ID
-     */
-    private String tenantId;
-
-    /**
      * 用户语言，枚举值：zh-cn / en
      */
     private String language;
+
+    /**
+     * 当前所在环境是否开启了多租户
+     */
+    private Boolean tenantEnabled;
+
+    /**
+     * 用户所属租户 ID
+     */
+    private String tenantId;
 
     /**
      * 是否为系统租户
@@ -97,7 +102,8 @@ public class BkUserDTO {
         return displayName + ":" + username + "@" + tenantId;
     }
 
-    public void setTenantId(String tenantId){
+    public void setTenantInfo(boolean tenantEnabled, String tenantId) {
+        this.tenantEnabled = tenantEnabled;
         this.tenantId = tenantId;
         this.systemTenant = TenantIdConstants.SYSTEM_TENANT_ID.equals(tenantId);
     }

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/tenant/ConditionalOnTenantDisabled.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/tenant/ConditionalOnTenantDisabled.java
@@ -24,27 +24,24 @@
 
 package com.tencent.bk.job.common.tenant;
 
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
-@Slf4j
-@Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties(TenantProperties.class)
-public class TenantAutoConfiguration {
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-    @Bean
-    @ConditionalOnTenantEnabled
-    public TenantEnvService tenantEnvService(TenantProperties tenantProperties) {
-        log.info("init tenantEnvService");
-        return new TenantEnvServiceImpl(tenantProperties);
-    }
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ConditionalOnProperty(
+    value = "tenant.enabled",
+    havingValue = "false",
+    matchIfMissing = true
+)
+public @interface ConditionalOnTenantDisabled {
 
-    @Bean
-    @ConditionalOnTenantDisabled
-    public TenantEnvService nonTenantEnvService() {
-        log.info("init nonTenantEnvService");
-        return new NonTenantEnvService();
-    }
 }

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/tenant/ConditionalOnTenantEnabled.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/tenant/ConditionalOnTenantEnabled.java
@@ -24,27 +24,23 @@
 
 package com.tencent.bk.job.common.tenant;
 
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
-@Slf4j
-@Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties(TenantProperties.class)
-public class TenantAutoConfiguration {
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-    @Bean
-    @ConditionalOnTenantEnabled
-    public TenantEnvService tenantEnvService(TenantProperties tenantProperties) {
-        log.info("init tenantEnvService");
-        return new TenantEnvServiceImpl(tenantProperties);
-    }
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ConditionalOnProperty(
+    value = "tenant.enabled",
+    havingValue = "true"
+)
+public @interface ConditionalOnTenantEnabled {
 
-    @Bean
-    @ConditionalOnTenantDisabled
-    public TenantEnvService nonTenantEnvService() {
-        log.info("init nonTenantEnvService");
-        return new NonTenantEnvService();
-    }
 }

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/tenant/NonTenantEnvService.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/tenant/NonTenantEnvService.java
@@ -24,27 +24,30 @@
 
 package com.tencent.bk.job.common.tenant;
 
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import com.tencent.bk.job.common.constant.TenantIdConstants;
 
-@Slf4j
-@Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties(TenantProperties.class)
-public class TenantAutoConfiguration {
+public class NonTenantEnvService implements TenantEnvService {
 
-    @Bean
-    @ConditionalOnTenantEnabled
-    public TenantEnvService tenantEnvService(TenantProperties tenantProperties) {
-        log.info("init tenantEnvService");
-        return new TenantEnvServiceImpl(tenantProperties);
+    @Override
+    public boolean isTenantEnabled() {
+        return false;
     }
 
-    @Bean
-    @ConditionalOnTenantDisabled
-    public TenantEnvService nonTenantEnvService() {
-        log.info("init nonTenantEnvService");
-        return new NonTenantEnvService();
+    @Override
+    public String getJobMachineTenantId() {
+        // 不开启多租户时，Job的机器属于默认租户
+        return TenantIdConstants.DEFAULT_TENANT_ID;
+    }
+
+    @Override
+    public String getTenantIdForGSE() {
+        // 不开启多租户时，使用默认租户
+        return TenantIdConstants.DEFAULT_TENANT_ID;
+    }
+
+    @Override
+    public String getTenantIdForArtifactoryBkJobProject() {
+        // 不开启多租户时，要求不传任何租户信息
+        return null;
     }
 }

--- a/src/backend/commons/esb-sdk/src/main/java/com/tencent/bk/job/common/esb/constants/BkApiTypeEnum.java
+++ b/src/backend/commons/esb-sdk/src/main/java/com/tencent/bk/job/common/esb/constants/BkApiTypeEnum.java
@@ -24,16 +24,26 @@
 
 package com.tencent.bk.job.common.esb.constants;
 
+import lombok.Getter;
+
 /**
- * 蓝鲸 API 网关类型
+ * 蓝鲸 API 类型
  */
-public enum ApiGwType {
+@Getter
+public enum BkApiTypeEnum {
+
     /**
      * ESB
      */
-    ESB,
+    ESB("esb"),
     /**
      * 蓝鲸网关，用于替换 ESB
      */
-    BK_APIGW;
+    APIGW("apigw");
+
+    private final String type;
+
+    BkApiTypeEnum(String type) {
+        this.type = type;
+    }
 }

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/cmsi/CmsiApiGwClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/cmsi/CmsiApiGwClient.java
@@ -60,10 +60,10 @@ import java.util.List;
 import static com.tencent.bk.job.common.metrics.CommonMetricNames.ESB_CMSI_API;
 
 /**
- * 消息通知 API 客户端
+ * 消息通知 APIGW 客户端
  */
 @Slf4j
-public class CmsiApiClient extends BkApiV2Client implements ICmsiClient {
+public class CmsiApiGwClient extends BkApiV2Client implements ICmsiClient {
 
     private static final String API_GET_NOTIFY_CHANNEL_LIST = "/v1/channels/";
     private static final String API_SEND_MAIL = "/v1/send_mail/";
@@ -74,11 +74,11 @@ public class CmsiApiClient extends BkApiV2Client implements ICmsiClient {
     private final AppProperties appProperties;
     private final IVirtualAdminAccountProvider virtualAdminAccountProvider;
 
-    public CmsiApiClient(BkApiGatewayProperties bkApiGatewayProperties,
-                         AppProperties appProperties,
-                         MeterRegistry meterRegistry,
-                         TenantEnvService tenantEnvService,
-                         IVirtualAdminAccountProvider virtualAdminAccountProvider) {
+    public CmsiApiGwClient(BkApiGatewayProperties bkApiGatewayProperties,
+                           AppProperties appProperties,
+                           MeterRegistry meterRegistry,
+                           TenantEnvService tenantEnvService,
+                           IVirtualAdminAccountProvider virtualAdminAccountProvider) {
         super(
             meterRegistry,
             ESB_CMSI_API,
@@ -125,16 +125,16 @@ public class CmsiApiClient extends BkApiV2Client implements ICmsiClient {
         CmsiSendMsgV1BasicReq req;
         String uri;
 
-        if (isMail(msgType)) {
+        if (NotifyChannelEnum.isMail(msgType)) {
             req = buildSendMailReq(notifyMessageDTO);
             uri = API_SEND_MAIL;
-        } else if (isSms(msgType)) {
+        } else if (NotifyChannelEnum.isSms(msgType)) {
             req = buildSendSmsReq(notifyMessageDTO);
             uri = API_SEND_SMS;
-        } else if (isVoice(msgType)) {
+        } else if (NotifyChannelEnum.isVoice(msgType)) {
             req = buildSendVoiceReq(notifyMessageDTO);
             uri = API_SEND_VOICE;
-        } else if (isWeixin(msgType)) {
+        } else if (NotifyChannelEnum.isWeixin(msgType)) {
             req = buildSendWxReq(notifyMessageDTO);
             uri = API_SEND_WEIXIN;
         } else {
@@ -181,21 +181,6 @@ public class CmsiApiClient extends BkApiV2Client implements ICmsiClient {
         }
     }
 
-    private Boolean isMail(String channel) {
-        return NotifyChannelEnum.Mail.getType().equals(channel);
-    }
-
-    private Boolean isSms(String channel) {
-        return NotifyChannelEnum.Sms.getType().equals(channel);
-    }
-
-    private Boolean isVoice(String channel) {
-        return NotifyChannelEnum.Voice.getType().equals(channel);
-    }
-
-    private Boolean isWeixin(String channel) {
-        return NotifyChannelEnum.Weixin.getType().equals(channel);
-    }
 
     private SendMailV1Req buildSendMailReq(NotifyMessageDTO notifyMessageDTO) {
         return SendMailV1Req.fromNotifyMessageDTO(notifyMessageDTO);

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/cmsi/CmsiEsbClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/cmsi/CmsiEsbClient.java
@@ -1,0 +1,261 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.paas.cmsi;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.tencent.bk.job.common.constant.ErrorCode;
+import com.tencent.bk.job.common.constant.HttpMethodEnum;
+import com.tencent.bk.job.common.esb.config.AppProperties;
+import com.tencent.bk.job.common.esb.config.EsbProperties;
+import com.tencent.bk.job.common.esb.metrics.EsbMetricTags;
+import com.tencent.bk.job.common.esb.model.BkApiAuthorization;
+import com.tencent.bk.job.common.esb.model.EsbReq;
+import com.tencent.bk.job.common.esb.model.EsbResp;
+import com.tencent.bk.job.common.esb.model.OpenApiRequestInfo;
+import com.tencent.bk.job.common.esb.sdk.BkApiV1Client;
+import com.tencent.bk.job.common.exception.InternalCmsiException;
+import com.tencent.bk.job.common.metrics.CommonMetricNames;
+import com.tencent.bk.job.common.model.error.ErrorType;
+import com.tencent.bk.job.common.paas.config.CmsiApiProperties;
+import com.tencent.bk.job.common.paas.exception.PaasException;
+import com.tencent.bk.job.common.paas.model.EsbNotifyChannelDTO;
+import com.tencent.bk.job.common.paas.model.NotifyChannelEnum;
+import com.tencent.bk.job.common.paas.model.NotifyMessageDTO;
+import com.tencent.bk.job.common.paas.model.PostSendMsgReq;
+import com.tencent.bk.job.common.paas.model.cmsi.req.SendVoiceEsbReq;
+import com.tencent.bk.job.common.tenant.TenantEnvService;
+import com.tencent.bk.job.common.util.http.HttpHelperFactory;
+import com.tencent.bk.job.common.util.http.HttpMetricUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.helpers.MessageFormatter;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.tencent.bk.job.common.metrics.CommonMetricNames.ESB_CMSI_API;
+
+/**
+ * 消息通知 ESB 客户端
+ */
+@Slf4j
+public class CmsiEsbClient extends BkApiV1Client implements ICmsiClient {
+
+    private static final String API_GET_NOTIFY_CHANNEL_LIST = "/api/c/compapi/cmsi/get_msg_type/";
+    private static final String API_POST_SEND_MSG = "/api/c/compapi/cmsi/send_msg/";
+
+    // 语音发送接口，环境不同URI不同，通过配置获取
+    private final String uriSendVoice;
+    // 使用语音发送的独立接口发送语音通知
+    private final Boolean useStandaloneVoiceAPI;
+    private final BkApiAuthorization authorization;
+
+    public CmsiEsbClient(EsbProperties esbProperties,
+                         AppProperties appProperties,
+                         MeterRegistry meterRegistry,
+                         CmsiApiProperties cmsiApiProperties,
+                         TenantEnvService tenantEnvService) {
+        super(
+            meterRegistry,
+            ESB_CMSI_API,
+            esbProperties.getService().getUrl(),
+            HttpHelperFactory.createHttpHelper(
+                httpClientBuilder -> httpClientBuilder.addInterceptorLast(getLogBkApiRequestIdInterceptor())
+            ),
+            tenantEnvService
+        );
+        this.uriSendVoice = cmsiApiProperties.getVoice().getUri();
+        this.useStandaloneVoiceAPI = cmsiApiProperties.getUseStandaloneVoiceAPI()
+            && StringUtils.isNotEmpty(this.uriSendVoice);
+        this.authorization = BkApiAuthorization.appAuthorization(appProperties.getCode(),
+            appProperties.getSecret(), "admin");
+    }
+
+    public List<EsbNotifyChannelDTO> getNotifyChannelList() {
+        try {
+            HttpMetricUtil.setHttpMetricName(CommonMetricNames.ESB_CMSI_API_HTTP);
+            HttpMetricUtil.addTagForCurrentMetric(
+                Tag.of(EsbMetricTags.KEY_API_NAME, API_GET_NOTIFY_CHANNEL_LIST)
+            );
+            EsbResp<List<EsbNotifyChannelDTO>> esbResp = doRequest(
+                OpenApiRequestInfo.builder()
+                    .method(HttpMethodEnum.GET)
+                    .uri(API_GET_NOTIFY_CHANNEL_LIST)
+                    .authorization(authorization)
+                    .build(),
+                new TypeReference<EsbResp<List<EsbNotifyChannelDTO>>>() {
+                }
+            );
+            return esbResp.getData();
+        } catch (Exception e) {
+            String errorMsg = "Get " + API_GET_NOTIFY_CHANNEL_LIST + " error";
+            log.error(errorMsg, e);
+            throw new InternalCmsiException(errorMsg, e, ErrorCode.CMSI_MSG_CHANNEL_DATA_ERROR);
+        } finally {
+            HttpMetricUtil.clearHttpMetric();
+        }
+    }
+
+    public void sendMsg(String msgType,
+                        String sender,
+                        Set<String> receivers,
+                        String title,
+                        String content) {
+        PostSendMsgReq req = buildSendMsgReq(msgType, sender, receivers, title, content);
+        String uri = API_POST_SEND_MSG;
+        try {
+            HttpMetricUtil.setHttpMetricName(CommonMetricNames.ESB_CMSI_API_HTTP);
+            HttpMetricUtil.addTagForCurrentMetric(Tag.of(EsbMetricTags.KEY_API_NAME, uri));
+            EsbResp<Object> esbResp = doRequest(
+                OpenApiRequestInfo.builder()
+                    .method(HttpMethodEnum.POST)
+                    .uri(uri)
+                    .body(req)
+                    .authorization(authorization)
+                    .build(),
+                new TypeReference<EsbResp<Object>>() {
+                }
+            );
+
+            handleResultOrThrow(esbResp, ErrorType.INTERNAL, ErrorCode.CMSI_FAIL_TO_SEND_MSG);
+        } catch (PaasException e) {
+            throw e;
+        } catch (Exception e) {
+            String msg = MessageFormatter.format(
+                "Fail to request {}",
+                uri
+            ).getMessage();
+            log.error(msg, e);
+            throw new PaasException(e, ErrorType.INTERNAL, ErrorCode.CMSI_API_ACCESS_ERROR, new Object[]{});
+        } finally {
+            HttpMetricUtil.clearHttpMetric();
+        }
+    }
+
+    public void sendVoiceMsg(String content,
+                             Collection<String> receivers) {
+        String uri = this.uriSendVoice;
+        SendVoiceEsbReq req = new SendVoiceEsbReq();
+        req.setMessage(content);
+        req.setReceivers(String.join(",", receivers));
+        try {
+            HttpMetricUtil.setHttpMetricName(CommonMetricNames.ESB_CMSI_API_HTTP);
+            HttpMetricUtil.addTagForCurrentMetric(Tag.of(EsbMetricTags.KEY_API_NAME, uri));
+            EsbResp<Object> esbResp = doRequest(
+                OpenApiRequestInfo.builder()
+                    .method(HttpMethodEnum.POST)
+                    .uri(uri)
+                    .body(req)
+                    .authorization(authorization)
+                    .build(),
+                new TypeReference<EsbResp<Object>>() {
+                }
+            );
+            handleResultOrThrow(esbResp, ErrorType.INTERNAL, ErrorCode.CMSI_FAIL_TO_SEND_MSG);
+        } catch (PaasException e) {
+            throw e;
+        } catch (Exception e) {
+            String msg = MessageFormatter.format(
+                "Fail to request {}",
+                uri
+            ).getMessage();
+            log.error(msg, e);
+            throw new PaasException(e, ErrorType.INTERNAL, ErrorCode.CMSI_API_ACCESS_ERROR, new Object[]{});
+        } finally {
+            HttpMetricUtil.clearHttpMetric();
+        }
+    }
+
+    public Boolean canUseStandaloneVoiceAPI() {
+        return this.useStandaloneVoiceAPI;
+    }
+
+    private void handleResultOrThrow(EsbResp<Object> esbResp, ErrorType errorType, int errorCode) {
+        if (esbResp.getResult() == null || !esbResp.getResult() || esbResp.getCode() != 0) {
+            throw new PaasException(
+                errorType,
+                errorCode,
+                new Object[]{
+                    esbResp.getCode().toString(),
+                    esbResp.getMessage()
+                });
+        }
+    }
+
+    private PostSendMsgReq buildSendMsgReq(String msgType,
+                                           String sender,
+                                           Set<String> receivers,
+                                           String title,
+                                           String content) {
+        PostSendMsgReq req = EsbReq.buildRequest(PostSendMsgReq.class, "superadmin");
+        if (title == null || title.isEmpty()) {
+            title = "Default Title";
+        }
+        req.setMsgType(msgType);
+        req.setSender(sender);
+        req.setReceiverUsername(String.join(",", receivers));
+        req.setTitle(title);
+        req.setContent(content);
+        return req;
+    }
+
+    @Override
+    public List<EsbNotifyChannelDTO> getNotifyChannelList(String tenantId) {
+        return getNotifyChannelList();
+    }
+
+    @Override
+    public void sendMsg(String msgType, NotifyMessageDTO notifyMessageDTO, String tenantId) {
+        if (notifyMessageDTO == null) {
+            log.warn("notifyMessageDTO is null, ignore");
+            return;
+        }
+        List<String> receiverUserList = notifyMessageDTO.getReceiverUsername();
+        if (CollectionUtils.isEmpty(receiverUserList)) {
+            log.warn("receiverUserList is empty, ignore");
+            return;
+        }
+        Set<String> receiverUserSet = receiverUserList.stream()
+            .map(String::trim)
+            .collect(Collectors.toSet());
+        // 语音通知走专门接口，其余渠道走通用发送接口
+        if (NotifyChannelEnum.isVoice(msgType) && canUseStandaloneVoiceAPI()) {
+            sendVoiceMsg(notifyMessageDTO.getContent(), receiverUserList);
+            return;
+        }
+        sendMsg(
+            msgType,
+            notifyMessageDTO.getSender(),
+            receiverUserSet,
+            notifyMessageDTO.getTitle(),
+            notifyMessageDTO.getContent()
+        );
+    }
+}

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/cmsi/ICmsiClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/cmsi/ICmsiClient.java
@@ -31,9 +31,9 @@ import java.util.List;
 
 public interface ICmsiClient {
 
-    public List<EsbNotifyChannelDTO> getNotifyChannelList(String tenantId);
+    List<EsbNotifyChannelDTO> getNotifyChannelList(String tenantId);
 
-    public void sendMsg(String msgType,
-                        NotifyMessageDTO notifyMessageDTO,
-                        String tenantId);
+    void sendMsg(String msgType,
+                 NotifyMessageDTO notifyMessageDTO,
+                 String tenantId);
 }

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/cmsi/MockCmsiClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/cmsi/MockCmsiClient.java
@@ -24,39 +24,14 @@
 
 package com.tencent.bk.job.common.paas.cmsi;
 
-import com.tencent.bk.job.common.esb.config.AppProperties;
-import com.tencent.bk.job.common.esb.config.BkApiGatewayProperties;
-import com.tencent.bk.job.common.esb.config.EsbProperties;
-import com.tencent.bk.job.common.esb.model.BkApiAuthorization;
-import com.tencent.bk.job.common.esb.sdk.BkApiV1Client;
 import com.tencent.bk.job.common.paas.model.EsbNotifyChannelDTO;
 import com.tencent.bk.job.common.paas.model.NotifyMessageDTO;
-import com.tencent.bk.job.common.tenant.TenantEnvService;
-import com.tencent.bk.job.common.util.http.HttpHelperFactory;
-import io.micrometer.core.instrument.MeterRegistry;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.tencent.bk.job.common.metrics.CommonMetricNames.ESB_CMSI_API;
-
-public class MockCmsiClient extends BkApiV1Client implements ICmsiClient {
-
-    public MockCmsiClient(BkApiGatewayProperties apiGatewayProperties,
-                          AppProperties appProperties,
-                          MeterRegistry meterRegistry,
-                          TenantEnvService tenantEnvService) {
-        super(
-            meterRegistry,
-            ESB_CMSI_API,
-            apiGatewayProperties.getCmsi().getUrl(),
-            HttpHelperFactory.createHttpHelper(
-                httpClientBuilder -> httpClientBuilder.addInterceptorLast(getLogBkApiRequestIdInterceptor())
-            ),
-            tenantEnvService
-        );
-    }
+public class MockCmsiClient implements ICmsiClient {
 
     @Override
     public List<EsbNotifyChannelDTO> getNotifyChannelList(String tenantId) {
@@ -97,6 +72,5 @@ public class MockCmsiClient extends BkApiV1Client implements ICmsiClient {
 
     @Override
     public void sendMsg(String msgType, NotifyMessageDTO notifyMessageDTO, String tenantId) {
-        return;
     }
 }

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/CmsiApiProperties.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/CmsiApiProperties.java
@@ -22,38 +22,36 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.common.paas.model;
+package com.tencent.bk.job.common.paas.config;
 
-public enum NotifyChannelEnum {
-    Mail("mail"),
-    Sms("sms"),
-    Voice("voice"),
-    Weixin("weixin");
+import com.tencent.bk.job.common.esb.constants.BkApiTypeEnum;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
-    private final String type;
+@Data
+@ConfigurationProperties(prefix = "cmsi")
+public class CmsiApiProperties {
 
-    NotifyChannelEnum(String type) {
-        this.type = type;
-    }
+    /**
+     * CMSI语音通知接口配置
+     */
+    private ChannelConfig voice;
 
-    public String getType() {
-        return type;
-    }
+    /**
+     * CMSI语音通知是否走独立接口
+     */
+    private Boolean useStandaloneVoiceAPI;
 
+    /**
+     * CMSI接口类型，默认APIGW
+     */
+    private String apiType = BkApiTypeEnum.APIGW.getType();
 
-    public static Boolean isMail(String channel) {
-        return Mail.getType().equalsIgnoreCase(channel);
-    }
-
-    public static Boolean isSms(String channel) {
-        return Sms.getType().equalsIgnoreCase(channel);
-    }
-
-    public static Boolean isVoice(String channel) {
-        return Voice.getType().equalsIgnoreCase(channel);
-    }
-
-    public static Boolean isWeixin(String channel) {
-        return Weixin.getType().equalsIgnoreCase(channel);
+    @Getter
+    @Setter
+    public static class ChannelConfig {
+        private String uri;
     }
 }

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/CmsiApiProperties.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/CmsiApiProperties.java
@@ -35,19 +35,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class CmsiApiProperties {
 
     /**
-     * CMSI语音通知接口配置
-     */
-    private ChannelConfig voice;
-
-    /**
-     * CMSI语音通知是否走独立接口
-     */
-    private Boolean useStandaloneVoiceAPI;
-
-    /**
      * CMSI接口类型，默认APIGW
      */
     private String apiType = BkApiTypeEnum.APIGW.getType();
+
+    /**
+     * CMSI语音通知接口配置
+     */
+    private ChannelConfig voice;
 
     @Getter
     @Setter

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/LoginAutoConfiguration.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/LoginAutoConfiguration.java
@@ -26,50 +26,70 @@ package com.tencent.bk.job.common.paas.config;
 
 import com.tencent.bk.job.common.esb.config.AppProperties;
 import com.tencent.bk.job.common.esb.config.BkApiGatewayProperties;
+import com.tencent.bk.job.common.esb.config.EsbProperties;
+import com.tencent.bk.job.common.paas.config.condition.ConditionalOnCustomLoginDisable;
+import com.tencent.bk.job.common.paas.config.condition.ConditionalOnCustomLoginEnable;
+import com.tencent.bk.job.common.paas.config.condition.ConditionalOnLoginUseApiGw;
+import com.tencent.bk.job.common.paas.config.condition.ConditionalOnLoginUseEsb;
 import com.tencent.bk.job.common.paas.login.CustomLoginClient;
 import com.tencent.bk.job.common.paas.login.ILoginClient;
-import com.tencent.bk.job.common.paas.login.StandardLoginClient;
-import com.tencent.bk.job.common.paas.login.v3.BkLoginApiClient;
+import com.tencent.bk.job.common.paas.login.StandardLoginApiGwClient;
+import com.tencent.bk.job.common.paas.login.StandardLoginEsbClient;
+import com.tencent.bk.job.common.paas.login.v3.BkLoginApiGwClient;
 import com.tencent.bk.job.common.tenant.TenantEnvService;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
 
 @Configuration(proxyBeanMethods = false)
 @Slf4j
-@Import(LoginConfiguration.class)
+@EnableConfigurationProperties(LoginProperties.class)
 public class LoginAutoConfiguration {
 
     @Bean
-    @ConditionalOnProperty(value = "paas.login.custom.enabled", havingValue = "true")
-    public ILoginClient customLoginClient(@Autowired LoginConfiguration loginConfiguration) {
-        log.info("Init CustomLoginClient");
-        return new CustomLoginClient(loginConfiguration.getCustomLoginApiUrl());
+    @ConditionalOnCustomLoginEnable
+    public ILoginClient customLoginClient(@Autowired LoginProperties loginProperties) {
+        log.info("Init customLoginClient");
+        return new CustomLoginClient(loginProperties.getCustom().getLoginUrl());
     }
 
     @Bean
-    @ConditionalOnProperty(value = "paas.login.custom.enabled", havingValue = "false", matchIfMissing = true)
-    public BkLoginApiClient bkLoginApiClient(BkApiGatewayProperties bkApiGatewayProperties,
-                                             AppProperties appProperties,
-                                             ObjectProvider<MeterRegistry> meterRegistryObjectProvider,
-                                             TenantEnvService tenantEnvService) {
-        log.info("Init LoginApiClient");
-        return new BkLoginApiClient(bkApiGatewayProperties, appProperties,
-            meterRegistryObjectProvider.getIfAvailable(), tenantEnvService);
-    }
-
-    @Bean
-    @ConditionalOnProperty(value = "paas.login.custom.enabled", havingValue = "false", matchIfMissing = true)
     @Primary
-    public ILoginClient standardLoginClient(BkLoginApiClient bkLoginApiClient) {
+    @ConditionalOnLoginUseApiGw
+    @ConditionalOnCustomLoginDisable
+    public ILoginClient standardLoginApiGwClient(BkApiGatewayProperties bkApiGatewayProperties,
+                                                 AppProperties appProperties,
+                                                 ObjectProvider<MeterRegistry> meterRegistryObjectProvider,
+                                                 TenantEnvService tenantEnvService) {
+        log.info("Init standardLoginApiGwClient");
+        return new StandardLoginApiGwClient(
+            new BkLoginApiGwClient(
+                bkApiGatewayProperties,
+                appProperties,
+                meterRegistryObjectProvider.getIfAvailable(),
+                tenantEnvService
+            )
+        );
+    }
 
-        log.info("Init StandardLoginClient");
-        return new StandardLoginClient(bkLoginApiClient);
+    @Bean
+    @ConditionalOnLoginUseEsb
+    @ConditionalOnCustomLoginDisable
+    public ILoginClient standardLoginEsbClient(EsbProperties esbProperties,
+                                               AppProperties appProperties,
+                                               MeterRegistry meterRegistry,
+                                               TenantEnvService tenantEnvService) {
+        log.info("Init standardLoginEsbClient");
+        return new StandardLoginEsbClient(
+            esbProperties,
+            appProperties,
+            meterRegistry,
+            tenantEnvService
+        );
     }
 }

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/LoginAutoConfiguration.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/LoginAutoConfiguration.java
@@ -73,7 +73,8 @@ public class LoginAutoConfiguration {
                 appProperties,
                 meterRegistryObjectProvider.getIfAvailable(),
                 tenantEnvService
-            )
+            ),
+            tenantEnvService
         );
     }
 

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/LoginProperties.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/LoginProperties.java
@@ -1,0 +1,88 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.paas.config;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.tencent.bk.job.common.esb.constants.BkApiTypeEnum;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "paas.login")
+public class LoginProperties {
+    /**
+     * 蓝鲸标准登录接口类型，默认APIGW
+     */
+    private String apiType = BkApiTypeEnum.APIGW.getType();
+    /**
+     * 蓝鲸标准的登录url
+     */
+    private String url;
+
+    /**
+     * 自定义第三方登录系统配置
+     */
+    private CustomLoginConfig custom = new CustomLoginConfig();
+
+    /**
+     * 获取真正使用的登录url
+     *
+     * @return 登录url
+     */
+    @JsonIgnore
+    public String getRealLoginUrl() {
+        if (custom.isEnabled()) {
+            return custom.getLoginUrl();
+        } else {
+            return url;
+        }
+    }
+
+    @Getter
+    @Setter
+    public static class CustomLoginConfig {
+        /**
+         * 是否使用第三方登录系统
+         */
+        private boolean enabled = false;
+
+        /**
+         * 第三方登录系统用户token的cookie名称
+         */
+        private String tokenName = "bk_token";
+
+        /**
+         * 第三方登录系统登录url
+         */
+        private String loginUrl;
+
+        /**
+         * 第三方登录系统API url，用于根据token获取用户信息
+         */
+        private String apiUrl;
+    }
+}

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/UserMgrAutoConfiguration.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/UserMgrAutoConfiguration.java
@@ -65,17 +65,9 @@ public class UserMgrAutoConfiguration {
 
     @Bean
     @ConditionalOnMockUserApiEnable
-    public IUserApiClient mockUserApiClient(AppProperties appProperties,
-                                            BkApiGatewayProperties bkApiGatewayProperties,
-                                            ObjectProvider<MeterRegistry> meterRegistryObjectProvider,
-                                            TenantEnvService tenantEnvService) {
+    public IUserApiClient mockUserApiClient() {
         log.info("Init MockUserApiClient");
-        return new MockUserApiClient(
-            bkApiGatewayProperties,
-            appProperties,
-            meterRegistryObjectProvider.getIfAvailable(),
-            tenantEnvService
-        );
+        return new MockUserApiClient();
     }
 
     @Bean

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/condition/ConditionalOnCmsiUseApiGw.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/condition/ConditionalOnCmsiUseApiGw.java
@@ -22,38 +22,28 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.common.paas.model;
+package com.tencent.bk.job.common.paas.config.condition;
 
-public enum NotifyChannelEnum {
-    Mail("mail"),
-    Sms("sms"),
-    Voice("voice"),
-    Weixin("weixin");
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
-    private final String type;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-    NotifyChannelEnum(String type) {
-        this.type = type;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-
-    public static Boolean isMail(String channel) {
-        return Mail.getType().equalsIgnoreCase(channel);
-    }
-
-    public static Boolean isSms(String channel) {
-        return Sms.getType().equalsIgnoreCase(channel);
-    }
-
-    public static Boolean isVoice(String channel) {
-        return Voice.getType().equalsIgnoreCase(channel);
-    }
-
-    public static Boolean isWeixin(String channel) {
-        return Weixin.getType().equalsIgnoreCase(channel);
-    }
+/**
+ * @see com.tencent.bk.job.common.esb.constants.BkApiTypeEnum
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ConditionalOnProperty(
+    value = "cmsi.api-type",
+    havingValue = "apigw",
+    matchIfMissing = true
+)
+public @interface ConditionalOnCmsiUseApiGw {
 }

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/condition/ConditionalOnCmsiUseEsb.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/condition/ConditionalOnCmsiUseEsb.java
@@ -22,38 +22,27 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.common.paas.model;
+package com.tencent.bk.job.common.paas.config.condition;
 
-public enum NotifyChannelEnum {
-    Mail("mail"),
-    Sms("sms"),
-    Voice("voice"),
-    Weixin("weixin");
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
-    private final String type;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-    NotifyChannelEnum(String type) {
-        this.type = type;
-    }
-
-    public String getType() {
-        return type;
-    }
-
-
-    public static Boolean isMail(String channel) {
-        return Mail.getType().equalsIgnoreCase(channel);
-    }
-
-    public static Boolean isSms(String channel) {
-        return Sms.getType().equalsIgnoreCase(channel);
-    }
-
-    public static Boolean isVoice(String channel) {
-        return Voice.getType().equalsIgnoreCase(channel);
-    }
-
-    public static Boolean isWeixin(String channel) {
-        return Weixin.getType().equalsIgnoreCase(channel);
-    }
+/**
+ * @see com.tencent.bk.job.common.esb.constants.BkApiTypeEnum
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ConditionalOnProperty(
+    value = "cmsi.api-type",
+    havingValue = "esb"
+)
+public @interface ConditionalOnCmsiUseEsb {
 }

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/condition/ConditionalOnCustomLoginDisable.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/condition/ConditionalOnCustomLoginDisable.java
@@ -22,40 +22,28 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.common.paas.login;
+package com.tencent.bk.job.common.paas.config.condition;
 
-import com.tencent.bk.job.common.model.dto.BkUserDTO;
-import com.tencent.bk.job.common.paas.login.v3.BkLoginApiClient;
-import com.tencent.bk.job.common.paas.login.v3.OpenApiBkUser;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
-@Slf4j
-public class StandardLoginClient implements ILoginClient {
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-    private final BkLoginApiClient bkLoginApiClient;
-
-    public StandardLoginClient(BkLoginApiClient bkLoginApiClient) {
-        this.bkLoginApiClient = bkLoginApiClient;
-    }
-
-    /**
-     * 根据 token 获取指定用户信息
-     *
-     * @param bkToken 用户登录 token
-     * @return 用户信息
-     */
-    @Override
-    public BkUserDTO getUserInfoByToken(String bkToken) {
-        OpenApiBkUser bkUser = bkLoginApiClient.getBkUserByToken(bkToken);
-        if (bkUser == null) {
-            return null;
-        }
-        BkUserDTO bkUserDTO = new BkUserDTO();
-        bkUserDTO.setUsername(bkUser.getUsername());
-        bkUserDTO.setDisplayName(bkUser.getDisplayName());
-        bkUserDTO.setTimeZone(bkUser.getTimeZone());
-        bkUserDTO.setTenantId(bkUser.getTenantId());
-        bkUserDTO.setLanguage(bkUser.getLanguage());
-        return bkUserDTO;
-    }
+/**
+ * @see com.tencent.bk.job.common.esb.constants.BkApiTypeEnum
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ConditionalOnProperty(
+    value = "paas.login.custom.enabled",
+    havingValue = "false",
+    matchIfMissing = true
+)
+public @interface ConditionalOnCustomLoginDisable {
 }

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/condition/ConditionalOnCustomLoginEnable.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/condition/ConditionalOnCustomLoginEnable.java
@@ -22,61 +22,27 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.common.paas.config;
+package com.tencent.bk.job.common.paas.config.condition;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 
-@Configuration(proxyBeanMethods = false)
-@Getter
-@Setter
-@ToString
-public class LoginConfiguration {
-    /**
-     * 蓝鲸标准的登录url
-     */
-    @Value("${paas.login.url:}")
-    private String loginUrl;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-    /**
-     * 是否使用第三方登录系统
-     */
-    @Value("${paas.login.custom.enabled:false}")
-    private boolean customPaasLoginEnabled;
-
-    /**
-     * 第三方登录系统用户token的cookie名称
-     */
-    @Value("${paas.login.custom.token-name:bk_token}")
-    private String customLoginToken;
-
-    /**
-     * 第三方登录系统登录url
-     */
-    @Value("${paas.login.custom.login-url:}")
-    private String customLoginUrl;
-
-    /**
-     * 第三方登录系统API url，用于根据token获取用户信息
-     */
-    @Value("${paas.login.custom.api-url:}")
-    private String customLoginApiUrl;
-
-    /**
-     * 获取真正使用的登录url
-     *
-     * @return 登录url
-     */
-    @JsonIgnore
-    public String getRealLoginUrl() {
-        if (isCustomPaasLoginEnabled()) {
-            return getCustomLoginUrl();
-        } else {
-            return getLoginUrl();
-        }
-    }
+/**
+ * @see com.tencent.bk.job.common.esb.constants.BkApiTypeEnum
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ConditionalOnProperty(
+    value = "paas.login.custom.enabled",
+    havingValue = "true"
+)
+public @interface ConditionalOnCustomLoginEnable {
 }

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/condition/ConditionalOnLoginUseApiGw.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/condition/ConditionalOnLoginUseApiGw.java
@@ -1,0 +1,49 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.paas.config.condition;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @see com.tencent.bk.job.common.esb.constants.BkApiTypeEnum
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ConditionalOnProperty(
+    value = "paas.login.api-type",
+    havingValue = "apigw",
+    matchIfMissing = true
+)
+public @interface ConditionalOnLoginUseApiGw {
+}

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/condition/ConditionalOnLoginUseEsb.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/config/condition/ConditionalOnLoginUseEsb.java
@@ -1,0 +1,48 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.paas.config.condition;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @see com.tencent.bk.job.common.esb.constants.BkApiTypeEnum
+ */
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@ConditionalOnProperty(
+    value = "paas.login.api-type",
+    havingValue = "esb"
+)
+public @interface ConditionalOnLoginUseEsb {
+}

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/CustomLoginClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/CustomLoginClient.java
@@ -85,7 +85,8 @@ public class CustomLoginClient implements ILoginClient {
             }
             BkUserDTO bkUserDto = new BkUserDTO();
             bkUserDto.setUsername(resp.getData().getUsername());
-            bkUserDto.setTenantId(TenantIdConstants.DEFAULT_TENANT_ID);
+            // 当前只有在单租户环境下才会用到自定义登录
+            bkUserDto.setTenantInfo(false, TenantIdConstants.DEFAULT_TENANT_ID);
             return bkUserDto;
         } catch (Exception e) {
             log.error("Error occur when get user info", e);

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/StandardLoginApiGwClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/StandardLoginApiGwClient.java
@@ -24,18 +24,23 @@
 
 package com.tencent.bk.job.common.paas.login;
 
+import com.tencent.bk.job.common.constant.TenantIdConstants;
 import com.tencent.bk.job.common.model.dto.BkUserDTO;
 import com.tencent.bk.job.common.paas.login.v3.BkLoginApiGwClient;
 import com.tencent.bk.job.common.paas.login.v3.OpenApiBkUser;
+import com.tencent.bk.job.common.tenant.TenantEnvService;
+import io.micrometer.core.instrument.util.StringUtils;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class StandardLoginApiGwClient implements ILoginClient {
 
     private final BkLoginApiGwClient bkLoginApiClient;
+    protected final TenantEnvService tenantEnvService;
 
-    public StandardLoginApiGwClient(BkLoginApiGwClient bkLoginApiGwClient) {
+    public StandardLoginApiGwClient(BkLoginApiGwClient bkLoginApiGwClient, TenantEnvService tenantEnvService) {
         this.bkLoginApiClient = bkLoginApiGwClient;
+        this.tenantEnvService = tenantEnvService;
     }
 
     /**
@@ -56,6 +61,10 @@ public class StandardLoginApiGwClient implements ILoginClient {
         bkUserDTO.setTimeZone(bkUser.getTimeZone());
         bkUserDTO.setTenantId(bkUser.getTenantId());
         bkUserDTO.setLanguage(bkUser.getLanguage());
+        // 兼容单租户环境
+        if (StringUtils.isBlank(bkUserDTO.getTenantId()) && !tenantEnvService.isTenantEnabled()) {
+            bkUserDTO.setTenantId(TenantIdConstants.DEFAULT_TENANT_ID);
+        }
         return bkUserDTO;
     }
 }

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/StandardLoginApiGwClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/StandardLoginApiGwClient.java
@@ -1,0 +1,61 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.paas.login;
+
+import com.tencent.bk.job.common.model.dto.BkUserDTO;
+import com.tencent.bk.job.common.paas.login.v3.BkLoginApiGwClient;
+import com.tencent.bk.job.common.paas.login.v3.OpenApiBkUser;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class StandardLoginApiGwClient implements ILoginClient {
+
+    private final BkLoginApiGwClient bkLoginApiClient;
+
+    public StandardLoginApiGwClient(BkLoginApiGwClient bkLoginApiGwClient) {
+        this.bkLoginApiClient = bkLoginApiGwClient;
+    }
+
+    /**
+     * 根据 token 获取指定用户信息
+     *
+     * @param bkToken 用户登录 token
+     * @return 用户信息
+     */
+    @Override
+    public BkUserDTO getUserInfoByToken(String bkToken) {
+        OpenApiBkUser bkUser = bkLoginApiClient.getBkUserByToken(bkToken);
+        if (bkUser == null) {
+            return null;
+        }
+        BkUserDTO bkUserDTO = new BkUserDTO();
+        bkUserDTO.setUsername(bkUser.getUsername());
+        bkUserDTO.setDisplayName(bkUser.getDisplayName());
+        bkUserDTO.setTimeZone(bkUser.getTimeZone());
+        bkUserDTO.setTenantId(bkUser.getTenantId());
+        bkUserDTO.setLanguage(bkUser.getLanguage());
+        return bkUserDTO;
+    }
+}

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/StandardLoginApiGwClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/StandardLoginApiGwClient.java
@@ -59,11 +59,11 @@ public class StandardLoginApiGwClient implements ILoginClient {
         bkUserDTO.setUsername(bkUser.getUsername());
         bkUserDTO.setDisplayName(bkUser.getDisplayName());
         bkUserDTO.setTimeZone(bkUser.getTimeZone());
-        bkUserDTO.setTenantId(bkUser.getTenantId());
+        bkUserDTO.setTenantInfo(tenantEnvService.isTenantEnabled(), bkUser.getTenantId());
         bkUserDTO.setLanguage(bkUser.getLanguage());
         // 兼容单租户环境
         if (StringUtils.isBlank(bkUserDTO.getTenantId()) && !tenantEnvService.isTenantEnabled()) {
-            bkUserDTO.setTenantId(TenantIdConstants.DEFAULT_TENANT_ID);
+            bkUserDTO.setTenantInfo(false, TenantIdConstants.DEFAULT_TENANT_ID);
         }
         return bkUserDTO;
     }

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/StandardLoginEsbClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/StandardLoginEsbClient.java
@@ -136,7 +136,7 @@ public class StandardLoginEsbClient extends BkApiV1Client implements ILoginClien
         bkUserDTO.setTimeZone(esbUserDto.getTimeZone());
         // 兼容单租户环境
         if(!tenantEnvService.isTenantEnabled()){
-            bkUserDTO.setTenantId(TenantIdConstants.DEFAULT_TENANT_ID);
+            bkUserDTO.setTenantInfo(false, TenantIdConstants.DEFAULT_TENANT_ID);
         }
         return bkUserDTO;
     }

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/StandardLoginEsbClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/StandardLoginEsbClient.java
@@ -27,6 +27,7 @@ package com.tencent.bk.job.common.paas.login;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.tencent.bk.job.common.constant.ErrorCode;
 import com.tencent.bk.job.common.constant.HttpMethodEnum;
+import com.tencent.bk.job.common.constant.TenantIdConstants;
 import com.tencent.bk.job.common.esb.config.AppProperties;
 import com.tencent.bk.job.common.esb.config.EsbProperties;
 import com.tencent.bk.job.common.esb.model.BkApiAuthorization;
@@ -133,6 +134,10 @@ public class StandardLoginEsbClient extends BkApiV1Client implements ILoginClien
         bkUserDTO.setPhone(esbUserDto.getPhone());
         bkUserDTO.setWxUserId(esbUserDto.getWxUserId());
         bkUserDTO.setTimeZone(esbUserDto.getTimeZone());
+        // 兼容单租户环境
+        if(!tenantEnvService.isTenantEnabled()){
+            bkUserDTO.setTenantId(TenantIdConstants.DEFAULT_TENANT_ID);
+        }
         return bkUserDTO;
     }
 }

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/StandardLoginEsbClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/StandardLoginEsbClient.java
@@ -1,0 +1,138 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.paas.login;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.tencent.bk.job.common.constant.ErrorCode;
+import com.tencent.bk.job.common.constant.HttpMethodEnum;
+import com.tencent.bk.job.common.esb.config.AppProperties;
+import com.tencent.bk.job.common.esb.config.EsbProperties;
+import com.tencent.bk.job.common.esb.model.BkApiAuthorization;
+import com.tencent.bk.job.common.esb.model.EsbResp;
+import com.tencent.bk.job.common.esb.model.OpenApiRequestInfo;
+import com.tencent.bk.job.common.esb.sdk.BkApiV1Client;
+import com.tencent.bk.job.common.exception.InternalUserManageException;
+import com.tencent.bk.job.common.metrics.CommonMetricNames;
+import com.tencent.bk.job.common.model.dto.BkUserDTO;
+import com.tencent.bk.job.common.paas.exception.AppPermissionDeniedException;
+import com.tencent.bk.job.common.paas.model.EsbUserDto;
+import com.tencent.bk.job.common.tenant.TenantEnvService;
+import com.tencent.bk.job.common.util.http.HttpHelperFactory;
+import com.tencent.bk.job.common.util.http.HttpMetricUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class StandardLoginEsbClient extends BkApiV1Client implements ILoginClient {
+
+    // 用户认证失败，即用户登录态无效
+    private static final Integer ESB_CODE_USER_NOT_LOGIN = 1302100;
+    // 用户不存在
+    private static final Integer ESB_CODE_USER_NOT_EXIST = 1302103;
+    // 用户认证成功，但用户无应用访问权限
+    private static final Integer ESB_CODE_USER_NO_APP_PERMISSION = 1302403;
+
+    private static final String API_GET_USER_INFO = "/api/c/compapi/v2/bk_login/get_user/";
+
+    private final AppProperties appProperties;
+
+    public StandardLoginEsbClient(EsbProperties esbProperties,
+                                  AppProperties appProperties,
+                                  MeterRegistry meterRegistry,
+                                  TenantEnvService tenantEnvService) {
+        super(
+            meterRegistry,
+            CommonMetricNames.BK_LOGIN_API,
+            esbProperties.getService().getUrl(),
+            HttpHelperFactory.createHttpHelper(
+                httpClientBuilder -> httpClientBuilder.addInterceptorLast(getLogBkApiRequestIdInterceptor())
+            ),
+            tenantEnvService
+        );
+        this.appProperties = appProperties;
+    }
+
+    /**
+     * 获取指定用户信息
+     *
+     * @param bkToken 用户登录 token
+     * @return 用户信息
+     */
+    @Override
+    public BkUserDTO getUserInfoByToken(String bkToken) {
+        try {
+            HttpMetricUtil.setHttpMetricName(CommonMetricNames.BK_LOGIN_API_HTTP);
+            HttpMetricUtil.addTagForCurrentMetric(
+                Tag.of("api_name", API_GET_USER_INFO)
+            );
+            EsbResp<EsbUserDto> esbResp = doRequest(
+                OpenApiRequestInfo.builder()
+                    .method(HttpMethodEnum.GET)
+                    .uri(API_GET_USER_INFO)
+                    .addQueryParam("bk_token", bkToken)
+                    .authorization(BkApiAuthorization.bkTokenUserAuthorization(
+                        appProperties.getCode(), appProperties.getSecret(), bkToken))
+                    .build(),
+                new TypeReference<EsbResp<EsbUserDto>>() {
+                }
+            );
+            Integer code = esbResp.getCode();
+            if (ErrorCode.RESULT_OK == code) {
+                return convertToBkUserDTO(esbResp.getData());
+            } else {
+                handleNotOkResp(esbResp);
+                return null;
+            }
+        } catch (Exception e) {
+            String errorMsg = "Get " + API_GET_USER_INFO + " error";
+            log.error(errorMsg, e);
+            throw new InternalUserManageException(errorMsg, e, ErrorCode.USER_MANAGE_API_ACCESS_ERROR);
+        } finally {
+            HttpMetricUtil.clearHttpMetric();
+        }
+    }
+
+    private void handleNotOkResp(EsbResp<EsbUserDto> esbResp) {
+        Integer code = esbResp.getCode();
+        if (ESB_CODE_USER_NO_APP_PERMISSION.equals(code)) {
+            throw new AppPermissionDeniedException(esbResp.getMessage());
+        } else if (ESB_CODE_USER_NOT_LOGIN.equals(code)) {
+            log.info("User not login, esbResp.code={}, esbResp.message={}", esbResp.getCode(), esbResp.getMessage());
+        } else if (ESB_CODE_USER_NOT_EXIST.equals(code)) {
+            log.info("User not exist, esbResp.code={}, esbResp.message={}", esbResp.getCode(), esbResp.getMessage());
+        }
+    }
+
+    private BkUserDTO convertToBkUserDTO(EsbUserDto esbUserDto) {
+        BkUserDTO bkUserDTO = new BkUserDTO();
+        bkUserDTO.setUsername(esbUserDto.getUsername());
+        bkUserDTO.setEmail(esbUserDto.getEmail());
+        bkUserDTO.setPhone(esbUserDto.getPhone());
+        bkUserDTO.setWxUserId(esbUserDto.getWxUserId());
+        bkUserDTO.setTimeZone(esbUserDto.getTimeZone());
+        return bkUserDTO;
+    }
+}

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/v3/BkLoginApiGwClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/v3/BkLoginApiGwClient.java
@@ -28,20 +28,20 @@ import static com.tencent.bk.job.common.metrics.CommonMetricNames.BK_LOGIN_API;
 import static com.tencent.bk.job.common.metrics.CommonMetricNames.BK_LOGIN_API_HTTP;
 
 /**
- * bk-login API 客户端
+ * bk-login APIGW 客户端
  */
 @Slf4j
-public class BkLoginApiClient extends BkApiV2Client {
+public class BkLoginApiGwClient extends BkApiV2Client {
 
     public static final String API_URL_USERINFO = "/login/api/v3/open/bk-tokens/userinfo";
 
     protected final BkApiAuthorization authorization;
 
 
-    public BkLoginApiClient(BkApiGatewayProperties bkApiGatewayProperties,
-                            AppProperties appProperties,
-                            MeterRegistry meterRegistry,
-                            TenantEnvService tenantEnvService) {
+    public BkLoginApiGwClient(BkApiGatewayProperties bkApiGatewayProperties,
+                              AppProperties appProperties,
+                              MeterRegistry meterRegistry,
+                              TenantEnvService tenantEnvService) {
         super(
             meterRegistry,
             BK_LOGIN_API,

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/model/EsbUserDto.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/model/EsbUserDto.java
@@ -1,0 +1,78 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.paas.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.io.Serializable;
+
+/**
+ * 蓝鲸平台用户信息,仅用于转换ESB API 调用返回的数据
+ */
+@Getter
+@Setter
+@ToString
+public class EsbUserDto implements Serializable {
+
+    /**
+     * 用户名
+     */
+    @JsonProperty("bk_username")
+    private String username;
+
+    @JsonProperty("bk_role")
+    private int role;
+
+    private String qq;
+
+    private String phone;
+
+    private String email;
+
+    /**
+     * 中文名称
+     */
+    private String chname;
+
+    private String language;
+
+    @JsonProperty("time_zone")
+    private String timeZone;
+
+    /**
+     * 企业号用户USERID/公众号用户OPENID
+     */
+    @JsonProperty("wx_userid")
+    private String wxUserId;
+
+    /**
+     * 开发商code
+     */
+    @JsonProperty("bk_supplier_account")
+    private String owner;
+}

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/model/cmsi/req/SendVoiceEsbReq.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/model/cmsi/req/SendVoiceEsbReq.java
@@ -22,38 +22,23 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.common.paas.model;
+package com.tencent.bk.job.common.paas.model.cmsi.req;
 
-public enum NotifyChannelEnum {
-    Mail("mail"),
-    Sms("sms"),
-    Voice("voice"),
-    Weixin("weixin");
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 
-    private final String type;
+@Data
+public class SendVoiceEsbReq {
 
-    NotifyChannelEnum(String type) {
-        this.type = type;
-    }
+    /**
+     * 自动语音读字信息
+     */
+    @JsonProperty("auto_read_message")
+    private String message;
 
-    public String getType() {
-        return type;
-    }
-
-
-    public static Boolean isMail(String channel) {
-        return Mail.getType().equalsIgnoreCase(channel);
-    }
-
-    public static Boolean isSms(String channel) {
-        return Sms.getType().equalsIgnoreCase(channel);
-    }
-
-    public static Boolean isVoice(String channel) {
-        return Voice.getType().equalsIgnoreCase(channel);
-    }
-
-    public static Boolean isWeixin(String channel) {
-        return Weixin.getType().equalsIgnoreCase(channel);
-    }
+    /**
+     * 待通知的用户列表，包含用户名，多个以逗号分隔
+     */
+    @JsonProperty("receiver__username")
+    public String receivers;
 }

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/user/IUserApiClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/user/IUserApiClient.java
@@ -32,11 +32,11 @@ import java.util.List;
 
 public interface IUserApiClient {
 
-    public List<OpenApiTenant> listAllTenant();
+    List<OpenApiTenant> listAllTenant();
 
-    public SimpleUserInfo getUserByUsername(String tenantId, String username);
+    SimpleUserInfo getUserByUsername(String tenantId, String username);
 
-    public List<SimpleUserInfo> batchGetVirtualUserByLoginName(String tenantId, String loginName);
+    List<SimpleUserInfo> batchGetVirtualUserByLoginName(String tenantId, String loginName);
 
     List<SimpleUserInfo> listUsersByUsernames(String tenantId, Collection<String> usernames);
 

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/user/MockUserApiClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/user/MockUserApiClient.java
@@ -25,35 +25,19 @@
 package com.tencent.bk.job.common.paas.user;
 
 import com.tencent.bk.job.common.constant.TenantIdConstants;
-import com.tencent.bk.job.common.esb.config.AppProperties;
-import com.tencent.bk.job.common.esb.config.BkApiGatewayProperties;
 import com.tencent.bk.job.common.paas.model.OpenApiTenant;
+import com.tencent.bk.job.common.paas.model.SimpleUserInfo;
 import com.tencent.bk.job.common.paas.model.TenantStatusEnum;
-import com.tencent.bk.job.common.tenant.TenantEnvService;
-import io.micrometer.core.instrument.MeterRegistry;
-import lombok.experimental.Delegate;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.util.CollectionUtils;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 public class MockUserApiClient implements IUserApiClient {
-
-    @Delegate
-    private final IUserApiClient proxy;
-
-    public MockUserApiClient(BkApiGatewayProperties bkApiGatewayProperties,
-                             AppProperties appProperties,
-                             MeterRegistry meterRegistry,
-                             TenantEnvService tenantEnvService) {
-        this.proxy = new UserMgrApiClient(
-            bkApiGatewayProperties,
-            appProperties,
-            meterRegistry,
-            tenantEnvService
-        );
-    }
 
     @Override
     public List<OpenApiTenant> listAllTenant() {
@@ -62,5 +46,25 @@ public class MockUserApiClient implements IUserApiClient {
         openApiTenant.setName(TenantIdConstants.DEFAULT_TENANT_ID);
         openApiTenant.setStatus(TenantStatusEnum.ENABLED.getStatus());
         return Collections.singletonList(openApiTenant);
+    }
+
+    @Override
+    public SimpleUserInfo getUserByUsername(String tenantId, String username) {
+        return new SimpleUserInfo(username, username, username);
+    }
+
+    @Override
+    public List<SimpleUserInfo> batchGetVirtualUserByLoginName(String tenantId, String loginName) {
+        return Collections.singletonList(new SimpleUserInfo(loginName, loginName, loginName));
+    }
+
+    @Override
+    public List<SimpleUserInfo> listUsersByUsernames(String tenantId, Collection<String> usernames) {
+        if (CollectionUtils.isEmpty(usernames)) {
+            return Collections.emptyList();
+        }
+        return usernames.stream()
+            .map(username -> new SimpleUserInfo(username, username, username))
+            .collect(Collectors.toList());
     }
 }

--- a/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/config/LoginExemptionConfig.java
+++ b/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/config/LoginExemptionConfig.java
@@ -19,4 +19,9 @@ public class LoginExemptionConfig {
      */
     @Value("${job.gateway.login-exemption.default-user:admin}")
     private String defaultUser;
+    /**
+     * 开启登录豁免后的默认用户所在租户ID
+     */
+    @Value("${job.gateway.login-exemption.default-user-tenant-id:default}")
+    private String defaultUserTenantId;
 }

--- a/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/config/RouteConfig.java
+++ b/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/config/RouteConfig.java
@@ -27,6 +27,7 @@ package com.tencent.bk.job.gateway.config;
 import com.tencent.bk.job.common.constant.ErrorCode;
 import com.tencent.bk.job.common.model.Response;
 import com.tencent.bk.job.common.model.dto.BkUserDTO;
+import com.tencent.bk.job.common.tenant.TenantEnvService;
 import com.tencent.bk.job.common.util.RequestUtil;
 import com.tencent.bk.job.gateway.web.service.LoginService;
 import lombok.extern.slf4j.Slf4j;
@@ -58,19 +59,23 @@ public class RouteConfig {
     }
 
     @Bean
-    public UserHandler userHandler(@Autowired LoginService loginService,
+    public UserHandler userHandler(@Autowired TenantEnvService tenantEnvService,
+                                   @Autowired LoginService loginService,
                                    @Autowired LoginExemptionConfig loginExemptionConfig) {
-        return new UserHandler(loginService, loginExemptionConfig);
+        return new UserHandler(tenantEnvService, loginService, loginExemptionConfig);
     }
 
     static class UserHandler {
+        private final TenantEnvService tenantEnvService;
         private final LoginService loginService;
         private final LoginExemptionConfig loginExemptionConfig;
 
         UserHandler(
+            TenantEnvService tenantEnvService,
             LoginService loginService,
             LoginExemptionConfig loginExemptionConfig
         ) {
+            this.tenantEnvService = tenantEnvService;
             this.loginService = loginService;
             this.loginExemptionConfig = loginExemptionConfig;
         }
@@ -80,6 +85,7 @@ public class RouteConfig {
             bkUserDTO.setId(1L);
             bkUserDTO.setUsername(loginExemptionConfig.getDefaultUser());
             bkUserDTO.setDisplayName(loginExemptionConfig.getDefaultUser());
+            bkUserDTO.setTenantInfo(tenantEnvService.isTenantEnabled(), loginExemptionConfig.getDefaultUserTenantId());
             return bkUserDTO;
         }
 

--- a/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/web/service/impl/LoginServiceImpl.java
+++ b/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/web/service/impl/LoginServiceImpl.java
@@ -31,7 +31,7 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import com.tencent.bk.job.common.constant.ErrorCode;
 import com.tencent.bk.job.common.exception.InternalException;
 import com.tencent.bk.job.common.model.dto.BkUserDTO;
-import com.tencent.bk.job.common.paas.config.LoginConfiguration;
+import com.tencent.bk.job.common.paas.config.LoginProperties;
 import com.tencent.bk.job.common.paas.login.ILoginClient;
 import com.tencent.bk.job.gateway.web.service.LoginService;
 import lombok.extern.slf4j.Slf4j;
@@ -47,13 +47,14 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 @Service
 public class LoginServiceImpl implements LoginService {
-    private final LoginConfiguration loginConfig;
+    private final LoginProperties loginProperties;
     private final String tokenName;
     private final String loginUrl;
     private final ILoginClient loginClient;
     private final LoadingCache<String, Optional<BkUserDTO>> onlineUserCache = CacheBuilder.newBuilder()
         .maximumSize(2000).expireAfterWrite(10, TimeUnit.SECONDS).build(
             new CacheLoader<String, Optional<BkUserDTO>>() {
+                @NotNull
                 @Override
                 public Optional<BkUserDTO> load(@NotNull String bkToken) {
                     BkUserDTO userDto = loginClient.getUserInfoByToken(bkToken);
@@ -63,18 +64,24 @@ public class LoginServiceImpl implements LoginService {
         );
 
     @Autowired
-    public LoginServiceImpl(LoginConfiguration loginConfig,
+    public LoginServiceImpl(LoginProperties loginProperties,
                             ILoginClient loginClient) {
-        this.loginConfig = loginConfig;
+        this.loginProperties = loginProperties;
         this.loginClient = loginClient;
         this.loginUrl = getLoginUrlProp();
-        this.tokenName = loginConfig.isCustomPaasLoginEnabled() ? loginConfig.getCustomLoginToken() : "bk_token";
-        log.info("Init login service, customLoginEnabled:{}, loginClient:{}, loginUrl:{}, tokenName:{}",
-            loginConfig.isCustomPaasLoginEnabled(), loginClient.getClass(), loginUrl, tokenName);
+        this.tokenName = loginProperties.getCustom().isEnabled() ?
+            loginProperties.getCustom().getTokenName() : "bk_token";
+        log.info(
+            "Init login service, customLoginEnabled:{}, loginClient:{}, loginUrl:{}, tokenName:{}",
+            loginProperties.getCustom().isEnabled(),
+            loginClient.getClass(),
+            loginUrl,
+            tokenName
+        );
     }
 
     private String getLoginUrlProp() {
-        String loginUrl = loginConfig.getRealLoginUrl();
+        String loginUrl = loginProperties.getRealLoginUrl();
         if (!loginUrl.endsWith("?")) {
             loginUrl = loginUrl + "?";
         }

--- a/src/backend/job-gateway/src/main/resources/application.yml
+++ b/src/backend/job-gateway/src/main/resources/application.yml
@@ -71,3 +71,4 @@ job:
     login-exemption:
       enabled: false
       default-user: admin
+      default-user-tenant-id: default

--- a/src/backend/job-manage/boot-job-manage/src/test/resources/application-test.yml
+++ b/src/backend/job-manage/boot-job-manage/src/test/resources/application-test.yml
@@ -49,4 +49,3 @@ cmsi:
   api-type: apigw
   voice:
     uri: /api/c/compapi/v2/cmsi/send_voice_msg/
-  useStandaloneVoiceAPI: true

--- a/src/backend/job-manage/boot-job-manage/src/test/resources/application-test.yml
+++ b/src/backend/job-manage/boot-job-manage/src/test/resources/application-test.yml
@@ -45,3 +45,8 @@ esb:
   service:
     url: esb.service
 
+cmsi:
+  api-type: apigw
+  voice:
+    uri: /api/c/compapi/v2/cmsi/send_voice_msg/
+  useStandaloneVoiceAPI: true

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/op/impl/TenantOpResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/op/impl/TenantOpResourceImpl.java
@@ -33,8 +33,8 @@ import com.tencent.bk.job.manage.api.op.TenantOpResource;
 import com.tencent.bk.job.manage.background.ha.BackGroundTaskDaemon;
 import com.tencent.bk.job.manage.background.sync.BizSetSyncService;
 import com.tencent.bk.job.manage.background.sync.BizSyncService;
+import com.tencent.bk.job.manage.background.sync.tenantset.ITenantSetSyncService;
 import com.tencent.bk.job.manage.background.sync.TenantHostSyncService;
-import com.tencent.bk.job.manage.background.sync.TenantSetSyncService;
 import com.tencent.bk.job.manage.model.op.req.InitTenantReq;
 import com.tencent.bk.job.manage.service.impl.notify.NotifyChannelInitService;
 import lombok.extern.slf4j.Slf4j;
@@ -54,7 +54,7 @@ public class TenantOpResourceImpl implements TenantOpResource {
     private final RedisTemplate<String, String> redisTemplate;
     private final BizSyncService bizSyncService;
     private final BizSetSyncService bizSetSyncService;
-    private final TenantSetSyncService tenantSetSyncService;
+    private final ITenantSetSyncService tenantSetSyncService;
     private final TenantHostSyncService tenantHostSyncService;
     private final NotifyChannelInitService notifyChannelInitService;
     private final BackGroundTaskDaemon backGroundTaskDaemon;
@@ -64,7 +64,7 @@ public class TenantOpResourceImpl implements TenantOpResource {
     public TenantOpResourceImpl(RedisTemplate<String, String> redisTemplate,
                                 BizSyncService bizSyncService,
                                 BizSetSyncService bizSetSyncService,
-                                TenantSetSyncService tenantSetSyncService,
+                                ITenantSetSyncService tenantSetSyncService,
                                 TenantHostSyncService tenantHostSyncService,
                                 NotifyChannelInitService notifyChannelInitService,
                                 BackGroundTaskDaemon backGroundTaskDaemon) {

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/background/sync/AppSyncService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/background/sync/AppSyncService.java
@@ -31,6 +31,7 @@ import com.tencent.bk.job.common.redis.util.HeartBeatRedisLockConfig;
 import com.tencent.bk.job.common.redis.util.LockResult;
 import com.tencent.bk.job.common.util.TimeUtil;
 import com.tencent.bk.job.common.util.ip.IpUtils;
+import com.tencent.bk.job.manage.background.sync.tenantset.ITenantSetSyncService;
 import com.tencent.bk.job.manage.config.JobManageConfig;
 import com.tencent.bk.job.manage.manager.app.ApplicationCache;
 import lombok.extern.slf4j.Slf4j;
@@ -62,13 +63,13 @@ public class AppSyncService {
     private final ApplicationCache applicationCache;
     private final BizSyncService bizSyncService;
     private final BizSetSyncService bizSetSyncService;
-    private final TenantSetSyncService tenantSetSyncService;
+    private final ITenantSetSyncService tenantSetSyncService;
     private final IUserApiClient userMgrApiClient;
 
     @Autowired
     public AppSyncService(BizSyncService bizSyncService,
                           BizSetSyncService bizSetSyncService,
-                          TenantSetSyncService tenantSetSyncService,
+                          ITenantSetSyncService tenantSetSyncService,
                           JobManageConfig jobManageConfig,
                           RedisTemplate<String, String> redisTemplate,
                           ApplicationCache applicationCache,

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/background/sync/tenantset/ITenantSetSyncService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/background/sync/tenantset/ITenantSetSyncService.java
@@ -22,29 +22,15 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.common.tenant;
+package com.tencent.bk.job.manage.background.sync.tenantset;
 
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+/**
+ * CMDB租户集同步接口
+ */
+public interface ITenantSetSyncService {
 
-@Slf4j
-@Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties(TenantProperties.class)
-public class TenantAutoConfiguration {
-
-    @Bean
-    @ConditionalOnTenantEnabled
-    public TenantEnvService tenantEnvService(TenantProperties tenantProperties) {
-        log.info("init tenantEnvService");
-        return new TenantEnvServiceImpl(tenantProperties);
-    }
-
-    @Bean
-    @ConditionalOnTenantDisabled
-    public TenantEnvService nonTenantEnvService() {
-        log.info("init nonTenantEnvService");
-        return new NonTenantEnvService();
-    }
+    /**
+     * 从CMDB同步租户集信息到本地DB
+     */
+    void syncTenantSetFromCMDB();
 }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/background/sync/tenantset/NonTenantSetSyncService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/background/sync/tenantset/NonTenantSetSyncService.java
@@ -22,29 +22,22 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.common.tenant;
+package com.tencent.bk.job.manage.background.sync.tenantset;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
+/**
+ * 单租户模式下的CMDB租户集同步逻辑
+ */
 @Slf4j
-@Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties(TenantProperties.class)
-public class TenantAutoConfiguration {
+public class NonTenantSetSyncService implements ITenantSetSyncService {
 
-    @Bean
-    @ConditionalOnTenantEnabled
-    public TenantEnvService tenantEnvService(TenantProperties tenantProperties) {
-        log.info("init tenantEnvService");
-        return new TenantEnvServiceImpl(tenantProperties);
-    }
-
-    @Bean
-    @ConditionalOnTenantDisabled
-    public TenantEnvService nonTenantEnvService() {
-        log.info("init nonTenantEnvService");
-        return new NonTenantEnvService();
+    /**
+     * 从CMDB同步租户集信息到本地DB
+     */
+    @Override
+    public void syncTenantSetFromCMDB() {
+        // 单租户模式下无需同步
+        log.debug("Do not syncTenantSetFromCMDB in nonTenant mode");
     }
 }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/background/sync/tenantset/TenantSetSyncService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/background/sync/tenantset/TenantSetSyncService.java
@@ -22,7 +22,7 @@
  * IN THE SOFTWARE.
  */
 
-package com.tencent.bk.job.manage.background.sync;
+package com.tencent.bk.job.manage.background.sync.tenantset;
 
 import com.tencent.bk.job.common.cc.config.CmdbConfig;
 import com.tencent.bk.job.common.cc.model.tenantset.TenantSetInfo;
@@ -35,12 +35,11 @@ import com.tencent.bk.job.common.model.dto.ApplicationAttrsDO;
 import com.tencent.bk.job.common.model.dto.ApplicationDTO;
 import com.tencent.bk.job.common.model.dto.ResourceScope;
 import com.tencent.bk.job.common.util.json.JsonUtils;
+import com.tencent.bk.job.manage.background.sync.BasicAppSyncService;
 import com.tencent.bk.job.manage.dao.ApplicationDAO;
 import com.tencent.bk.job.manage.dao.NoTenantHostDAO;
 import com.tencent.bk.job.manage.service.ApplicationService;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Set;
@@ -50,14 +49,12 @@ import java.util.stream.Collectors;
  * CMDB租户集同步逻辑
  */
 @Slf4j
-@Service
-public class TenantSetSyncService extends BasicAppSyncService {
+public class TenantSetSyncService extends BasicAppSyncService implements ITenantSetSyncService {
 
     private final ApplicationDAO applicationDAO;
     protected final ITenantSetCmdbClient tenantSetCmdbClient;
     private final CmdbConfig cmdbConfig;
 
-    @Autowired
     public TenantSetSyncService(ApplicationDAO applicationDAO,
                                 NoTenantHostDAO noTenantHostDAO,
                                 ApplicationService applicationService,
@@ -73,6 +70,7 @@ public class TenantSetSyncService extends BasicAppSyncService {
     /**
      * 从CMDB同步租户集信息到本地DB
      */
+    @Override
     public void syncTenantSetFromCMDB() {
         log.info("[{}] Begin to sync tenantSet from cmdb", Thread.currentThread().getName());
         List<TenantSetInfo> ccTenantSets = tenantSetCmdbClient.listAllTenantSet();

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/config/TenantConfiguration.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/config/TenantConfiguration.java
@@ -1,0 +1,71 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.config;
+
+import com.tencent.bk.job.common.cc.config.CmdbConfig;
+import com.tencent.bk.job.common.cc.sdk.IBizCmdbClient;
+import com.tencent.bk.job.common.cc.sdk.ITenantSetCmdbClient;
+import com.tencent.bk.job.common.tenant.ConditionalOnTenantDisabled;
+import com.tencent.bk.job.common.tenant.ConditionalOnTenantEnabled;
+import com.tencent.bk.job.manage.background.sync.tenantset.ITenantSetSyncService;
+import com.tencent.bk.job.manage.background.sync.tenantset.NonTenantSetSyncService;
+import com.tencent.bk.job.manage.background.sync.tenantset.TenantSetSyncService;
+import com.tencent.bk.job.manage.dao.ApplicationDAO;
+import com.tencent.bk.job.manage.dao.NoTenantHostDAO;
+import com.tencent.bk.job.manage.service.ApplicationService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Slf4j
+@Configuration
+public class TenantConfiguration {
+    @Bean
+    @ConditionalOnTenantEnabled
+    public ITenantSetSyncService tenantSetSyncService(ApplicationDAO applicationDAO,
+                                                      NoTenantHostDAO noTenantHostDAO,
+                                                      ApplicationService applicationService,
+                                                      IBizCmdbClient bizCmdbClient,
+                                                      ITenantSetCmdbClient tenantSetCmdbClient,
+                                                      CmdbConfig cmdbConfig) {
+        log.info("init tenantSetSyncService");
+        return new TenantSetSyncService(
+            applicationDAO,
+            noTenantHostDAO,
+            applicationService,
+            bizCmdbClient,
+            tenantSetCmdbClient,
+            cmdbConfig
+        );
+    }
+
+    @Bean
+    @ConditionalOnTenantDisabled
+    public ITenantSetSyncService nonTenantSetSyncService() {
+        log.info("init nonTenantSetSyncService");
+        return new NonTenantSetSyncService();
+    }
+}

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/impl/ApplicationDAOImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/dao/impl/ApplicationDAOImpl.java
@@ -256,7 +256,7 @@ public class ApplicationDAOImpl implements ApplicationDAO {
             applicationDTO.getAttrs() == null ? null : JsonUtils.toJson(applicationDTO.getAttrs()),
             UByte.valueOf(Bool.FALSE.byteValue()),
             applicationDTO.getTenantId(),
-            applicationDTO.getDeFault()
+            applicationDTO.getDeFaultOrDefaultValue()
         );
         try {
             val record = query.returning(T_APP.APP_ID).fetchOne();
@@ -286,7 +286,7 @@ public class ApplicationDAOImpl implements ApplicationDAO {
             .set(T_APP.TIMEZONE, applicationDTO.getTimeZone())
             .set(T_APP.LANGUAGE, applicationDTO.getLanguage())
             .set(T_APP.ATTRS, applicationDTO.getAttrs() == null ? null : JsonUtils.toJson(applicationDTO.getAttrs()))
-            .set(T_APP.DEFAULT, applicationDTO.getDeFault())
+            .set(T_APP.DEFAULT, applicationDTO.getDeFaultOrDefaultValue())
             .where(T_APP.APP_ID.eq(ULong.valueOf(applicationDTO.getId())));
         return query.execute();
     }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/model/db/CacheAppDO.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/model/db/CacheAppDO.java
@@ -83,7 +83,7 @@ public class CacheAppDO {
         cacheAppDO.setName(application.getName());
         cacheAppDO.setAttrs(application.getAttrs());
         cacheAppDO.setTenantId(application.getTenantId());
-        cacheAppDO.setDeFault(application.getDeFault());
+        cacheAppDO.setDeFault(application.getDeFaultOrDefaultValue());
         return cacheAppDO;
     }
 

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/globalsetting/impl/GlobalSettingsServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/globalsetting/impl/GlobalSettingsServiceImpl.java
@@ -36,7 +36,7 @@ import com.tencent.bk.job.common.i18n.locale.LocaleUtils;
 import com.tencent.bk.job.common.i18n.service.MessageI18nService;
 import com.tencent.bk.job.common.iam.constant.ActionId;
 import com.tencent.bk.job.common.notice.config.BkNoticeProperties;
-import com.tencent.bk.job.common.paas.config.LoginConfiguration;
+import com.tencent.bk.job.common.paas.config.LoginProperties;
 import com.tencent.bk.job.common.paas.model.SimpleUserInfo;
 import com.tencent.bk.job.common.paas.user.IUserApiClient;
 import com.tencent.bk.job.common.util.JobContextUtil;
@@ -122,7 +122,7 @@ public class GlobalSettingsServiceImpl implements GlobalSettingsService {
     private final NotifyTemplateConverter notifyTemplateConverter;
     private final BuildProperties buildProperties;
     private final IUserApiClient userApiClient;
-    private final LoginConfiguration loginConfiguration;
+    private final LoginProperties loginProperties;
 
     @Value("${job.manage.upload.filesize.max:5GB}")
     private String configedMaxFileSize;
@@ -140,7 +140,7 @@ public class GlobalSettingsServiceImpl implements GlobalSettingsService {
                                      NotifyTemplateConverter notifyTemplateConverter,
                                      BuildProperties buildProperties,
                                      IUserApiClient userApiClient,
-                                     LoginConfiguration loginConfiguration) {
+                                     LoginProperties loginProperties) {
         this.notifySendService = notifySendService;
         this.notifyUserService = notifyUserService;
         this.globalSettingDAO = globalSettingDAO;
@@ -153,7 +153,7 @@ public class GlobalSettingsServiceImpl implements GlobalSettingsService {
         this.notifyTemplateConverter = notifyTemplateConverter;
         this.buildProperties = buildProperties;
         this.userApiClient = userApiClient;
-        this.loginConfiguration = loginConfiguration;
+        this.loginProperties = loginProperties;
     }
 
     private static String removeSuffixBackSlash(String rawStr) {
@@ -667,7 +667,7 @@ public class GlobalSettingsServiceImpl implements GlobalSettingsService {
     }
 
     private String getBkLoginUrl() {
-        return loginConfiguration.getRealLoginUrl();
+        return loginProperties.getRealLoginUrl();
     }
 
     @Override

--- a/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
@@ -85,6 +85,11 @@ data:
         {{- else }}
         url: {{ .Values.bkLoginUrl }}
         {{- end }}
+    cmsi:
+      api-type: {{ .Values.cmsi.apiType }}
+      voice:
+        uri: {{ .Values.cmsi.voice.uri }}
+      useStandaloneVoiceAPI: {{ .Values.cmsi.useStandaloneVoiceAPI }}
     bkNotice:
       enabled: {{ .Values.bkNotice.enabled }}
     job:

--- a/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
@@ -83,6 +83,7 @@ data:
           api-url: {{ .Values.login.custom.apiUrl }}
           token-name: {{ .Values.login.custom.tokenName }}
         {{- else }}
+        api-type: {{ .Values.login.apiType }}
         url: {{ .Values.bkLoginUrl }}
         {{- end }}
     cmsi:

--- a/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/configmap-common.yaml
@@ -89,7 +89,6 @@ data:
       api-type: {{ .Values.cmsi.apiType }}
       voice:
         uri: {{ .Values.cmsi.voice.uri }}
-      useStandaloneVoiceAPI: {{ .Values.cmsi.useStandaloneVoiceAPI }}
     bkNotice:
       enabled: {{ .Values.bkNotice.enabled }}
     job:

--- a/support-files/kubernetes/charts/bk-job/templates/job-gateway/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-gateway/configmap.yaml
@@ -409,6 +409,7 @@ data:
         login-exemption:
           enabled: {{ .Values.gatewayConfig.loginExemption.enabled | default false }}
           default-user: {{ .Values.gatewayConfig.loginExemption.defaultUser | default "admin" }}
+          default-user-tenant-id: {{ .Values.gatewayConfig.loginExemption.defaultUserTenantId | default "default" }}
         user-map:
           {{- toYaml .Values.gatewayConfig.userMap | nindent 10 }}
         csrf-check:

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -900,6 +900,8 @@ gatewayConfig:
     enabled: false
     # 开启登录豁免时使用的默认用户名
     defaultUser: admin
+    # 开启登录豁免时使用的默认用户所在的租户ID
+    defaultUserTenantId: default
   # 用户映射功能
   userMap:
     # 是否开启用户映射，仅限开发测试环境使用，生产环境请勿开启

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -694,6 +694,17 @@ login:
     # 完成页面登录后前端通过Cookie提交的凭据的Key，也是后台向apiUrl获取用户信息提交的凭据的Key
     tokenName: "bk_token"
 
+ # CMSI接口配置
+cmsi:
+  # 对接的API类型，取值：apigw、esb
+  apiType: apigw
+  # 语音通知配置
+  voice:
+    # 接口uri
+    uri: /api/c/compapi/v2/cmsi/send_voice_msg/
+  # 是否使用独立发送语音的接口
+  useStandaloneVoiceAPI: true
+
 # 消息通知中心配置
 bkNotice:
   # 是否对接消息通知中心

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -683,6 +683,8 @@ swagger:
 
 ## 登录配置
 login:
+  # 对接的API类型，取值：apigw、esb
+  apiType: apigw
   ## 自定义登录配置
   custom:
     # 是否对接自定义登录地址，默认不开启（使用蓝鲸集成的统一登录）

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -702,8 +702,6 @@ cmsi:
   voice:
     # 接口uri
     uri: /api/c/compapi/v2/cmsi/send_voice_msg/
-  # 是否使用独立发送语音的接口
-  useStandaloneVoiceAPI: true
 
 # 消息通知中心配置
 bkNotice:


### PR DESCRIPTION
1. CMDB接口调用兼容单租户环境；
2. 制品库接口调用兼容单租户环境；
3. 修复CMDB业务集事件处理失败；
4. CMSI接口支持同时对接APIGW与ESB；
5. 去除已验证通过的CMSI接口切换逻辑；
6. 统一登录支持APIGW与ESB切换；
7. 支持Mock用户管理所有接口；
8. 网关获取用户信息兼容单租户环境。