### PR TITLE
perf: 优化执行历史查询 #3778

### DIFF
--- a/src/backend/job-analysis/service-job-analysis/src/main/java/com/tencent/bk/job/analysis/task/analysis/task/impl/AbstractTimerTaskWatcher.java
+++ b/src/backend/job-analysis/service-job-analysis/src/main/java/com/tencent/bk/job/analysis/task/analysis/task/impl/AbstractTimerTaskWatcher.java
@@ -31,7 +31,6 @@ import com.tencent.bk.job.analysis.model.dto.AnalysisTaskInstanceDTO;
 import com.tencent.bk.job.analysis.service.ApplicationService;
 import com.tencent.bk.job.analysis.task.analysis.AnalysisTaskStatusEnum;
 import com.tencent.bk.job.analysis.task.analysis.BaseAnalysisTask;
-import com.tencent.bk.job.common.model.PageData;
 import com.tencent.bk.job.common.util.Counter;
 import com.tencent.bk.job.common.util.date.DateUtils;
 import com.tencent.bk.job.common.util.json.JsonUtils;
@@ -39,7 +38,6 @@ import com.tencent.bk.job.crontab.api.inner.ServiceCronJobResource;
 import com.tencent.bk.job.crontab.model.inner.ServiceCronJobDTO;
 import com.tencent.bk.job.execute.api.inner.ServiceTaskExecuteResultResource;
 import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
-import com.tencent.bk.job.execute.model.inner.ServiceTaskInstanceDTO;
 import com.tencent.bk.job.manage.model.inner.resp.ServiceApplicationDTO;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -74,11 +72,11 @@ public abstract class AbstractTimerTaskWatcher extends BaseAnalysisTask {
         List<ServiceCronJobDTO> cronJobVOList
     );
 
