### PR TITLE
fix: 部分主机权限过期后重试任务接口报错 #4159

### DIFF
--- a/src/backend/commons/common-iam/src/main/java/com/tencent/bk/job/common/iam/model/AuthResult.java
+++ b/src/backend/commons/common-iam/src/main/java/com/tencent/bk/job/common/iam/model/AuthResult.java
@@ -169,7 +169,8 @@ public class AuthResult {
     public AuthResult mergeAuthResult(AuthResult otherAuthResult) {
         AuthResult authResult = new AuthResult();
         boolean isPass = this.pass && otherAuthResult.isPass();
-        authResult.setUser(user);
+        // Use the non-null user from either result to ensure user info is always available
+        authResult.setUser(this.user != null ? this.user : otherAuthResult.getUser());
         authResult.setPass(isPass);
         if (!isPass) {
             List<PermissionActionResource> requiredActionResourceList = new ArrayList<>();

--- a/src/backend/commons/common-iam/src/main/java/com/tencent/bk/job/common/iam/service/impl/AppAuthServiceImpl.java
+++ b/src/backend/commons/common-iam/src/main/java/com/tencent/bk/job/common/iam/service/impl/AppAuthServiceImpl.java
@@ -182,11 +182,11 @@ public class AppAuthServiceImpl extends BasicAuthService implements AppAuthServi
         List<String> notAllowResourceIds =
             resources.stream().filter(resource -> !allowResourceIds.contains(resource.getResourceId()))
                 .map(PermissionResource::getResourceId).collect(Collectors.toList());
-        AuthResult authResult = new AuthResult();
+        AuthResult authResult;
         if (!notAllowResourceIds.isEmpty()) {
             authResult = buildFailAuthResult(user, actionId, resourceType, notAllowResourceIds);
         } else {
-            authResult.setPass(true);
+            authResult = AuthResult.pass(user);
         }
         return authResult;
     }

--- a/src/backend/commons/common-iam/src/main/java/com/tencent/bk/job/common/iam/service/impl/WebAuthServiceImpl.java
+++ b/src/backend/commons/common-iam/src/main/java/com/tencent/bk/job/common/iam/service/impl/WebAuthServiceImpl.java
@@ -65,8 +65,13 @@ public class WebAuthServiceImpl implements WebAuthService {
         if (!authResult.isPass()) {
             String applyUrl = authResult.getApplyUrl();
             if (isReturnApplyUrl && StringUtils.isBlank(applyUrl)) {
-                applyUrl = authService.getApplyUrl(authResult.getUser().getTenantId(),
-                    authResult.getRequiredActionResources());
+                User user = authResult.getUser();
+                if (user != null) {
+                    applyUrl = authService.getApplyUrl(user.getTenantId(),
+                        authResult.getRequiredActionResources());
+                } else {
+                    log.warn("AuthResult user is null, cannot get apply url for permission denied response");
+                }
             }
             vo.setApplyUrl(applyUrl);
 


### PR DESCRIPTION
## 问题描述

用户拥有账号权限但缺少主机权限时，`/task-execution/redo-task` 接口返回 HTTP 500（NullPointerException）。

## 根本原因

异常发生在 `WebAuthServiceImpl.toAuthResultVO()` 中调用 `authResult.getUser().getTenantId()`，`getUser()` 返回 null，触发 NPE。

追溯链路：
1. `AppAuthServiceImpl.batchAuthResources()` 在全部资源鉴权通过时，使用 `new AuthResult()` + `setPass(true)`，**未设置 user 字段**
2. `AuthResult.mergeAuthResult()` 直接取 `this.user`，若 `this` 来自上述方法则 user 为 null，合并结果 user 同样为 null
3. `WebAuthServiceImpl.toAuthResultVO()` 无 null 保护，直接调用 `.getUser().getTenantId()` 触发 NPE

## 修复方案

1. **`AppAuthServiceImpl`**：pass 分支改用 `AuthResult.pass(user)`，确保 user 始终被设置
2. **`AuthResult`**：`mergeAuthResult()` 改为取两者中非 null 的 user（`this.user != null ? this.user : otherAuthResult.getUser()`）
3. **`WebAuthServiceImpl`**：对 user 增加 null 检查，为 null 时打 warn 日志，避免 NPE

Closes #4159