### PR TITLE
perf: 各服务支持优雅停机 #4162

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ openspec/
 pre-*-bkcodeai
 
 tests/openapi/bin/
+
+# Claude Code
+.claude/

--- a/src/backend/commons/common-redis/src/main/java/com/tencent/bk/job/common/redis/util/RedisSlideWindowFlowController.java
+++ b/src/backend/commons/common-redis/src/main/java/com/tencent/bk/job/common/redis/util/RedisSlideWindowFlowController.java
@@ -29,6 +29,7 @@ import com.tencent.bk.job.common.util.FlowController;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.helpers.MessageFormatter;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.RedisScript;
 
@@ -46,7 +47,7 @@ import java.util.TimerTask;
  * 基于Redis的分布式实时滑动窗口限流器
  */
 @Slf4j
-public class RedisSlideWindowFlowController implements FlowController {
+public class RedisSlideWindowFlowController implements FlowController, DisposableBean {
 
     private static final String checkScript = "return redis.call('llen',KEYS[1])";
 
@@ -326,5 +327,25 @@ public class RedisSlideWindowFlowController implements FlowController {
             log.warn("Redis lua script return an unexpected value:{}, do not limit rate for {}", result, resourceId);
             return true;
         }
+    }
+
+    /**
+     * 服务停机时停止内部定时任务，避免 Redis 连接关闭后持续报错
+     */
+    @Override
+    public void destroy() {
+        log.info("RedisSlideWindowFlowController destroying, cancelling timer task");
+        isReady = false;
+        try {
+            clearTask.cancel();
+        } catch (Exception e) {
+            log.warn("Failed to cancel clearTask", e);
+        }
+        try {
+            timer.cancel();
+        } catch (Exception e) {
+            log.warn("Failed to cancel timer", e);
+        }
+        log.info("RedisSlideWindowFlowController destroyed.");
     }
 }

--- a/src/backend/job-analysis/boot-job-analysis/src/main/resources/application.yml
+++ b/src/backend/job-analysis/boot-job-analysis/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
   profiles:
     active: prod
   mvc:

--- a/src/backend/job-backup/boot-job-backup/src/main/resources/application.yml
+++ b/src/backend/job-backup/boot-job-backup/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
   profiles:
     active: prod
   mvc:

--- a/src/backend/job-config/src/main/resources/application.yml
+++ b/src/backend/job-config/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: job-config
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
   profiles:
     active: prod,native
   mvc:

--- a/src/backend/job-crontab/boot-job-crontab/src/main/resources/application.yml
+++ b/src/backend/job-crontab/boot-job-crontab/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
   profiles:
     active: prod
   mvc:

--- a/src/backend/job-execute/boot-job-execute/src/main/resources/application.yml
+++ b/src/backend/job-execute/boot-job-execute/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
   profiles:
     active: prod
   mvc:

--- a/src/backend/job-file-gateway/boot-job-file-gateway/src/main/resources/application.yml
+++ b/src/backend/job-file-gateway/boot-job-file-gateway/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
   profiles:
     active: prod
   mvc:

--- a/src/backend/job-logsvr/boot-job-logsvr/src/main/resources/application.yml
+++ b/src/backend/job-logsvr/boot-job-logsvr/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
   profiles:
     active: prod
   mvc:

--- a/src/backend/job-manage/boot-job-manage/src/main/resources/application.yml
+++ b/src/backend/job-manage/boot-job-manage/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   main:
     allow-bean-definition-overriding: true
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
   profiles:
     active: prod
   mvc:


### PR DESCRIPTION
## 问题背景

服务停机时，`RedisSlideWindowFlowController` 内部的 `java.util.Timer` 定时任务仍在运行，当 Redis 连接已关闭后持续尝试连接，导致大量 `RedisConnectionFailureException` 错误日志涌出。

## 修改内容

1. **`RedisSlideWindowFlowController` 实现 `DisposableBean`**
   - 新增 `destroy()` 方法，在 Spring 容器关闭时主动取消 Timer 任务和 Timer 本身
   - 同时将 `isReady` 置为 `false`，避免停机期间继续触发限流操作

2. **各服务 `application.yml` 添加 lifecycle 超时配置**
   ```yaml
   spring:
     lifecycle:
       timeout-per-shutdown-phase: 30s
   ```
   覆盖所有 8 个服务：`job-analysis`、`job-backup`、`job-config`、`job-crontab`、`job-execute`、`job-file-gateway`、`job-logsvr`、`job-manage`，为实现了 `SmartLifecycle` 的组件提供足够的有序停机等待时间。

3. **`.gitignore` 新增 `.claude/` 条目**