### PR TITLE
fix: 含有未执行的本地文件分发步骤的任务去重试报错 #3931

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/web/impl/WebTaskInstanceResourceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/api/web/impl/WebTaskInstanceResourceImpl.java
@@ -226,7 +226,10 @@ public class WebTaskInstanceResourceImpl implements WebTaskInstanceResource {
                 });
                 fileSourceVO.setFileLocation(files);
             }
-            fileSourceVO.setHost(fileSource.getServers().convertToTaskTargetVO());
+            ExecuteTargetDTO servers = fileSource.getServers();
+            if (servers != null) {
+                fileSourceVO.setHost(servers.convertToTaskTargetVO());
+            }
             fileSources.add(fileSourceVO);
         }
         fileStepVO.setFileSourceList(fileSources);


### PR DESCRIPTION
1.安全处理未执行步骤中的空值。