### PR TITLE
feat: 执行方案列表接口支持返回是否需要更新字段 #3852

### DIFF
--- a/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/esb/v3/response/EsbPlanBasicInfoV3DTO.java
+++ b/src/backend/job-manage/api-job-manage/src/main/java/com/tencent/bk/job/manage/model/esb/v3/response/EsbPlanBasicInfoV3DTO.java
@@ -24,6 +24,7 @@
 
 package com.tencent.bk.job.manage.model.esb.v3.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.tencent.bk.job.common.esb.model.EsbAppScopeDTO;
@@ -86,9 +87,11 @@ public class EsbPlanBasicInfoV3DTO extends EsbAppScopeDTO {
 
     /**
      * 是否需要从作业模版同步
+     * 该字段仅在/get_job_plan_list接口返回，因此为null时不会序列化
      */
     @JsonProperty("need_update")
     @JsonPropertyDescription("Need update")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Boolean needUpdate;
 
 }


### PR DESCRIPTION
/get_job_plan_detail和/get_job_plan_list 返回结构存在耦合，导致/get_job_plan_detail会返回need_update字段为null。巡检场景只需要在方案列表中反应是否需要同步，故/get_job_plan_detail不返回need_update字段。