### PR TITLE
fix: 作业执行详情页面搜索日志报错 #3813

### DIFF
--- a/src/backend/job-logsvr/service-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/service/impl/LogServiceImpl.java
+++ b/src/backend/job-logsvr/service-job-logsvr/src/main/java/com/tencent/bk/job/logsvr/service/impl/LogServiceImpl.java
@@ -67,8 +67,10 @@ import java.util.stream.Collectors;
 @Slf4j
 public class LogServiceImpl implements LogService {
     private static final int BATCH_SIZE = 100;
-    private static final char[] SPECIAL_CHAR = {'*', '(', ')', '+', '?', '\\', '$', '^', '>', '.'};
-    private static final String[] ESCAPE_CHAR = {"\\*", "\\(", "\\)", "\\+", "\\?", "\\\\", "\\$", "\\^", "\\>", "\\."};
+    private static final char[] SPECIAL_CHAR = {'*', '(', ')', '+', '?', '\\', '$', '^', '>', '.', '[', ']', '|', '{'
+        , '}'};
+    private static final String[] ESCAPE_CHAR = {"\\*", "\\(", "\\)", "\\+", "\\?", "\\\\", "\\$", "\\^", "\\>", "\\" +
+        ".", "\\[", "\\]", "\\|", "\\{", "\\}"};
     private final MongoTemplate mongoTemplate;
     private final LogCollectionFactory logCollectionFactory;
 


### PR DESCRIPTION
移除字面量正则表达式的常量(Pattern.LITERAL)，增加特殊字符的转义处理