### PR TITLE
fix: 标签管理-关联脚本量-跳转的"脚本管理"页面URL写死,手动点击"全部脚本"仍显示筛选后的数据 #4073

### DIFF
--- a/src/frontend/src/views/script-manage/list/index.vue
+++ b/src/frontend/src/views/script-manage/list/index.vue
@@ -400,7 +400,7 @@
         {
           name: I18n.t('script.场景标签_colHead'),
           id: 'tags',
-          remoteMethod: this.tagSericeHandler.fetchTagOfSearch,
+          remoteMethod: () => this.tagSericeHandler.fetchTagOfSearch(),
           remoteExecuteImmediate: true,
         },
         {


### PR DESCRIPTION
# Reviewed, transaction id: 73397