### PR TITLE
fix: SpringBoot升级后日志中时间戳方括号丢失 #4168

### DIFF
--- a/src/backend/commons/common-log/src/main/resources/logback-default.xml
+++ b/src/backend/commons/common-log/src/main/resources/logback-default.xml
@@ -8,8 +8,8 @@ Default job logback configuration provided for import
     <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
     <conversionRule conversionWord="wEx" converterClass="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
 
-    <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-[yyyy-MM-dd HH:mm:ss.SSS]}}){faint} %clr(%5p [${APP_NAME:-anon-service},%X{traceId:-},%X{spanId:-}]) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
-    <property name="FILE_LOG_PATTERN" value="${FILE_LOG_PATTERN:-%d{${LOG_DATEFORMAT_PATTERN:-[yyyy-MM-dd HH:mm:ss.SSS]}} %5p [${APP_NAME:-anon-service},%X{traceId:-},%X{spanId:-}] ${PID:- } --- [%t] %-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
+    <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr([%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}]){faint} %clr(%5p [${APP_NAME:-anon-service},%X{traceId:-},%X{spanId:-}]) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
+    <property name="FILE_LOG_PATTERN" value="${FILE_LOG_PATTERN:-[%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}] %5p [${APP_NAME:-anon-service},%X{traceId:-},%X{spanId:-}] ${PID:- } --- [%t] %-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
     <property name="AUDIT_EVENT_LOG_PATTERN" value="%m%n"/>
     <property name="APP_LOG_FILE" value="${APP_LOG_DIR}/${APP_LOG_NAME}"/>
     <property name="ERROR_LOG_FILE" value="${APP_LOG_DIR}/error.log"/>

--- a/src/backend/job-config/src/main/resources/logback-spring.xml
+++ b/src/backend/job-config/src/main/resources/logback-spring.xml
@@ -10,7 +10,7 @@
     <property name="APP_LOG_DIR" value="${BK_LOG_DIR}/job-config}" scope="context"/>
     <property name="APP_LOG_NAME" value="config.log"/>
     <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(%5p [${APP_NAME:-anon-service},%X{traceId:-},%X{spanId:-}]) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.15t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
-    <property name="FILE_LOG_PATTERN" value="${FILE_LOG_PATTERN:-%d{${LOG_DATEFORMAT_PATTERN:-[yyyy-MM-dd HH:mm:ss.SSS]}} %5p [${APP_NAME:-anon-service},%X{traceId:-},%X{spanId:-}] ${PID:- } --- [%t] %-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
+    <property name="FILE_LOG_PATTERN" value="${FILE_LOG_PATTERN:-[%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}] %5p [${APP_NAME:-anon-service},%X{traceId:-},%X{spanId:-}] ${PID:- } --- [%t] %-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
     <property name="APP_LOG_FILE" value="${APP_LOG_DIR}/${APP_LOG_NAME}"/>
     <property name="ERROR_LOG_FILE" value="${APP_LOG_DIR}/error.log"/>
 


### PR DESCRIPTION
## 问题

SpringBoot 升级后，logback 1.3+ 将 `%d{...}` 内的 `[` 和 `]` 误解析为时区 ID，导致日志时间戳前后的方括号丢失。

## 修复

将方括号从 `%d{}` 内移至外部，作为字面字符写在 pattern 里：

```
// 修复前（logback 1.3+ 会将 ] 误解析为时区 ID）
%d{[yyyy-MM-dd HH:mm:ss.SSS]}

// 修复后
[%d{yyyy-MM-dd HH:mm:ss.SSS}]
```

## 涉及文件

- `commons/common-log/src/main/resources/logback-default.xml`
- `job-config/src/main/resources/logback-spring.xml`

Fixes #4168