### PR TITLE
perf: APM数据上报失败的报错日志优化 #4175

### DIFF
--- a/src/backend/commons/common-log/src/main/resources/logback-default.xml
+++ b/src/backend/commons/common-log/src/main/resources/logback-default.xml
@@ -41,7 +41,7 @@ Default job logback configuration provided for import
         <encoder class="com.tencent.bk.job.common.log.pojo.encoder.SpecificLoggerAdjustLevelEncoder">
             <pattern>${FILE_LOG_PATTERN}</pattern>
             <charset>UTF-8</charset>
-            <targetLogger>io.opentelemetry.exporter.internal.grpc.OkHttpGrpcExporter</targetLogger>
+            <targetLogger>io.opentelemetry.exporter.internal.http.HttpExporter</targetLogger>
             <originLoggingLevel>ERROR</originLoggingLevel>
             <targetLoggingLevel>WARN</targetLoggingLevel>
         </encoder>
@@ -181,7 +181,7 @@ Default job logback configuration provided for import
         </filter>
         <!-- 因为这个过滤器需要走HashSet匹配，考虑性能，所以放在后面 -->
         <filter class="com.tencent.bk.job.common.log.pojo.filter.LoggerExclusionFilter">
-            <exclusiveLogger>io.opentelemetry.exporter.internal.grpc.OkHttpGrpcExporter</exclusiveLogger>
+            <exclusiveLogger>io.opentelemetry.exporter.internal.http.HttpExporter</exclusiveLogger>
             <onMatch>DENY</onMatch>
             <onMismatch>ACCEPT</onMismatch>
         </filter>


### PR DESCRIPTION
## 问题背景

SpringBoot 升级后，APM 由 gRPC 导出器切换为 HTTP 导出器（`HttpExporter`）。原有 logback 配置针对的 `OkHttpGrpcExporter` 在 `opentelemetry-exporter-common 1.43.0` 中已不存在，导致 `HttpExporter` 上报失败时仍以 `ERROR` 级别输出大量日志并写入 `error.log`，造成日志噪音。

## 修改内容

将 `logback-default.xml` 中的 logger 路径从旧的 `OkHttpGrpcExporter` 替换为 `HttpExporter`：

1. **`app-appender` 的 `SpecificLoggerAdjustLevelEncoder`**：将 `HttpExporter` 的 `ERROR` 日志降级为 `WARN`
2. **`error-appender` 的 `LoggerExclusionFilter`**：过滤 `HttpExporter` 的 `ERROR` 日志，不写入 `error.log`

## 涉及文件

- `src/backend/commons/common-log/src/main/resources/logback-default.xml`