### PR TITLE
feat: 支持CRD容器执行 #4200

### DIFF
--- a/docs/apidoc/bk-api-gateway/v3/zh/bkci_plugin_fast_execute_script.md
+++ b/docs/apidoc/bk-api-gateway/v3/zh/bkci_plugin_fast_execute_script.md
@@ -92,7 +92,7 @@
 
 | 字段                 | 类型     | 必选 | 描述                                                                                                      |
 |--------------------|--------|----|---------------------------------------------------------------------------------------------------------|
-| kind               | string | 是  | workload类型，目前支持的workload类型有deployment、daemonSet、statefulSet、gameStatefulSet、gameDeployment、cronJob、job) |
+| kind               | string | 是  | workload类型，目前支持的workload类型有deployment、daemonSet、statefulSet、gameStatefulSet、gameDeployment、cronJob、job、customResource(CRD自定义资源) |
 | workload_name_list | array  | 否  | workload 名称列表                                                                                           |
 
 ##### kube_pod_prop_filter

--- a/docs/apidoc/bk-api-gateway/v4/zh/v4_fast_execute_script.md
+++ b/docs/apidoc/bk-api-gateway/v4/zh/v4_fast_execute_script.md
@@ -95,7 +95,7 @@
 
 | 字段                 | 类型     | 必选 | 描述                                            |
 |--------------------|--------|----|-----------------------------------------------|
-| kind               | string | 是  | workload类型，如deployment、statefulset、daemonset等 |
+| kind               | string | 是  | workload类型，如deployment、statefulSet、daemonSet、customResource(CRD自定义资源)等 |
 | workload_name_list | array  | 是  | workload名称列表                                  |
 
 ###### kube_pod_filter

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/constants/KubeTopoNodeTypeEnum.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/constants/KubeTopoNodeTypeEnum.java
@@ -34,7 +34,8 @@ public enum KubeTopoNodeTypeEnum {
     DAEMON_SET("daemonSet"),
     STATEFUL_SET("statefulSet"),
     CRON_JOB("cronJob"),
-    JOB("job");
+    JOB("job"),
+    CUSTOM_RESOURCE("customResource");
 
     private final String value;
 

--- a/support-files/bk-api-gateway/v3/apidocs/en/system_bkci_plugin_fast_execute_script.md.j2
+++ b/support-files/bk-api-gateway/v3/apidocs/en/system_bkci_plugin_fast_execute_script.md.j2
@@ -83,7 +83,7 @@ Fast execute script (dedicated to Blue Shield job execution plugin, informally p
 
 | Fields             | Type   | Required | Description                                                                                                              |
 |--------------------|--------|----------|--------------------------------------------------------------------------------------------------------------------------|
-| kind               | string | yes      | The workload types currently supported are (deployment daemonSet、statefulSet、gameStatefulSet、gameDeployment、cronJob、job) |
+| kind               | string | yes      | The workload types currently supported are (deployment, daemonSet, statefulSet, gameStatefulSet, gameDeployment, cronJob, job, customResource(CRD custom resource)) |
 | workload_name_list | array  | no       | Workload list                                                                                                            |
 
 ##### kube_pod_prop_filter

--- a/support-files/bk-api-gateway/v3/apidocs/en/v4/_generic_v4_execute_target.md.j2
+++ b/support-files/bk-api-gateway/v3/apidocs/en/v4/_generic_v4_execute_target.md.j2
@@ -51,7 +51,7 @@
 
 | Field              | Type   | Required | Description                                                |
 |--------------------|--------|----------|------------------------------------------------------------|
-| kind               | string | Yes      | Workload type, e.g., deployment, statefulset, daemonset    |
+| kind               | string | Yes      | Workload type, e.g., deployment, statefulSet, daemonSet, customResource(CRD custom resource) |
 | workload_name_list | array  | Yes      | Workload name list                                         |
 
 ###### kube_pod_filter

--- a/support-files/bk-api-gateway/v3/apidocs/zh/system_bkci_plugin_fast_execute_script.md.j2
+++ b/support-files/bk-api-gateway/v3/apidocs/zh/system_bkci_plugin_fast_execute_script.md.j2
@@ -84,7 +84,7 @@
 
 | 字段 | 类型 | 必选 | 描述 |
 |-----------|------------|--------|------------|
-| kind | string | 是 | workload类型，目前支持的workload类型有deployment、daemonSet、statefulSet、gameStatefulSet、gameDeployment、cronJob、job) |
+| kind | string | 是 | workload类型，目前支持的workload类型有deployment、daemonSet、statefulSet、gameStatefulSet、gameDeployment、cronJob、job、customResource(CRD自定义资源) |
 | workload_name_list | array | 否 | workload 名称列表 |
 
 ##### kube_pod_prop_filter

--- a/support-files/bk-api-gateway/v3/apidocs/zh/v4/_generic_v4_execute_target.md.j2
+++ b/support-files/bk-api-gateway/v3/apidocs/zh/v4/_generic_v4_execute_target.md.j2
@@ -51,7 +51,7 @@
 
 | 字段                 | 类型     | 必选 | 描述                                            |
 |--------------------|--------|----|-----------------------------------------------|
-| kind               | string | 是  | workload类型，如deployment、statefulset、daemonset等 |
+| kind               | string | 是  | workload类型，如deployment、statefulSet、daemonSet、customResource(CRD自定义资源)等 |
 | workload_name_list | array  | 是  | workload名称列表                                  |
 
 ###### kube_pod_filter


### PR DESCRIPTION
1.在蓝盾插件接口(bkci_plugin_fast_execute_script)和v4接口(v4_fast_execute_script)的API文档中，为workload过滤器的kind字段新增customResource取值声明，支持CRD自定义资源类型。 2.在KubeTopoNodeTypeEnum枚举中新增CUSTOM_RESOURCE(customResource)。