### PR TITLE
perf: 开发类Tag不触发Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,12 @@ name: Tag Realse
 on:
   push:
     tags:
-      - 'v*'
+      - 'v3.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release'
+        required: true
 
 jobs:
   build:
@@ -14,6 +19,11 @@ jobs:
         id: variables
         run: |
           tag="$(basename $GITHUB_REF)"
+          # Only release for v3.x tags that do not contain alpha or codev
+          if [[ ! "$tag" =~ ^v3\. ]] || [[ "$tag" =~ alpha ]] || [[ "$tag" =~ codev ]]; then
+            echo "Tag '$tag' does not qualify for release (must start with v3. and not contain 'alpha' or 'codev'). Skipping."
+            exit 1
+          fi
           bkjobVersion=${tag##v}
           echo "::set-output name=tag::${tag}"
           echo "::set-output name=bkjobVersion::${bkjobVersion}"


### PR DESCRIPTION
## 问题背景

类似 `9.9.9-codev.x` 的开发类 Tag 不应触发 Release 流水线，当前 `release.yml` 使用 `v*` 会匹配所有 v 开头的 Tag，导致开发测试 Tag 误触发 Release。

## 修改内容

- `on.push.tags` 从 `v*` 改为 `v3.*`，在 tag filter 层过滤掉非 `v3.` 开头的 Tag（如 `9.9.9-codev.x`）
- `Set up variables` 步骤增加运行时校验：若 tag 包含 `alpha` 或 `codev` 则 `exit 1`，跳过本次 Release 执行
- 新增 `workflow_dispatch` 支持，允许手动指定 tag 触发

**触发规则**：只有 `v3.` 开头且不含 `alpha`、`codev` 的 tag 才会触发 Release。

## 涉及文件

- `.github/workflows/release.yml`