### PR TITLE
feat: 消息通知发送数量支持按业务配额 #3328

### DIFF
--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/cmsi/CmsiEsbClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/cmsi/CmsiEsbClient.java
@@ -212,7 +212,8 @@ public class CmsiEsbClient extends BkApiV1Client implements ICmsiClient {
             title = "Default Title";
         }
         req.setMsgType(msgType);
-        req.setSender(sender);
+        // 使用蓝鲸公共账号发送，不需要传具体的发件人
+        req.setSender(null);
         req.setReceiverUsername(String.join(",", receivers));
         req.setTitle(title);
         req.setContent(content);

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/model/cmsi/req/SendMailV1Req.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/model/cmsi/req/SendMailV1Req.java
@@ -64,7 +64,8 @@ public class SendMailV1Req extends CmsiSendMsgV1BasicReq {
     public static SendMailV1Req fromNotifyMessageDTO(NotifyMessageDTO notifyMessageDTO) {
         SendMailV1Req sendMailV1Req = new SendMailV1Req();
         sendMailV1Req.setReceiverUsername(notifyMessageDTO.getReceiverUsername());
-        sendMailV1Req.setSender(notifyMessageDTO.getSender());
+        // 使用蓝鲸公共账号发送，不需要传具体的发件人
+        sendMailV1Req.setSender(null);
         sendMailV1Req.setTitle(notifyMessageDTO.getTitle());
         sendMailV1Req.setContent(notifyMessageDTO.getContent());
         return sendMailV1Req;


### PR DESCRIPTION
1. 调用cmsi接口发送通知时，去掉发件人，使用蓝鲸公共账号发送