### PR TITLE
perf: File-Worker发布过程中的日志优化 #4208

### DIFF
--- a/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/service/TaskReporterImpl.java
+++ b/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/service/TaskReporterImpl.java
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.io.InterruptedIOException;
 import java.util.List;
 
 @Slf4j
@@ -169,7 +170,32 @@ public class TaskReporterImpl implements TaskReporter {
             log.info("url={},body={}", url, req.getBody());
             jobHttpClient.post(req);
         } catch (Exception e) {
-            log.error("Fail to request file-gateway:", e);
+            if (isCausedByInterruption(e)) {
+                // Task interrupted during File-Worker shutdown/restart is expected behavior,
+                // downgrade to INFO to avoid misleading ERROR logs during publishing
+                log.info("Task reporting interrupted (likely during File-Worker shutdown): {}", e.getMessage());
+            } else {
+                log.error("Fail to request file-gateway:", e);
+            }
         }
+    }
+
+    /**
+     * Check whether the exception is caused by an interruption (e.g. InterruptedIOException),
+     * which is expected during File-Worker graceful shutdown.
+     */
+    private boolean isCausedByInterruption(Throwable e) {
+        Throwable cause = e;
+        while (cause != null) {
+            if (cause instanceof InterruptedIOException || cause instanceof InterruptedException) {
+                return true;
+            }
+            // Avoid infinite loop on circular cause chains
+            if (cause.getCause() == cause) {
+                break;
+            }
+            cause = cause.getCause();
+        }
+        return false;
     }
 }


### PR DESCRIPTION
## 问题背景

File-Worker 优雅关停过程中，`TaskReporterImpl` 向 file-gateway 上报任务状态时，因线程中断（`InterruptedIOException` / `InterruptedException`）导致 HTTP 请求失败，打印了 ERROR 级别日志，属于发布期间预期行为，造成误报。

## 修改内容

对 `reportTaskStatus` 中捕获的异常进行根因判断：若根因为中断异常（`InterruptedIOException` / `InterruptedException`），则降级为 INFO 日志；其他真实错误仍保持 ERROR 级别，确保告警准确性。

## 涉及文件

- `src/backend/job-file-worker/service-job-file-worker/src/main/java/com/tencent/bk/job/file/worker/service/TaskReporterImpl.java`