-    PageData<ServiceTaskInstanceDTO> getFailResults(
+    int getFailCount(
         ServiceTaskExecuteResultResource taskExecuteResultResource,
         ServiceCronJobDTO cronJobDTO
     ) {
-        PageData<ServiceTaskInstanceDTO> failResults = taskExecuteResultResource.getTaskExecuteResult(
+        Integer failCount = taskExecuteResultResource.getTaskExecuteCount(
             cronJobDTO.getAppId(),
             null,
             null,
@@ -88,16 +86,10 @@ public abstract class AbstractTimerTaskWatcher extends BaseAnalysisTask {
             null,
             null,
             null,
-            0,
-            Integer.MAX_VALUE,
             cronJobDTO.getId()
         ).getData();
-        log.info("" + failResults.getTotal()
-            + " fail results found of cronJobId:"
-            + cronJobDTO.getId()
-            + "," + cronJobDTO.getName()
-        );
-        return failResults;
+        log.info("{} fail results found of cronJobId:{}", failCount, cronJobDTO.getId());
+        return failCount;
     }
 
     @Override

--- a/src/backend/job-analysis/service-job-analysis/src/main/java/com/tencent/bk/job/analysis/task/analysis/task/impl/TimerTaskFailRateWatcher.java
+++ b/src/backend/job-analysis/service-job-analysis/src/main/java/com/tencent/bk/job/analysis/task/analysis/task/impl/TimerTaskFailRateWatcher.java
@@ -36,13 +36,12 @@ import com.tencent.bk.job.analysis.task.analysis.enums.AnalysisResourceEnum;
 import com.tencent.bk.job.analysis.task.analysis.task.pojo.AnalysisTaskResultData;
 import com.tencent.bk.job.analysis.task.analysis.task.pojo.AnalysisTaskResultItem;
 import com.tencent.bk.job.analysis.task.analysis.task.pojo.AnalysisTaskResultVO;
-import com.tencent.bk.job.common.model.PageData;
+import com.tencent.bk.job.common.util.I18nUtil;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import com.tencent.bk.job.crontab.api.inner.ServiceCronJobResource;
 import com.tencent.bk.job.crontab.model.inner.ServiceCronJobDTO;
 import com.tencent.bk.job.execute.api.inner.ServiceTaskExecuteResultResource;
 import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
-import com.tencent.bk.job.execute.model.inner.ServiceTaskInstanceDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -85,43 +84,36 @@ public class TimerTaskFailRateWatcher extends AbstractTimerTaskWatcher {
         //2.遍历定时任务
         cronJobVOList.forEach(it -> {
             //3.拿到每一个定时任务在指定时间段内的执行结果并找出失败的
-            log.info("begin to find fail result of task:" + it.getId() + "," + it.getName());
-            PageData<ServiceTaskInstanceDTO> failResult = getFailResults(taskExecuteResultResource, it);
-            log.info("begin to find success result of task:" + it.getId() + "," + it.getName());
-            PageData<ServiceTaskInstanceDTO> successResult =
-                taskExecuteResultResource.getTaskExecuteResult(
-                    appId,
-                    null,
-                    null,
-                    RunStatusEnum.SUCCESS.getValue(),
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    0,
-                    Integer.MAX_VALUE,
-                    it.getId()
-                ).getData();
-            log.info("" + successResult.getTotal()
-                + " success results found of cronJobId:"
-                + it.getId()
-                + "," + it.getName()
-            );
-            long executedNum = failResult.getTotal() + successResult.getTotal();
-            if (executedNum > 0 && (float) successResult.getTotal() / executedNum < 0.6) {
+            int failCnt = getFailCount(taskExecuteResultResource, it);
+            Integer successCnt = taskExecuteResultResource.getTaskExecuteCount(
+                appId,
+                null,
+                null,
+                RunStatusEnum.SUCCESS.getValue(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                it.getId()
+            ).getData();
+            log.info("{} success tasks found of cronJob(id={}, name={})", successCnt, it.getId(), it.getName());
+            // 计算错误率
+            long executedNum = failCnt + successCnt;
+            if (executedNum > 0 && (float) successCnt / executedNum < 0.6) {
                 highFailRateCronJobBaseInfoList.add(
                     new HighFailRateCronJobBaseInfo(
                         AnalysisResourceEnum.TIMER_TASK,
                         new AnalysisTaskResultItemLocation(
-                            "${job.analysis.analysistask.result.ItemLocation.description.TimerTaskName}",
+                            I18nUtil.getI18nMessage(
+                                "job.analysis.analysistask.result.ItemLocation.description.TimerTaskName"),
                             it.getName()),
                         it.getName()
                     )
                 );
             }
         });
-        log.info("highFailRateCronJobBaseInfoList:" + JsonUtils.toJson(highFailRateCronJobBaseInfoList));
+        log.info("highFailRateCronJobBaseInfoList: {}", JsonUtils.toJson(highFailRateCronJobBaseInfoList));
         //结果入库
         analysisTaskInstanceDTO.setResultData(
             JsonUtils.toJson(

--- a/src/backend/job-analysis/service-job-analysis/src/main/java/com/tencent/bk/job/analysis/task/analysis/task/impl/TimerTaskFailRateWatcher.java
+++ b/src/backend/job-analysis/service-job-analysis/src/main/java/com/tencent/bk/job/analysis/task/analysis/task/impl/TimerTaskFailRateWatcher.java
@@ -105,8 +105,7 @@ public class TimerTaskFailRateWatcher extends AbstractTimerTaskWatcher {
                     new HighFailRateCronJobBaseInfo(
                         AnalysisResourceEnum.TIMER_TASK,
                         new AnalysisTaskResultItemLocation(
-                            I18nUtil.getI18nMessage(
-                                "job.analysis.analysistask.result.ItemLocation.description.TimerTaskName"),
+                            "${job.analysis.analysistask.result.ItemLocation.description.TimerTaskName}",
                             it.getName()),
                         it.getName()
                     )

--- a/src/backend/job-analysis/service-job-analysis/src/main/java/com/tencent/bk/job/analysis/task/analysis/task/impl/TimerTaskFailWatcher.java
+++ b/src/backend/job-analysis/service-job-analysis/src/main/java/com/tencent/bk/job/analysis/task/analysis/task/impl/TimerTaskFailWatcher.java
@@ -36,12 +36,11 @@ import com.tencent.bk.job.analysis.task.analysis.enums.AnalysisResourceEnum;
 import com.tencent.bk.job.analysis.task.analysis.task.pojo.AnalysisTaskResultData;
 import com.tencent.bk.job.analysis.task.analysis.task.pojo.AnalysisTaskResultItem;
 import com.tencent.bk.job.analysis.task.analysis.task.pojo.AnalysisTaskResultVO;
-import com.tencent.bk.job.common.model.PageData;
+import com.tencent.bk.job.common.util.I18nUtil;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import com.tencent.bk.job.crontab.api.inner.ServiceCronJobResource;
 import com.tencent.bk.job.crontab.model.inner.ServiceCronJobDTO;
 import com.tencent.bk.job.execute.api.inner.ServiceTaskExecuteResultResource;
-import com.tencent.bk.job.execute.model.inner.ServiceTaskInstanceDTO;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -85,24 +84,28 @@ public class TimerTaskFailWatcher extends AbstractTimerTaskWatcher {
         //2.遍历定时任务
         cronJobVOList.forEach(it -> {
             //3.拿到每一个定时任务在指定时间段内的执行结果并找出失败的
-            log.info("begin to find fail result of task:" + it.getId() + "," + it.getName());
-            PageData<ServiceTaskInstanceDTO> failResults = getFailResults(taskExecuteResultResource, it);
-            if (failResults.getTotal() > 0) {
+            log.info("begin to find fail result of task: {}, {}", it.getId(), it.getName());
+            int failCnt = getFailCount(taskExecuteResultResource, it);
+            if (failCnt > 0) {
                 failCronJobBaseInfoList.add(
                     new FailCronJobBaseInfo(
                         AnalysisResourceEnum.TIMER_TASK,
                         new AnalysisTaskResultItemLocation(
-                            "${job.analysis.analysistask.result.ItemLocation"
-                                + ".description.TimerTaskName}",
-                            it.getName()),
+                            I18nUtil.getI18nMessage(
+                                "job.analysis.analysistask.result.ItemLocation.description.TimerTaskName"),
+                            it.getName()
+                        ),
                         it.getName()
                     )
                 );
             }
         });
         //结果入库
-        log.info(String.format("%d failResults are recorded:%s", failCronJobBaseInfoList.size(),
-            JsonUtils.toJson(failCronJobBaseInfoList)));
+        log.info(
+            "{} fail tasks are recorded: {}",
+            failCronJobBaseInfoList.size(),
+            JsonUtils.toJson(failCronJobBaseInfoList)
+        );
         analysisTaskInstanceDTO.setResultData(
             JsonUtils.toJson(
                 new AnalysisTaskResultData<>(

--- a/src/backend/job-analysis/service-job-analysis/src/main/java/com/tencent/bk/job/analysis/task/analysis/task/impl/TimerTaskFailWatcher.java
+++ b/src/backend/job-analysis/service-job-analysis/src/main/java/com/tencent/bk/job/analysis/task/analysis/task/impl/TimerTaskFailWatcher.java
@@ -91,8 +91,7 @@ public class TimerTaskFailWatcher extends AbstractTimerTaskWatcher {
                     new FailCronJobBaseInfo(
                         AnalysisResourceEnum.TIMER_TASK,
                         new AnalysisTaskResultItemLocation(
-                            I18nUtil.getI18nMessage(
-                                "job.analysis.analysistask.result.ItemLocation.description.TimerTaskName"),
+                            "${job.analysis.analysistask.result.ItemLocation.description.TimerTaskName}",
                             it.getName()
                         ),
                         it.getName()

--- a/src/backend/job-execute/api-job-execute/src/main/java/com/tencent/bk/job/execute/api/inner/ServiceTaskExecuteResultResource.java
+++ b/src/backend/job-execute/api-job-execute/src/main/java/com/tencent/bk/job/execute/api/inner/ServiceTaskExecuteResultResource.java
@@ -26,9 +26,7 @@ package com.tencent.bk.job.execute.api.inner;
 
 import com.tencent.bk.job.common.annotation.InternalAPI;
 import com.tencent.bk.job.common.model.InternalResponse;
-import com.tencent.bk.job.common.model.PageData;
 import com.tencent.bk.job.execute.model.inner.ServiceCronTaskExecuteResultStatistics;
-import com.tencent.bk.job.execute.model.inner.ServiceTaskInstanceDTO;
 import com.tencent.bk.job.execute.model.inner.request.ServiceGetCronTaskExecuteStatisticsRequest;
 import com.tentent.bk.job.common.api.feign.annotation.SmartFeignClient;
 import io.swagger.annotations.Api;
@@ -60,27 +58,36 @@ public interface ServiceTaskExecuteResultResource {
 
     @ApiOperation(value = "获取作业执行历史列表", produces = "application/json")
     @GetMapping("/service/execution/app/{appId}/task-execution-history/list")
-    InternalResponse<PageData<ServiceTaskInstanceDTO>> getTaskExecuteResult(
-        @ApiParam(value = "业务ID", required = true, example = "1") @PathVariable("appId") Long appId,
-        @ApiParam(value = "任务名称", name = "taskName", required = false) @RequestParam(value = "taskName",
-            required = false) String taskName,
-        @ApiParam(value = "任务ID", name = "taskInstanceId", required = false) @RequestParam(value = "taskInstanceId",
-            required = false) Long taskInstanceId,
-        @ApiParam(value = "任务状态", name = "status", required = false) @RequestParam(value = "status",
-            required = false) Integer status,
-        @ApiParam(value = "执行人", name = "operator", required = false) @RequestParam(value = "operator",
-            required = false) String operator,
-        @ApiParam(value = "执行方式", name = "startupMode", required = false) @RequestParam(value = "startupMode",
-            required = false) Integer startupMode,
-        @ApiParam(value = "任务类型", name = "taskType", required = false) @RequestParam(value = "taskType",
-            required = false) Integer taskType,
-        @ApiParam(value = "开始时间", name = "startTime", required = false) @RequestParam(value = "startTime",
-            required = false) String startTime,
-        @ApiParam(value = "结束时间", name = "endTime", required = false) @RequestParam(value = "endTime",
-            required = false) String endTime,
-        @ApiParam(value = "分页-开始", required = false) @RequestParam(value = "start", required = false) Integer start,
-        @ApiParam(value = "分页-每页大小", required = false) @RequestParam(value = "pageSize",
-            required = false) Integer pageSize,
-        @ApiParam(value = "定时任务ID", required = false) @RequestParam(value = "cronTaskId",
-            required = false) Long cronTaskId);
+    InternalResponse<Integer> getTaskExecuteCount(
+        @ApiParam(value = "业务ID", required = true, example = "1")
+        @PathVariable("appId")
+        Long appId,
+        @ApiParam(value = "任务名称", name = "taskName", required = false)
+        @RequestParam(value = "taskName", required = false)
+        String taskName,
+        @ApiParam(value = "任务ID", name = "taskInstanceId", required = false)
+        @RequestParam(value = "taskInstanceId", required = false)
+        Long taskInstanceId,
+        @ApiParam(value = "任务状态", name = "status", required = false)
+        @RequestParam(value = "status", required = false)
+        Integer status,
+        @ApiParam(value = "执行人", name = "operator", required = false)
+        @RequestParam(value = "operator", required = false)
+        String operator,
+        @ApiParam(value = "执行方式", name = "startupMode", required = false)
+        @RequestParam(value = "startupMode", required = false)
+        Integer startupMode,
+        @ApiParam(value = "任务类型", name = "taskType", required = false)
+        @RequestParam(value = "taskType", required = false)
+        Integer taskType,
+        @ApiParam(value = "开始时间", name = "startTime", required = false)
+        @RequestParam(value = "startTime", required = false)
+        String startTime,
+        @ApiParam(value = "结束时间", name = "endTime", required = false)
+        @RequestParam(value = "endTime", required = false)
+        String endTime,
+        @ApiParam(value = "定时任务ID", required = false)
+        @RequestParam(value = "cronTaskId", required = false)
+        Long cronTaskId
+    );
 }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/TaskInstanceDAO.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/TaskInstanceDAO.java
@@ -72,6 +72,11 @@ public interface TaskInstanceDAO {
                                                          SimplePaginationCondition condition);
 
     /**
+     * 根据条件查总数
+     */
+    int getTaskInstanceCountWithCondition(TaskInstanceQuery taskQuery);
+
+    /**
      * 获取定时作业执行情况
      *
      * @param appId               业务ID

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/TaskInstanceDAOImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/TaskInstanceDAOImpl.java
@@ -32,6 +32,7 @@ import com.tencent.bk.job.common.mysql.dynamic.ds.DbOperationEnum;
 import com.tencent.bk.job.common.mysql.dynamic.ds.MySQLOperation;
 import com.tencent.bk.job.common.mysql.jooq.JooqDataTypeUtil;
 import com.tencent.bk.job.common.util.BatchUtil;
+import com.tencent.bk.job.common.util.CollectionUtil;
 import com.tencent.bk.job.execute.common.constants.RunStatusEnum;
 import com.tencent.bk.job.execute.dao.TaskInstanceDAO;
 import com.tencent.bk.job.execute.dao.common.DSLContextProviderFactory;
@@ -227,12 +228,12 @@ public class TaskInstanceDAOImpl extends BaseDAO implements TaskInstanceDAO {
     public List<TaskInstanceDTO> listJobInstance(TaskInstanceQuery taskQuery,
                                                  SimplePaginationCondition simplePaginationCondition) {
         List<Condition> conditions = buildSearchCondition(taskQuery);
-        Result<?> result = stepwiseSelectTaskInstance(conditions,
+        List<TaskInstanceDTO> result = stepwiseSelectTaskInstance(conditions,
             simplePaginationCondition.getOffset(),
             simplePaginationCondition.getLength()
         );
 
-        return result.stream().map(this::extractInfo).collect(Collectors.toList());
+        return result;
     }
 
     @Override
@@ -245,24 +246,33 @@ public class TaskInstanceDAOImpl extends BaseDAO implements TaskInstanceDAO {
             conditions.add(TASK_INSTANCE_HOST.IPV6.eq(taskQuery.getIpv6()));
         }
 
-        Result<? extends Record> result = stepwiseSelectTaskInstanceByIpCondition(
+        List<TaskInstanceDTO> result = stepwiseSelectTaskInstanceByIpCondition(
             conditions,
             simplePaginationCondition.getOffset(),
             simplePaginationCondition.getLength()
         );
-        return result.stream().map(this::extractInfo).collect(Collectors.toList());
+        return result;
     }
+
+    @SuppressWarnings("all")
+    @Override
+    public int getTaskInstanceCountWithCondition(TaskInstanceQuery taskQuery) {
+        List<Condition> conditions = buildSearchCondition(taskQuery);
+        return dsl().selectCount().from(TASK_INSTANCE).where(conditions).fetchOne(0,
+            Integer.class);
+    }
+
 
     private PageData<TaskInstanceDTO> listPageTaskInstanceByBasicInfo(TaskInstanceQuery taskQuery,
                                                                       BaseSearchCondition baseSearchCondition) {
         int start = baseSearchCondition.getStartOrDefault(0);
         int length = baseSearchCondition.getLengthOrDefault(10);
         List<Condition> conditions = buildSearchCondition(taskQuery);
-        Result<? extends Record> result = stepwiseSelectTaskInstance(conditions, start, length);
+        List<TaskInstanceDTO> result = stepwiseSelectTaskInstance(conditions, start, length);
 
         int count = 0;
         if (baseSearchCondition.isCountPageTotal()) {
-            count = getPageTaskInstanceCount(taskQuery);
+            count = getTaskInstanceCountWithCondition(taskQuery);
         }
 
         return buildTaskInstancePageData(start, length, count, result);
@@ -276,7 +286,7 @@ public class TaskInstanceDAOImpl extends BaseDAO implements TaskInstanceDAO {
      * @param length 查询长度
      * @return 查询结果
      */
-    private Result<? extends Record> stepwiseSelectTaskInstance(List<Condition> conditions,
+    private List<TaskInstanceDTO> stepwiseSelectTaskInstance(List<Condition> conditions,
                                                                 int start,
                                                                 int length) {
         Collection<SortField<?>> orderFields = new ArrayList<>();
@@ -298,7 +308,7 @@ public class TaskInstanceDAOImpl extends BaseDAO implements TaskInstanceDAO {
             .orderBy(orderFields)
             .fetch();
 
-        return result;
+        return result.stream().map(this::extractInfo).collect(Collectors.toList());
     }
 
     private PageData<TaskInstanceDTO> listPageTaskInstanceByIp(TaskInstanceQuery taskQuery,
@@ -311,7 +321,7 @@ public class TaskInstanceDAOImpl extends BaseDAO implements TaskInstanceDAO {
         }
         int start = baseSearchCondition.getStartOrDefault(0);
         int length = baseSearchCondition.getLengthOrDefault(10);
-        Result<? extends Record> result = stepwiseSelectTaskInstanceByIpCondition(conditions, start, length);
+        List<TaskInstanceDTO> result = stepwiseSelectTaskInstanceByIpCondition(conditions, start, length);
 
         Integer count = 0;
         if (baseSearchCondition.isCountPageTotal()) {
@@ -327,9 +337,9 @@ public class TaskInstanceDAOImpl extends BaseDAO implements TaskInstanceDAO {
         return buildTaskInstancePageData(start, length, count, result);
     }
 
-    private Result<? extends Record> stepwiseSelectTaskInstanceByIpCondition(List<Condition> conditions,
-                                                                             int start,
-                                                                             int length) {
+    private List<TaskInstanceDTO> stepwiseSelectTaskInstanceByIpCondition(List<Condition> conditions,
+                                                                          int start,
+                                                                          int length) {
         Collection<SortField<?>> orderFields = new ArrayList<>();
         orderFields.add(TASK_INSTANCE.CREATE_TIME.desc());
         // 条件中包含IP需要连表查询，只查出ID，根据ID走主键索引，避免回表
@@ -342,38 +352,50 @@ public class TaskInstanceDAOImpl extends BaseDAO implements TaskInstanceDAO {
             .limit(start, length)
             .fetch();
         // 根据ID查询完整任务实例信息
-        Set<Long> taskInstanceIds = result.stream()
+        List<Long> taskInstanceIds = result.stream()
             .map(record -> record.get(TASK_INSTANCE.ID))
-            .collect(Collectors.toSet());
-        Result<? extends Record> allFieldResult = dsl().select(ALL_FIELDS)
-            .from(TASK_INSTANCE)
-            .where(TASK_INSTANCE.ID.in(taskInstanceIds))
-            .orderBy(orderFields)
-            .fetch();
-        return allFieldResult;
+            .collect(Collectors.toList());
+
+        return selectByIdsInBatch(taskInstanceIds);
+    }
+
+    /**
+     * 防止id in 一个大列表导致全表扫描，当id列表过大时，分批查询
+     */
+    private List<TaskInstanceDTO> selectByIdsInBatch(List<Long> ids) {
+        // 先让id有序再去查DB性能更好，能减少数据页的换入换出
+        // 防止大列表直接排序，经过测试50w数据量排序性价比最高
+        List<List<Long>> sortBatches = CollectionUtil.partitionList(ids, 500000);
+        sortBatches.forEach(batch -> batch.sort(Long::compareTo));
+
+        List<List<Long>> batchIds = new ArrayList<>();
+        sortBatches.forEach(sortedList -> {
+            // 大表中，in 2000-5000大小的列表 对于存储引擎友好
+            List<List<Long>> subBatch = CollectionUtil.partitionList(sortedList, 2000);
+            batchIds.addAll(subBatch);
+        });
+
+        List<TaskInstanceDTO> result = new ArrayList<>();
+        for (int i = 0; i < batchIds.size(); i++) {
+            Result<? extends Record> allFieldResult = dsl().select(ALL_FIELDS)
+                .from(TASK_INSTANCE)
+                .where(TASK_INSTANCE.ID.in(batchIds.get(i)))
+                .fetch();
+            result.addAll(allFieldResult.stream().map(this::extractInfo).collect(Collectors.toList()));
+        }
+        return result;
     }
 
     private PageData<TaskInstanceDTO> buildTaskInstancePageData(int start,
                                                                 int length,
                                                                 int count,
-                                                                Result<? extends Record> result) {
-        List<TaskInstanceDTO> taskInstances = new ArrayList<>();
-        if (result != null && !result.isEmpty()) {
-            result.forEach(record -> taskInstances.add(extractInfo(record)));
-        }
+                                                                List<TaskInstanceDTO> result) {
         PageData<TaskInstanceDTO> pageData = new PageData<>();
-        pageData.setData(taskInstances);
+        pageData.setData(result);
         pageData.setStart(start);
         pageData.setPageSize(length);
         pageData.setTotal(Long.valueOf(String.valueOf(count)));
         return pageData;
-    }
-
-    @SuppressWarnings("all")
-    private int getPageTaskInstanceCount(TaskInstanceQuery taskQuery) {
-        List<Condition> conditions = buildSearchCondition(taskQuery);
-        return dsl().selectCount().from(TASK_INSTANCE).where(conditions).fetchOne(0,
-            Integer.class);
     }
 
     private List<Condition> buildSearchCondition(TaskInstanceQuery taskQuery) {

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/TaskInstanceDAOImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/dao/impl/TaskInstanceDAOImpl.java
@@ -60,6 +60,7 @@ import org.springframework.stereotype.Repository;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -356,7 +357,10 @@ public class TaskInstanceDAOImpl extends BaseDAO implements TaskInstanceDAO {
             .map(record -> record.get(TASK_INSTANCE.ID))
             .collect(Collectors.toList());
 
-        return selectByIdsInBatch(taskInstanceIds);
+        List<TaskInstanceDTO> taskInstanceDTOList = selectByIdsInBatch(taskInstanceIds);
+        // 分批查出来的结果，不同批次间无序，需要排序
+        taskInstanceDTOList.sort(Comparator.comparing(TaskInstanceDTO::getCreateTime).reversed());
+        return taskInstanceDTOList;
     }
 
     /**

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/TaskResultService.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/TaskResultService.java
@@ -63,6 +63,11 @@ public interface TaskResultService {
                                           SimplePaginationCondition condition);
 
     /**
+     * 根据条件查找符合的总数
+     */
+    int countTaskInstance(TaskInstanceQuery taskQuery);
+
+    /**
      * 获取作业执行结果
      *
      * @param username       用户名

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/TaskResultServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/TaskResultServiceImpl.java
@@ -162,6 +162,11 @@ public class TaskResultServiceImpl implements TaskResultService {
         return CollectionUtils.isEmpty(taskInstanceList) ? Collections.emptyList() : taskInstanceList;
     }
 
+    @Override
+    public int countTaskInstance(TaskInstanceQuery taskQuery) {
+        return taskInstanceDAO.getTaskInstanceCountWithCondition(taskQuery);
+    }
+
     private void computeTotalTime(List<TaskInstanceDTO> pageData) {
         if (CollectionUtils.isNotEmpty(pageData)) {
             pageData.forEach(taskInstanceDTO -> {


### PR DESCRIPTION
1. job-analysis分析时只查总数
2. 根据条件查作业历史时，先查出所有id，然后通过id分批查询所有字段