### PR TITLE
perf: 升级SpringBoot及相关组件版本 #4142

### DIFF
--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/WatchableThreadPoolExecutor.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/WatchableThreadPoolExecutor.java
@@ -119,11 +119,11 @@ public class WatchableThreadPoolExecutor extends ThreadPoolExecutor {
             getTags(),
             this,
             threadPoolExecutor -> (double) threadPoolExecutor.getMaximumPoolSize());
-        meterRegistry.gauge("job_thread_pool_task_total",
+        meterRegistry.gauge("job_thread_pool_task_count",
             getTags(),
             this,
             threadPoolExecutor -> (double) threadPoolExecutor.getTaskCount());
-        meterRegistry.gauge("job_thread_pool_completed_task_total",
+        meterRegistry.gauge("job_thread_pool_completed_task_count",
             getTags(),
             this,
             threadPoolExecutor -> (double) threadPoolExecutor.getCompletedTaskCount());

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/ResultHandleTaskSampler.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/result/ResultHandleTaskSampler.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.execute.engine.result;
 
 import com.tencent.bk.job.execute.monitor.ExecuteMetricNames;
+import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -156,31 +157,29 @@ public class ResultHandleTaskSampler {
         }
 
         private void measureFinishedFileTasksByApp() {
-            finishedFileTaskCounterMap.forEach((appId, counter) -> {
-                meterRegistry.gauge(
+            finishedFileTaskCounterMap.forEach((appId, counter) ->
+                FunctionCounter.builder(
                     ExecuteMetricNames.GSE_FINISHED_TASKS_TOTAL,
-                    Arrays.asList(
-                        Tag.of("appId", appId.toString()),
-                        Tag.of("type", "file")
-                    ),
                     counter,
-                    getFunctionByCounter(counter)
-                );
-            });
+                    AtomicLong::doubleValue
+                ).tags(Arrays.asList(
+                    Tag.of("appId", appId.toString()),
+                    Tag.of("type", "file")
+                )).register(meterRegistry)
+            );
         }
 
         private void measureFinishedScriptTasksByApp() {
-            finishedScriptTaskCounterMap.forEach((appId, counter) -> {
-                meterRegistry.gauge(
+            finishedScriptTaskCounterMap.forEach((appId, counter) ->
+                FunctionCounter.builder(
                     ExecuteMetricNames.GSE_FINISHED_TASKS_TOTAL,
-                    Arrays.asList(
-                        Tag.of("appId", appId.toString()),
-                        Tag.of("type", "script")
-                    ),
                     counter,
-                    getFunctionByCounter(counter)
-                );
-            });
+                    AtomicLong::doubleValue
+                ).tags(Arrays.asList(
+                    Tag.of("appId", appId.toString()),
+                    Tag.of("type", "script")
+                )).register(meterRegistry)
+            );
         }
 
         @Override


### PR DESCRIPTION
1.根据MicroMeter 1.13.0新规范使用计数器与指标名称，避免指标名称_total后缀被意外去除。