### PR TITLE
perf: 网关报错日志优化 #4057

### DIFF
--- a/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/web/exception/GatewayErrorWebExceptionHandler.java
+++ b/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/web/exception/GatewayErrorWebExceptionHandler.java
@@ -1,0 +1,83 @@
+package com.tencent.bk.job.gateway.web.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.WebProperties;
+import org.springframework.boot.autoconfigure.web.reactive.error.DefaultErrorWebExceptionHandler;
+import org.springframework.boot.web.reactive.error.ErrorAttributes;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.codec.ServerCodecConfigurer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * gateway全局异常处理器,
+ * 针对非业务逻辑导致的边界异常（如PrematureCloseException），进行日志降级处理。
+ * 边界异常：通常是客户端、网络、K8s环境问题，导致连接在响应生成之前就被关闭的异常。
+ */
+@Component
+@Order(-1)
+@Slf4j
+public class GatewayErrorWebExceptionHandler extends DefaultErrorWebExceptionHandler {
+
+    /**
+     * 边界异常消息列表，匹配到这些消息的异常会降级日志
+     */
+    private static final Set<String> BOUNDARY_EXCEPTION_MESSAGES = Collections.unmodifiableSet(
+        new HashSet<>(Arrays.asList(
+            "Connection prematurely closed BEFORE response",
+            "Connection has been closed BEFORE response"
+        ))
+    );
+
+    public GatewayErrorWebExceptionHandler(ErrorAttributes errorAttributes,
+                                           WebProperties webProperties,
+                                           ServerProperties serverProperties,
+                                           ApplicationContext applicationContext,
+                                           ServerCodecConfigurer serverCodecConfigurer
+    ) {
+        super(errorAttributes,
+            webProperties.getResources(),
+            serverProperties.getError(),
+            applicationContext
+        );
+        super.setMessageWriters(serverCodecConfigurer.getWriters());
+        super.setMessageReaders(serverCodecConfigurer.getReaders());
+    }
+
+    @Override
+    protected void logError(ServerRequest request,
+                            ServerResponse response,
+                            Throwable throwable
+    ) {
+        // 边界异常日志降级warn
+        if (isBoundaryException(throwable)) {
+            log.warn(
+                "Boundary exception detected. path={}, method={}, exceptionType={}, throwableMessage={}",
+                request.path(),
+                request.methodName(),
+                throwable.getClass().getSimpleName(),
+                throwable.getMessage()
+            );
+            return;
+        }
+        super.logError(request, response, throwable);
+    }
+
+    /**
+     * 判断是否属于可接受的边界异常
+     */
+    private boolean isBoundaryException(Throwable throwable) {
+        if (throwable == null || throwable.getMessage() == null) {
+            return false;
+        }
+        return BOUNDARY_EXCEPTION_MESSAGES.stream().anyMatch(throwable.getMessage()::contains);
+    }
+}


### PR DESCRIPTION
* 实现

在Gateway新增全局异常处理器，对包含特定特征的连接边界异常进行识别，并将其日志级别从`ERROR`降级为`WARN`，不改变原有异常处理和响应流程。

* 异常分析

在运行过程中，Gateway偶发出现如下异常：

```bash
PrematureCloseException: Connection prematurely closed BEFORE response
```

对应的reactor netty源码逻辑

```java
protected void onInboundClose() {
	if (isInboundCancelled() || isInboundDisposed()) {
		listener().onStateChange(this, ConnectionObserver.State.DISCONNECTING);
		return;
	}
	listener().onStateChange(this, HttpClientState.RESPONSE_INCOMPLETE);
	if (responseState == null) {
		Throwable exception;
		if (markSentHeaderAndBody()) {
			exception = AbortedException.beforeSend();
		}
		else if (markSentBody()) {
			exception = new PrematureCloseException("Connection has been closed BEFORE response, while sending request body");
		}
		else {
			exception = new PrematureCloseException("Connection prematurely closed BEFORE response");
		}
		listener().onUncaughtException(this, addOutboundErrorCause(exception, unprocessedOutboundError));
		return;
	}
	super.onInboundError(addOutboundErrorCause(new PrematureCloseException("Connection prematurely closed DURING response"),
			unprocessedOutboundError));
}
```

从异常定义和触发条件可以看出，该异常表示请求尚未收到任何响应，连接就已经被关闭，结合网上资料和实际场景分析，这类异常通常可能由以下因素导致：客户端主动中断请求、网络抖动或链路不稳定、Ingress提前关闭连接、上游服务运行环境异常。

一般不是Gateway 或后端服务存在业务或实现缺陷，属于连接生命周期中的典型边界异常，可以将其日志级别降级为warn减少干扰。

* 本地复现分析

该异常本身具有较强的概率性，在正常环境下难以稳定复现,多种常见尝试均无法触发该异常:

1. 后端接口模拟长耗时并持续返回数据，客户端取消请求
   → 未复现

2. 在nginx层配置极短超时
   → 未复现

3. 后端服务模拟STW或直接kill进程
   → 报错为connection reset，非该异常

最终从异常定义本身入手，通过连接超时与连接池复用的组合场景成功复现：

1. 后端tomcat设置较短的连接超时

2. gateway配置连接池的空闲连接回收时间大于tomcat超时

在并发场景下，tomcat已关闭连接，而gateway连接池尚未来得及回收连接被复用后，出现请求无响应，从而触发 PrematureCloseException

示例配置：

```bash
# 后端服务的tomcat
server.tomcat.connection-timeout=100ms

# gateway连接池配置（空闲回收时间大于 Tomcat 超时）
spring.cloud.gateway.httpclient.pool.max-idle-time=150ms
```
