### PR TITLE
fix: 上传正确的bash脚本，却提示首行没有定义合法的脚本类型 #3784

### DIFF
--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/manager/script/check/checker/ScriptLogicChecker.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/manager/script/check/checker/ScriptLogicChecker.java
@@ -62,7 +62,7 @@ public class ScriptLogicChecker extends DefaultChecker {
         ArrayList<ScriptCheckResultItemDTO> checkResults = Lists.newArrayList();
         String[] lines = param.getLines();
         try {
-            if (!shellDefine.matcher(lines[0]).matches()) {
+            if (!shellDefine.matcher(lines[0].replaceAll("\\s+$", "")).matches()) {
                 checkResults.add(createResult(1, LOGIC_NEED_SHEBANG, null, lines[0], lines[0]));
             }
 

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/manager/script/check/checker/ScriptLogicChecker.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/manager/script/check/checker/ScriptLogicChecker.java
@@ -43,7 +43,9 @@ import static com.tencent.bk.job.manage.manager.script.check.consts.ScriptCheckI
  */
 @Slf4j
 public class ScriptLogicChecker extends DefaultChecker {
-    private final Pattern shellDefine = Pattern.compile("^#!/bin/(ksh|bash|tsh|sh)$");
+    // 匹配脚本shebang行，要求#!开头，紧跟/bin/或/usr/bin/env下的 ksh、bash、tsh、sh，允许换行符制表符等空白字符结尾
+    private final Pattern shellDefine = Pattern.compile("^#!(/usr/bin/env (ksh|bash|tsh|sh)" +
+        "|/bin/(ksh|bash|tsh|sh))\\s*$");
     private final Pattern cdDirCheck = Pattern.compile("^((\\s*?[^#c].*)(;|[|]{1,2}|[&]{1,2}))?(\\s*)cd(\\s+((" +
         "(?<b>[\"'])[^;&|\"']*\\k<b>)+|[^;&|\"']+))+(([;&|]*$)|(([|&]|[;]+)[^|&]+))");
 
@@ -62,7 +64,7 @@ public class ScriptLogicChecker extends DefaultChecker {
         ArrayList<ScriptCheckResultItemDTO> checkResults = Lists.newArrayList();
         String[] lines = param.getLines();
         try {
-            if (!shellDefine.matcher(lines[0].replaceAll("\\s+$", "")).matches()) {
+            if (!shellDefine.matcher(lines[0]).matches()) {
                 checkResults.add(createResult(1, LOGIC_NEED_SHEBANG, null, lines[0], lines[0]));
             }
 


### PR DESCRIPTION
导入的脚本中，行末可能存在一些隐藏字符，比如\r,\r\n等，先去除空白字符再判断