### PR TITLE
perf: 消息通知相关错误日志优化 #4172

### DIFF
--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/WatchableSendMsgService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/WatchableSendMsgService.java
@@ -196,13 +196,13 @@ public class WatchableSendMsgService {
             case NO_LIMIT:
                 break;
             case RESOURCE_SCOPE_LIMIT:
-                log.warn("Send notify exceed resource scope quota limit, resourceScope: {}",resourceScope);
+                log.info("Send notify exceed resource scope quota limit, resourceScope: {}",resourceScope);
                 throw new ResourceExhaustedException(ErrorCode.SEND_NOTIFY_EXCEED_RESOURCE_SCOPE_QUOTA_LIMIT);
             case USER_LIMIT:
-                log.warn("Send notify exceed user quota limit, triggerUser: {}", triggerUser);
+                log.info("Send notify exceed user quota limit, triggerUser: {}", triggerUser);
                 throw new ResourceExhaustedException(ErrorCode.SEND_NOTIFY_EXCEED_USER_QUOTA_LIMIT);
             case SYSTEM_LIMIT:
-                log.warn("Send notify exceed system quota limit, resourceScope: {}, triggerUser: {}",
+                log.info("Send notify exceed system quota limit, resourceScope: {}, triggerUser: {}",
                     resourceScope, triggerUser);
                 throw new ResourceExhaustedException(ErrorCode.SEND_NOTIFY_EXCEED_SYSTEM_QUOTA_LIMIT);
         }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/notify/SendNotifyTask.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/notify/SendNotifyTask.java
@@ -78,12 +78,13 @@ public class SendNotifyTask implements Runnable {
         }
         log.info("SendNotifyTask start, real receivers: {}", validReceivers);
         try {
-            boolean result = sendMsgWithRetry();
-            if (result) {
+            SendResult result = sendMsgWithRetry();
+            if (result == SendResult.SUCCESS) {
                 logSendSuccess();
-            } else {
+            } else if (result == SendResult.FAIL) {
                 handleSendFail(null);
             }
+            // SendResult.QUOTA_EXCEEDED: already logged as INFO in WatchableSendMsgService, skip error log
         } catch (Exception e) {
             handleSendFail(e);
         }
@@ -98,10 +99,10 @@ public class SendNotifyTask implements Runnable {
         log.info("valid receivers is null or empty, skip, msgType={},title={}", msgType, title);
     }
 
-    private boolean sendMsgWithRetry() {
+    private SendResult sendMsgWithRetry() {
         int count = 0;
-        boolean result = false;
-        while (!result && count < NOTIFY_MAX_RETRY_COUNT) {
+        boolean success = false;
+        while (!success && count < NOTIFY_MAX_RETRY_COUNT) {
             count += 1;
             try {
                 watchableSendMsgService.sendMsgWithApp(
@@ -113,10 +114,10 @@ public class SendNotifyTask implements Runnable {
                     title,
                     content
                 );
-                result = true;
+                success = true;
             } catch (ResourceExhaustedException e) {
-                log.warn("Notification sending has reached the quota limit and will not be retried.", e);
-                break;
+                // 超配额属于预期内情况，WatchableSendMsgService 已打印 INFO 日志，此处忽略异常不再重试
+                return SendResult.QUOTA_EXCEEDED;
             } catch (Exception e) {
                 if (count < NOTIFY_MAX_RETRY_COUNT) {
                     long sleepMills = count * 1000;
@@ -132,7 +133,13 @@ public class SendNotifyTask implements Runnable {
                 }
             }
         }
-        return result;
+        return success ? SendResult.SUCCESS : SendResult.FAIL;
+    }
+
+    private enum SendResult {
+        SUCCESS,
+        FAIL,
+        QUOTA_EXCEEDED
     }
 
     private void logSendSuccess() {


### PR DESCRIPTION
## 问题背景

消息通知场景下，超配额属于预期内情况，但当前代码：
1. `WatchableSendMsgService` 对超配额情况打印 `WARN` 日志，级别偏高
2. `SendNotifyTask` 在超配额时仍会触发 `handleSendFail`，导致额外打印 `ERROR` 日志

造成日志噪音，影响问题排查。

## 修改内容

1. **`WatchableSendMsgService`**：将超配额场景的 3 处 `WARN` 日志改为 `INFO`
2. **`SendNotifyTask`**：重构发送结果枚举（`SUCCESS` / `FAIL` / `QUOTA_EXCEEDED`），超配额时不再调用 `handleSendFail`，避免打印多余的 `ERROR` 日志

## 涉及文件

- `WatchableSendMsgService.java`
- `SendNotifyTask.java`