### PR TITLE
perf: 作业模板不存在时的报错信息优化 #4186

### DIFF
--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/template/impl/TaskTemplateServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/template/impl/TaskTemplateServiceImpl.java
@@ -819,6 +819,9 @@ public class TaskTemplateServiceImpl implements TaskTemplateService {
     @Override
     public TaskTemplateInfoDTO getTaskTemplateBasicInfoById(Long appId, Long templateId) {
         TaskTemplateInfoDTO template = taskTemplateDAO.getTaskTemplateById(appId, templateId);
+        if (template == null) {
+            return null;
+        }
         setTags(appId, Collections.singletonList(template));
         return template;
     }


### PR DESCRIPTION
## 问题背景

接口 `/web/scope/biz/{bizId}/task/plan/{templateId}` 在作业模板不存在时，`TaskTemplateServiceImpl.getTaskTemplateBasicInfoById(appId, templateId)` 内部的 `setTags()` 对 `null` 调用 `.getId()` 抛出 NullPointerException，导致返回 HTTP 500 内部服务器错误，对用户不友好。

## 修改内容

在 `getTaskTemplateBasicInfoById(Long appId, Long templateId)` 中增加 null 检查：DAO 查询结果为 null 时直接返回 null，不再调用 `setTags()`。这样调用方的 null 判断可以正常触发 `NotFoundException`，返回明确的错误信息（HTTP 404）而非 500。

## 涉及文件

- `job-manage/service-job-manage/.../service/template/impl/TaskTemplateServiceImpl.java`