### PR TITLE
perf: Windows路径兼容斜杠 #4155

### DIFF
--- a/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/FilePathValidateUtil.java
+++ b/src/backend/commons/common-utils/src/main/java/com/tencent/bk/job/common/util/FilePathValidateUtil.java
@@ -10,15 +10,15 @@ import java.util.regex.Pattern;
  */
 @Slf4j
 public class FilePathValidateUtil {
-    // 传统DOS正则表达式
-    private static final String CONVENTIONAL_DOS_PATH_REGEX = "(^[A-Za-z]:\\\\([^\\\\])(([^\\\\/:?\"<>|]" +
-        "|REGEX:(.*))*\\\\?)*)|(^[A-Za-z]:[\\\\])";
+    // 传统DOS正则表达式（兼容斜杠与反斜杠作为目录分隔符，以及混合使用的情况）
+    private static final String CONVENTIONAL_DOS_PATH_REGEX = "(^[A-Za-z]:[/\\\\]([^/\\\\])(([^/\\\\:?\"<>|]" +
+        "|REGEX:(.*))*[/\\\\]?)*)|(^[A-Za-z]:[/\\\\])";
 
     // Linux路径正则表达式
     private static final String LINUX_PATH_REGEX = "^/(((../)*|(./)*)|(\\.?[^.].*/{0,1}))+";
 
     // 内置变量或全局变量正则表达式
-    private static final String VARIABLE_REGEX = "(([A-Za-z]:\\\\)|(/)).*\\[[a-zA-Z0-9:/_-]*\\].*" +
+    private static final String VARIABLE_REGEX = "(([A-Za-z]:[/\\\\])|(/)).*\\[[a-zA-Z0-9:/_-]*\\].*" +
         "|.*\\$\\{[a-zA-Z_][a-zA-Z0-9_-]*\\}.*";
 
     // 传统DOS Pattern

--- a/src/backend/commons/common-utils/src/test/java/com/tencent/bk/job/common/util/FilePathValidateUtilTest.java
+++ b/src/backend/commons/common-utils/src/test/java/com/tencent/bk/job/common/util/FilePathValidateUtilTest.java
@@ -28,8 +28,15 @@ public class FilePathValidateUtilTest {
         assertThat(FilePathValidateUtil.validateFileSystemAbsolutePath("C:\\user\\abc|a")).isFalse();
         assertThat(FilePathValidateUtil.validateFileSystemAbsolutePath("C:\\user\\abc?a")).isFalse();
         assertThat(FilePathValidateUtil.validateFileSystemAbsolutePath("C:\\user\\abc<a")).isFalse();
-        assertThat(FilePathValidateUtil.validateFileSystemAbsolutePath("C:\\logs/logs")).isFalse();
+        assertThat(FilePathValidateUtil.validateFileSystemAbsolutePath("C:\\logs/logs")).isTrue();
         assertThat(FilePathValidateUtil.validateFileSystemAbsolutePath("C:\\logs\\log*.log")).isTrue();
+        // 兼容斜杠作为目录分隔符的Windows路径
+        assertThat(FilePathValidateUtil.validateFileSystemAbsolutePath("C:/cygwinroot/tmp")).isTrue();
+        assertThat(FilePathValidateUtil.validateFileSystemAbsolutePath("E:/")).isTrue();
+        assertThat(FilePathValidateUtil.validateFileSystemAbsolutePath("D:\\xxx1/xxx2.MD5")).isTrue();
+        assertThat(FilePathValidateUtil.validateFileSystemAbsolutePath("D:/Download/")).isTrue();
+        assertThat(FilePathValidateUtil.validateFileSystemAbsolutePath("C:/logs/access.log")).isTrue();
+        assertThat(FilePathValidateUtil.validateFileSystemAbsolutePath("C:/")).isTrue();
         assertThat(FilePathValidateUtil.validateFileSystemAbsolutePath("C:\\tmp\\REGEX:myfile-[A-Za-z]{0,10}.tar.gz")).isTrue();
         assertThat(FilePathValidateUtil.validateFileSystemAbsolutePath("C:\\tmp\\REGE:a|b")).isFalse();
         assertThat(FilePathValidateUtil.validateFileSystemAbsolutePath("C:\\tmp\\REGEX:a|b")).isTrue();


### PR DESCRIPTION
## 背景

部分存量调用方在 Windows 路径中使用了斜杠（`/`），旧版 Agent 能支持，但新增路径格式校验后这部分调用方开始失败。

## 改动

修改 `FilePathValidateUtil`，在 Windows 路径正则中兼容斜杠与反斜杠（包括混合使用），使以下路径能够通过校验：
- `C:/cygwinroot/tmp`
- `D:/P4_chiji/WinClient_CGame/`
- `E:/`
- `D:\xxx1/xxx2.MD5`
- `D:/Download/`

## 文件

- `FilePathValidateUtil.java`：扩展正则，兼容 `/` 作为目录分隔符
- `FilePathValidateUtilTest.java`：添加完善的斜杠路径测试用例

Fix #4155