### PR TITLE
perf: 升级审计SDK版本 #3955

### DIFF
--- a/src/backend/build.gradle
+++ b/src/backend/build.gradle
@@ -156,7 +156,7 @@ ext {
         set('bkjobVersion', "1.0.0")
         println "bkjobVersion:" + bkjobVersion
     }
-    set('bkAuditJavaSdkVersion', "1.0.8")
+    set('bkAuditJavaSdkVersion', "1.0.9")
     set('mockitoVersion', "4.0.0")
     set('embeddedRedisVersion', "0.6")
     set('openai4jVersion', "0.18.0")

--- a/tests/openapi/build.gradle
+++ b/tests/openapi/build.gradle
@@ -50,8 +50,8 @@ dependencies {
     testImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     testImplementation "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
     testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-joda:$jacksonVersion"
-    testImplementation "io.jsonwebtoken:jjwt-impl: $jwtVersion"
-    testImplementation "io.jsonwebtoken:jjwt-jackson: $jwtVersion"
+    testImplementation "io.jsonwebtoken:jjwt-impl:$jwtVersion"
+    testImplementation "io.jsonwebtoken:jjwt-jackson:$jwtVersion"
     testImplementation "com.google.guava:guava:$guavaVersion"
     testImplementation "com.squareup.okhttp3:okhttp:$okHttpVersion"
     testImplementation 'ch.qos.logback:logback-core:1.2.13'


### PR DESCRIPTION
1.升级审计SDK，消除启动时Json序列化报错。