### PR TITLE
fix: 网关access日志中部分字段缺失 #4222

### DIFF
--- a/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/filter/global/AddTraceResponseHeaderGlobalFilter.java
+++ b/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/filter/global/AddTraceResponseHeaderGlobalFilter.java
@@ -27,6 +27,7 @@ package com.tencent.bk.job.gateway.filter.global;
 import com.tencent.bk.job.common.constant.JobCommonHeaders;
 import com.tencent.bk.job.gateway.consts.GlobalFilterOrder;
 import com.tencent.bk.job.gateway.web.server.AccessLogConstants;
+import com.tencent.bk.job.gateway.web.server.AccessLogExchangeDataStore;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
@@ -34,7 +35,6 @@ import org.springframework.cloud.gateway.filter.GlobalFilter;
 import io.micrometer.tracing.Span;
 import io.micrometer.tracing.Tracer;
 import org.springframework.core.Ordered;
-import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
@@ -44,10 +44,13 @@ import reactor.core.publisher.Mono;
 @Slf4j
 public class AddTraceResponseHeaderGlobalFilter implements GlobalFilter, Ordered {
     private final Tracer tracer;
+    private final AccessLogExchangeDataStore accessLogDataStore;
 
     @Autowired
-    public AddTraceResponseHeaderGlobalFilter(Tracer tracer) {
+    public AddTraceResponseHeaderGlobalFilter(Tracer tracer,
+                                              AccessLogExchangeDataStore accessLogDataStore) {
         this.tracer = tracer;
+        this.accessLogDataStore = accessLogDataStore;
     }
 
     @Override
@@ -59,12 +62,11 @@ public class AddTraceResponseHeaderGlobalFilter implements GlobalFilter, Ordered
         }
         try (Tracer.SpanInScope ignore = tracer.withSpan(span)) {
             String traceId = span.context().traceId();
-            ServerHttpRequest request = exchange.getRequest();
             ServerHttpResponse response = exchange.getResponse();
             response.getHeaders().add(JobCommonHeaders.REQUEST_ID, traceId);
-            // 由于Reactor Netty异步模型存在线程切换，trace可能无法正确传播,将trace写入请求头确保访问日志能稳定获取链路信息
-            request.mutate().header(AccessLogConstants.Header.SPAN_ID, span.context().spanId());
-            return chain.filter(exchange.mutate().request(request).build());
+            // 写入内存Store供Reactor Netty AccessLog读取，避免通过响应头暴露内部数据
+            accessLogDataStore.put(traceId, AccessLogConstants.LogField.SPAN_ID, span.context().spanId());
+            return chain.filter(exchange);
         } catch (Exception e) {
             span.error(e);
             throw e;

--- a/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/filter/web/AuthorizeGatewayFilterFactory.java
+++ b/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/filter/web/AuthorizeGatewayFilterFactory.java
@@ -38,6 +38,8 @@ import com.tencent.bk.job.common.util.json.JsonUtils;
 import com.tencent.bk.job.gateway.common.consts.HeaderConsts;
 import com.tencent.bk.job.gateway.config.LoginExemptionConfig;
 import com.tencent.bk.job.gateway.config.UserMapProperties;
+import com.tencent.bk.job.gateway.web.server.AccessLogConstants;
+import com.tencent.bk.job.gateway.web.server.AccessLogExchangeDataStore;
 import com.tencent.bk.job.gateway.web.service.LoginService;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -70,17 +72,20 @@ public class AuthorizeGatewayFilterFactory extends AbstractGatewayFilterFactory<
     private final LoginExemptionConfig loginExemptionConfig;
     private final TenantEnvService tenantEnvService;
     private final UserMapProperties userMapProperties;
+    private final AccessLogExchangeDataStore accessLogDataStore;
 
     @Autowired
     public AuthorizeGatewayFilterFactory(LoginService loginService,
                                          LoginExemptionConfig loginExemptionConfig,
                                          TenantEnvService tenantEnvService,
-                                         UserMapProperties userMapProperties) {
+                                         UserMapProperties userMapProperties,
+                                         AccessLogExchangeDataStore accessLogDataStore) {
         super(Config.class);
         this.loginService = loginService;
         this.loginExemptionConfig = loginExemptionConfig;
         this.tenantEnvService = tenantEnvService;
         this.userMapProperties = userMapProperties;
+        this.accessLogDataStore = accessLogDataStore;
     }
 
     private GatewayFilter getLoginExemptionFilter() {
@@ -91,6 +96,9 @@ public class AuthorizeGatewayFilterFactory extends AbstractGatewayFilterFactory<
             request = request.mutate()
                 .header("username", username)
                 .build();
+            // 写入内存Store供Reactor Netty AccessLog读取
+            String traceId = exchange.getResponse().getHeaders().getFirst(JobCommonHeaders.REQUEST_ID);
+            accessLogDataStore.put(traceId, AccessLogConstants.LogField.USER_NAME, username);
             return chain.filter(exchange.mutate().request(request).build());
         };
     }
@@ -148,6 +156,9 @@ public class AuthorizeGatewayFilterFactory extends AbstractGatewayFilterFactory<
                 .header(JobCommonHeaders.BK_TENANT_ID, tenantId)
                 .header(JobCommonHeaders.BK_USER_TIMEZONE, user.getTimeZone())
                 .build();
+            // 写入内存Store供Reactor Netty AccessLog读取
+            String traceId = response.getHeaders().getFirst(JobCommonHeaders.REQUEST_ID);
+            accessLogDataStore.put(traceId, AccessLogConstants.LogField.USER_NAME, targetUsername);
             if (targetUsername.equals(username)) {
                 log.info(
                     "UserAccess, tenantId: {}, username: {}, displayName: {}",
@@ -189,8 +200,7 @@ public class AuthorizeGatewayFilterFactory extends AbstractGatewayFilterFactory<
         DataBuffer dataBuffer = response.bufferFactory().wrap(bodyBytes);
         response.getHeaders().setContentLength(bodyBytes.length);
         response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
-        response.writeWith(Mono.just(dataBuffer)).subscribe();
-        return response.setComplete();
+        return response.writeWith(Mono.just(dataBuffer));
     }
 
     private BkUserDTO getUserByTokenList(List<String> bkTokenList, String lang) {

--- a/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/web/server/AccessLogConstants.java
+++ b/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/web/server/AccessLogConstants.java
@@ -51,14 +51,6 @@ public class AccessLogConstants {
     }
 
     /**
-     * 请求头，用于上下文传递信息
-     */
-    public static final class Header {
-        public static final String UPSTREAM_SERVER = "X-Bk-Job-Upstream-Server";
-        public static final String SPAN_ID = "X-Bk-Job-Span-Id";
-    }
-
-    /**
      * 格式化常量
      */
     public static final class Format {

--- a/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/web/server/AccessLogExchangeDataStore.java
+++ b/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/web/server/AccessLogExchangeDataStore.java
@@ -1,0 +1,77 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.gateway.web.server;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * AccessLog数据中转Store。
+ * <p>
+ * 由于Spring Framework 6.x中request.mutate().header()不再修改底层Netty请求头，
+ * Gateway过滤器无法通过请求头向Reactor Netty AccessLog传递数据。
+ * 本Store作为Spring层（Gateway过滤器）与Netty层（AccessLog回调）之间的数据桥梁，
+ * 以traceId为key，避免将内部数据通过HTTP响应头暴露给API调用方。
+ */
+@Component
+public class AccessLogExchangeDataStore {
+
+    private final Cache<String, Map<String, String>> cache = CacheBuilder.newBuilder()
+        .maximumSize(5000)
+        .expireAfterWrite(10, TimeUnit.MINUTES)
+        .build();
+
+    /**
+     * 写入单个字段
+     *
+     * @param traceId 请求的traceId，作为唯一标识
+     * @param key     字段名
+     * @param value   字段值
+     */
+    public void put(String traceId, String key, String value) {
+        if (traceId == null || key == null) {
+            return;
+        }
+        cache.asMap().computeIfAbsent(traceId, k -> new ConcurrentHashMap<>()).put(key, value);
+    }
+
+    /**
+     * 读取并移除指定traceId的所有字段（原子操作）
+     *
+     * @param traceId 请求的traceId
+     * @return 字段Map，如果不存在返回null
+     */
+    public Map<String, String> getAndRemove(String traceId) {
+        if (traceId == null) {
+            return null;
+        }
+        return cache.asMap().remove(traceId);
+    }
+}

--- a/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/web/server/config/WebServerCommonConfig.java
+++ b/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/web/server/config/WebServerCommonConfig.java
@@ -24,6 +24,7 @@
 
 package com.tencent.bk.job.gateway.web.server.config;
 
+import com.tencent.bk.job.gateway.web.server.AccessLogExchangeDataStore;
 import com.tencent.bk.job.gateway.web.server.AccessLogFieldRegistry;
 import com.tencent.bk.job.gateway.web.server.AccessLogFormatter;
 import com.tencent.bk.job.gateway.web.server.AccessLogMetadataCollector;
@@ -42,8 +43,8 @@ import java.util.List;
 @Slf4j
 public class WebServerCommonConfig {
     @Bean
-    public AccessLogEnricherFilter accessLogEnricherFilter() {
-        return new AccessLogEnricherFilter();
+    public AccessLogEnricherFilter accessLogEnricherFilter(AccessLogExchangeDataStore accessLogDataStore) {
+        return new AccessLogEnricherFilter(accessLogDataStore);
     }
 
     @Bean
@@ -52,8 +53,10 @@ public class WebServerCommonConfig {
     }
 
     @Bean
-    public RequestContextMetadataProvider requestContextMetadataProvider() {
-        return new RequestContextMetadataProvider();
+    public RequestContextMetadataProvider requestContextMetadataProvider(
+        AccessLogExchangeDataStore accessLogDataStore
+    ) {
+        return new RequestContextMetadataProvider(accessLogDataStore);
     }
 
     @Bean

--- a/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/web/server/filter/AccessLogEnricherFilter.java
+++ b/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/web/server/filter/AccessLogEnricherFilter.java
@@ -24,7 +24,9 @@
 
 package com.tencent.bk.job.gateway.web.server.filter;
 
+import com.tencent.bk.job.common.constant.JobCommonHeaders;
 import com.tencent.bk.job.gateway.web.server.AccessLogConstants;
+import com.tencent.bk.job.gateway.web.server.AccessLogExchangeDataStore;
 import com.tencent.bk.job.gateway.web.server.RouteServerInfo;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.client.ServiceInstance;
@@ -34,19 +36,22 @@ import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.cloud.gateway.filter.ReactiveLoadBalancerClientFilter;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.core.Ordered;
-import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
 import java.net.URI;
 
 /**
- * 访问日志增强过滤器，获取后端路由信息并写入请求头，供访问日志使用
+ * 访问日志增强过滤器，获取后端路由信息写入AccessLog Store，供访问日志使用
  */
-@Component
 @Slf4j
 public class AccessLogEnricherFilter implements GlobalFilter, Ordered {
+
+    private final AccessLogExchangeDataStore accessLogDataStore;
+
+    public AccessLogEnricherFilter(AccessLogExchangeDataStore accessLogDataStore) {
+        this.accessLogDataStore = accessLogDataStore;
+    }
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange,
@@ -60,18 +65,16 @@ public class AccessLogEnricherFilter implements GlobalFilter, Ordered {
     }
 
     private Mono<Void> doFilter(ServerWebExchange exchange, GatewayFilterChain chain) {
-        ServerHttpRequest request = exchange.getRequest();
-
         // 获取负载均衡选择的后端实例
         Response<ServiceInstance> resp =
             exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_LOADBALANCER_RESPONSE_ATTR);
 
         RouteServerInfo routeServerInfo = buildRouteInfo(exchange, resp.getServer());
-        request.mutate()
-            .header(AccessLogConstants.Header.UPSTREAM_SERVER,
-                routeServerInfo != null ? routeServerInfo.toString() : AccessLogConstants.Default.MISSING)
-            .build();
-        return chain.filter(exchange.mutate().request(request).build());
+        // 写入内存Store供Reactor Netty AccessLog读取
+        String traceId = exchange.getResponse().getHeaders().getFirst(JobCommonHeaders.REQUEST_ID);
+        String upstream = routeServerInfo != null ? routeServerInfo.toString() : AccessLogConstants.Default.MISSING;
+        accessLogDataStore.put(traceId, AccessLogConstants.LogField.UPSTREAM, upstream);
+        return chain.filter(exchange);
     }
 
     private RouteServerInfo buildRouteInfo(ServerWebExchange exchange, ServiceInstance serviceInstance) {

--- a/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/web/server/provider/RequestContextMetadataProvider.java
+++ b/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/web/server/provider/RequestContextMetadataProvider.java
@@ -26,27 +26,41 @@ package com.tencent.bk.job.gateway.web.server.provider;
 
 import com.tencent.bk.job.common.constant.JobCommonHeaders;
 import com.tencent.bk.job.gateway.web.server.AccessLogConstants;
+import com.tencent.bk.job.gateway.web.server.AccessLogExchangeDataStore;
 import reactor.netty.http.server.logging.AccessLogArgProvider;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * 从上下文获取访问日志数据
+ * 从上下文获取访问日志数据。
+ * <p>
+ * traceId从响应头读取（该字段本身就需要暴露给调用方），
+ * 其余字段（spanId、username、upstream）从内存Store读取，避免通过HTTP响应头暴露内部数据。
  */
 public class RequestContextMetadataProvider implements AccessLogMetadataProvider {
+
+    private final AccessLogExchangeDataStore accessLogDataStore;
+
+    public RequestContextMetadataProvider(AccessLogExchangeDataStore accessLogDataStore) {
+        this.accessLogDataStore = accessLogDataStore;
+    }
 
     @Override
     public Map<String, Object> extract(AccessLogArgProvider provider) {
         Map<String, Object> map = new LinkedHashMap<>();
-        map.put(AccessLogConstants.LogField.UPSTREAM,
-            provider.requestHeader(AccessLogConstants.Header.UPSTREAM_SERVER));
-        map.put(AccessLogConstants.LogField.USER_NAME, provider.requestHeader(JobCommonHeaders.USERNAME) != null ?
-            provider.requestHeader(JobCommonHeaders.USERNAME) : provider.requestHeader("username"));
-        map.put(AccessLogConstants.LogField.TRACE_ID,
-            provider.responseHeader(JobCommonHeaders.REQUEST_ID));
-        map.put(AccessLogConstants.LogField.SPAN_ID,
-            provider.requestHeader(AccessLogConstants.Header.SPAN_ID));
+        // traceId从响应头读取（本身是有意暴露给调用方的）
+        CharSequence traceIdSeq = provider.responseHeader(JobCommonHeaders.REQUEST_ID);
+        String traceId = traceIdSeq != null ? traceIdSeq.toString() : null;
+        map.put(AccessLogConstants.LogField.TRACE_ID, traceId);
+
+        // 其余字段从内存Store读取并清理
+        Map<String, String> storeData = accessLogDataStore.getAndRemove(traceId);
+        if (storeData != null) {
+            map.put(AccessLogConstants.LogField.SPAN_ID, storeData.get(AccessLogConstants.LogField.SPAN_ID));
+            map.put(AccessLogConstants.LogField.USER_NAME, storeData.get(AccessLogConstants.LogField.USER_NAME));
+            map.put(AccessLogConstants.LogField.UPSTREAM, storeData.get(AccessLogConstants.LogField.UPSTREAM));
+        }
         return map;
     }
 }


### PR DESCRIPTION
1. 引入AccessLogExchangeDataStore内存中转，解决Spring 6.x升级后request.mutate().header()不再修改Netty请求头导致的spanId/userName/upstream字段丢失问题。