### PR TITLE
fix: File-Worker指标数据不准确 #4144

### DIFF
--- a/src/backend/job-file-gateway/api-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/consts/FileWorkerOnlineStatusEnum.java
+++ b/src/backend/job-file-gateway/api-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/consts/FileWorkerOnlineStatusEnum.java
@@ -25,8 +25,8 @@
 package com.tencent.bk.job.file_gateway.consts;
 
 public enum FileWorkerOnlineStatusEnum {
-    ONLINE((byte) 0, "online"),
-    OFFLINE((byte) 1, "offline");
+    ONLINE((byte) 1, "online"),
+    OFFLINE((byte) 0, "offline");
 
     private final Byte status;
     private final String description;


### PR DESCRIPTION
fix #4144

将 `FileWorkerOnlineStatusEnum` 中 `ONLINE` 与 `OFFLINE` 的枚举值与数据库实际存储对齐（`1=在线`，`0=离线`），修复 `fileWorker_online_num` 指标统计不准确的问题。