### PR TITLE
perf: 执行账号管理无权限跳转链接跳转后展示账号的拓扑信息 #2428

### DIFF
--- a/src/backend/commons/common-iam/build.gradle
+++ b/src/backend/commons/common-iam/build.gradle
@@ -32,4 +32,7 @@ dependencies {
     implementation 'org.apache.httpcomponents:httpclient'
     implementation 'org.aspectj:aspectjweaver'
     implementation 'io.micrometer:micrometer-registry-prometheus'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.mockito:mockito-core'
+    testImplementation 'org.assertj:assertj-core'
 }

--- a/src/backend/commons/common-iam/src/main/java/com/tencent/bk/job/common/iam/service/impl/AuthServiceImpl.java
+++ b/src/backend/commons/common-iam/src/main/java/com/tencent/bk/job/common/iam/service/impl/AuthServiceImpl.java
@@ -132,7 +132,8 @@ public class AuthServiceImpl extends BasicAuthService implements AuthService {
             // 将 pathInfo 中的父级资源信息转换为 parentHierarchicalResources，
             // 使申请权限跳转链接中能够展示完整的资源拓扑（如业务信息）
             if (pathInfo != null) {
-                List<PermissionResource> parentResources = buildParentHierarchicalResources(pathInfo);
+                List<PermissionResource> parentResources =
+                    buildParentHierarchicalResources(pathInfo, resourceType, resourceId);
                 if (!parentResources.isEmpty()) {
                     permissionResource.setParentHierarchicalResources(parentResources);
                 }
@@ -145,21 +146,29 @@ public class AuthServiceImpl extends BasicAuthService implements AuthService {
     /**
      * 将 pathInfo 链表解析为父级层级资源列表
      * <p>
-     * pathInfo 描述的是资源的祖先路径（如 biz/{bizId}），需要将其转为 parentHierarchicalResources，
-     * 以便权限申请跳转链接中能展示完整的资源拓扑（例如"业务 > 账号"）。
+     * pathInfo 描述的是资源在 IAM 中的路径，可能仅包含祖先节点（如 biz/{bizId}），
+     * 也可能包含资源自身（如 biz/{bizId} → account/{accountId}）。
+     * 为避免与被鉴权资源重复，需要跳过 type+id 与被鉴权资源匹配的节点，
+     * 仅保留真正的祖先节点作为 parentHierarchicalResources。
      *
-     * @param pathInfo 资源路径信息
+     * @param pathInfo     资源路径信息
+     * @param resourceType 被鉴权资源的类型
+     * @param resourceId   被鉴权资源的 ID
      * @return 父级层级资源列表
      */
-    private List<PermissionResource> buildParentHierarchicalResources(PathInfoDTO pathInfo) {
+    private List<PermissionResource> buildParentHierarchicalResources(PathInfoDTO pathInfo,
+                                                                      ResourceTypeEnum resourceType,
+                                                                      String resourceId) {
         List<PermissionResource> parentResources = new ArrayList<>();
         PathInfoDTO node = pathInfo;
         while (node != null) {
-            ResourceTypeEnum parentType = ResourceTypeEnum.getByResourceTypeId(node.getType());
-            String parentId = node.getId();
-            if (parentType != null && StringUtils.isNotEmpty(parentId)) {
-                String parentName = resourceNameQueryService.getResourceName(parentType, parentId);
-                PermissionResource parentResource = new PermissionResource(parentType, parentId, parentName);
+            ResourceTypeEnum nodeType = ResourceTypeEnum.getByResourceTypeId(node.getType());
+            String nodeId = node.getId();
+            // 跳过与被鉴权资源 type+id 匹配的节点，避免在 buildApplyActions 中出现重复
+            if (nodeType != null && StringUtils.isNotEmpty(nodeId)
+                && !(nodeType == resourceType && nodeId.equals(resourceId))) {
+                String parentName = resourceNameQueryService.getResourceName(nodeType, nodeId);
+                PermissionResource parentResource = new PermissionResource(nodeType, nodeId, parentName);
                 parentResources.add(parentResource);
             }
             node = node.getChild();

--- a/src/backend/commons/common-iam/src/main/java/com/tencent/bk/job/common/iam/service/impl/AuthServiceImpl.java
+++ b/src/backend/commons/common-iam/src/main/java/com/tencent/bk/job/common/iam/service/impl/AuthServiceImpl.java
@@ -106,7 +106,7 @@ public class AuthServiceImpl extends BasicAuthService implements AuthService {
         if (isAllowed) {
             return AuthResult.pass(user);
         } else {
-            return buildFailAuthResult(user, actionId, resourceType, resourceId);
+            return buildFailAuthResult(user, actionId, resourceType, resourceId, pathInfo);
         }
     }
 
@@ -114,14 +114,57 @@ public class AuthServiceImpl extends BasicAuthService implements AuthService {
                                            String actionId,
                                            ResourceTypeEnum resourceType,
                                            String resourceId) {
+        return buildFailAuthResult(user, actionId, resourceType, resourceId, null);
+    }
+
+    private AuthResult buildFailAuthResult(User user,
+                                           String actionId,
+                                           ResourceTypeEnum resourceType,
+                                           String resourceId,
+                                           PathInfoDTO pathInfo) {
         AuthResult authResult = AuthResult.fail(user);
         if (resourceType == null || StringUtils.isEmpty(resourceId)) {
             authResult.addRequiredPermission(actionId, null);
         } else {
             String resourceName = resourceNameQueryService.getResourceName(resourceType, resourceId);
-            authResult.addRequiredPermission(actionId, new PermissionResource(resourceType, resourceId, resourceName));
+            PermissionResource permissionResource =
+                new PermissionResource(resourceType, resourceId, resourceName);
+            // 将 pathInfo 中的父级资源信息转换为 parentHierarchicalResources，
+            // 使申请权限跳转链接中能够展示完整的资源拓扑（如业务信息）
+            if (pathInfo != null) {
+                List<PermissionResource> parentResources = buildParentHierarchicalResources(pathInfo);
+                if (!parentResources.isEmpty()) {
+                    permissionResource.setParentHierarchicalResources(parentResources);
+                }
+            }
+            authResult.addRequiredPermission(actionId, permissionResource);
         }
         return authResult;
+    }
+
+    /**
+     * 将 pathInfo 链表解析为父级层级资源列表
+     * <p>
+     * pathInfo 描述的是资源的祖先路径（如 biz/{bizId}），需要将其转为 parentHierarchicalResources，
+     * 以便权限申请跳转链接中能展示完整的资源拓扑（例如"业务 > 账号"）。
+     *
+     * @param pathInfo 资源路径信息
+     * @return 父级层级资源列表
+     */
+    private List<PermissionResource> buildParentHierarchicalResources(PathInfoDTO pathInfo) {
+        List<PermissionResource> parentResources = new ArrayList<>();
+        PathInfoDTO node = pathInfo;
+        while (node != null) {
+            ResourceTypeEnum parentType = ResourceTypeEnum.getByResourceTypeId(node.getType());
+            String parentId = node.getId();
+            if (parentType != null && StringUtils.isNotEmpty(parentId)) {
+                String parentName = resourceNameQueryService.getResourceName(parentType, parentId);
+                PermissionResource parentResource = new PermissionResource(parentType, parentId, parentName);
+                parentResources.add(parentResource);
+            }
+            node = node.getChild();
+        }
+        return parentResources;
     }
 
     @Override

--- a/src/backend/commons/common-iam/src/test/java/com/tencent/bk/job/common/iam/service/impl/AuthServiceImplTest.java
+++ b/src/backend/commons/common-iam/src/test/java/com/tencent/bk/job/common/iam/service/impl/AuthServiceImplTest.java
@@ -211,6 +211,69 @@ class AuthServiceImplTest {
         assertThat(resource.getParentHierarchicalResources()).isNull();
     }
 
+    @Test
+    @DisplayName("Case6: pathInfo包含资源自身(biz->account) — 应去重，parentHierarchicalResources 仅包含biz")
+    void authFail_pathIncludesResource_shouldDedup() {
+        String bizId = "2";
+        String accountId = "3";
+        when(resourceNameQueryService.getResourceName(ResourceTypeEnum.ACCOUNT, accountId))
+            .thenReturn("root");
+        when(resourceNameQueryService.getResourceName(ResourceTypeEnum.BUSINESS, bizId))
+            .thenReturn("蓝鲸");
+
+        // biz/2 -> account/3，pathInfo 包含了资源本身
+        PathInfoDTO pathInfo = PathBuilder.newBuilder(ResourceTypeId.BIZ, bizId)
+            .child(ResourceTypeId.ACCOUNT, accountId).build();
+
+        AuthResult result = authService.auth(TEST_USER, "use_account",
+            ResourceTypeEnum.ACCOUNT, accountId, pathInfo);
+
+        assertThat(result.isPass()).isFalse();
+
+        PermissionResource resource = extractFirstPermissionResource(result);
+        assertThat(resource.getResourceId()).isEqualTo(accountId);
+        assertThat(resource.getResourceName()).isEqualTo("root");
+
+        // parentHierarchicalResources 应仅包含 biz，account 节点被去重
+        List<PermissionResource> parents = resource.getParentHierarchicalResources();
+        assertThat(parents).hasSize(1);
+        assertThat(parents.get(0).getResourceType()).isEqualTo(ResourceTypeEnum.BUSINESS);
+        assertThat(parents.get(0).getResourceId()).isEqualTo(bizId);
+        assertThat(parents.get(0).getResourceName()).isEqualTo("蓝鲸");
+    }
+
+    @Test
+    @DisplayName("Case7: 两层路径(biz->template)鉴权Plan — template不是Plan，应全部保留")
+    void authFail_pathDoesNotIncludeResource_shouldKeepAll() {
+        String bizId = "2";
+        String templateId = "500";
+        String planId = "1001";
+        when(resourceNameQueryService.getResourceName(ResourceTypeEnum.PLAN, planId))
+            .thenReturn("默认方案");
+        when(resourceNameQueryService.getResourceName(ResourceTypeEnum.BUSINESS, bizId))
+            .thenReturn("蓝鲸");
+        when(resourceNameQueryService.getResourceName(ResourceTypeEnum.TEMPLATE, templateId))
+            .thenReturn("发布模板");
+
+        // biz/2 -> job_template/500，路径不包含 Plan 资源本身
+        PathInfoDTO pathInfo = PathBuilder.newBuilder(ResourceTypeId.BIZ, bizId)
+            .child(ResourceTypeId.TEMPLATE, templateId).build();
+
+        AuthResult result = authService.auth(TEST_USER, ACTION_VIEW_JOB_PLAN,
+            ResourceTypeEnum.PLAN, planId, pathInfo);
+
+        assertThat(result.isPass()).isFalse();
+
+        PermissionResource resource = extractFirstPermissionResource(result);
+        assertThat(resource.getResourceId()).isEqualTo(planId);
+
+        // biz 和 template 都不匹配 Plan，应全部保留
+        List<PermissionResource> parents = resource.getParentHierarchicalResources();
+        assertThat(parents).hasSize(2);
+        assertThat(parents.get(0).getResourceType()).isEqualTo(ResourceTypeEnum.BUSINESS);
+        assertThat(parents.get(1).getResourceType()).isEqualTo(ResourceTypeEnum.TEMPLATE);
+    }
+
     /**
      * 从 AuthResult 中提取第一个 PermissionResource
      */

--- a/src/backend/commons/common-iam/src/test/java/com/tencent/bk/job/common/iam/service/impl/AuthServiceImplTest.java
+++ b/src/backend/commons/common-iam/src/test/java/com/tencent/bk/job/common/iam/service/impl/AuthServiceImplTest.java
@@ -1,0 +1,226 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.iam.service.impl;
+
+import com.tencent.bk.job.common.i18n.service.MessageI18nService;
+import com.tencent.bk.job.common.iam.client.IIamClient;
+import com.tencent.bk.job.common.iam.constant.ResourceTypeEnum;
+import com.tencent.bk.job.common.iam.constant.ResourceTypeId;
+import com.tencent.bk.job.common.iam.model.AuthResult;
+import com.tencent.bk.job.common.iam.model.PermissionActionResource;
+import com.tencent.bk.job.common.iam.model.PermissionResource;
+import com.tencent.bk.job.common.iam.model.PermissionResourceGroup;
+import com.tencent.bk.job.common.iam.service.ResourceNameQueryService;
+import com.tencent.bk.job.common.model.User;
+import com.tencent.bk.sdk.iam.dto.InstanceDTO;
+import com.tencent.bk.sdk.iam.dto.PathInfoDTO;
+import com.tencent.bk.sdk.iam.helper.AuthHelper;
+import com.tencent.bk.sdk.iam.util.PathBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * AuthServiceImpl 单元测试：验证鉴权失败时 parentHierarchicalResources 的构建逻辑 (#2428)
+ */
+class AuthServiceImplTest {
+
+    private AuthHelper authHelper;
+    private ResourceNameQueryService resourceNameQueryService;
+    private AuthServiceImpl authService;
+
+    private static final String TENANT_ID = "default";
+    private static final String USERNAME = "testuser";
+    private static final User TEST_USER = new User(TENANT_ID, USERNAME, "测试用户");
+
+    private static final String ACTION_MANAGE_ACCOUNT = "manage_account";
+    private static final String ACTION_VIEW_JOB_PLAN = "view_job_plan";
+    private static final String ACTION_MANAGE_SCRIPT = "manage_script";
+
+    @BeforeEach
+    void setUp() {
+        authHelper = mock(AuthHelper.class);
+        IIamClient iamClient = mock(IIamClient.class);
+        MessageI18nService i18nService = mock(MessageI18nService.class);
+        resourceNameQueryService = mock(ResourceNameQueryService.class);
+
+        authService = new AuthServiceImpl(authHelper, i18nService, iamClient);
+        authService.setResourceNameQueryService(resourceNameQueryService);
+
+        // 默认所有鉴权返回 false，触发失败路径
+        when(authHelper.isAllowed(anyString(), anyString(), anyString(), any(InstanceDTO.class)))
+            .thenReturn(false);
+    }
+
+    @Test
+    @DisplayName("Case1: 单层路径(biz) — 账号鉴权失败时，parentHierarchicalResources 应包含业务信息")
+    void authFail_singleLevelPath_shouldBuildParentHierarchicalResources() {
+        String bizId = "2";
+        String accountId = "100";
+        when(resourceNameQueryService.getResourceName(ResourceTypeEnum.ACCOUNT, accountId))
+            .thenReturn("root");
+        when(resourceNameQueryService.getResourceName(ResourceTypeEnum.BUSINESS, bizId))
+            .thenReturn("蓝鲸");
+
+        // biz/2 -> 单节点路径
+        PathInfoDTO pathInfo = PathBuilder.newBuilder(ResourceTypeId.BIZ, bizId).build();
+
+        AuthResult result = authService.auth(TEST_USER, ACTION_MANAGE_ACCOUNT,
+            ResourceTypeEnum.ACCOUNT, accountId, pathInfo);
+
+        assertThat(result.isPass()).isFalse();
+
+        PermissionResource resource = extractFirstPermissionResource(result);
+        assertThat(resource.getResourceId()).isEqualTo(accountId);
+        assertThat(resource.getResourceName()).isEqualTo("root");
+
+        List<PermissionResource> parents = resource.getParentHierarchicalResources();
+        assertThat(parents).hasSize(1);
+        assertThat(parents.get(0).getResourceType()).isEqualTo(ResourceTypeEnum.BUSINESS);
+        assertThat(parents.get(0).getResourceId()).isEqualTo(bizId);
+        assertThat(parents.get(0).getResourceName()).isEqualTo("蓝鲸");
+    }
+
+    @Test
+    @DisplayName("Case2: 两层路径(biz->template) — 执行方案鉴权失败时，parentHierarchicalResources 应包含业务和模板信息")
+    void authFail_twoLevelPath_shouldBuildMultipleParentResources() {
+        String bizId = "2";
+        String templateId = "500";
+        String planId = "1001";
+        when(resourceNameQueryService.getResourceName(ResourceTypeEnum.PLAN, planId))
+            .thenReturn("默认方案");
+        when(resourceNameQueryService.getResourceName(ResourceTypeEnum.BUSINESS, bizId))
+            .thenReturn("蓝鲸");
+        when(resourceNameQueryService.getResourceName(ResourceTypeEnum.TEMPLATE, templateId))
+            .thenReturn("发布模板");
+
+        // biz/2 -> job_template/500
+        PathInfoDTO pathInfo = PathBuilder.newBuilder(ResourceTypeId.BIZ, bizId)
+            .child(ResourceTypeId.TEMPLATE, templateId).build();
+
+        AuthResult result = authService.auth(TEST_USER, ACTION_VIEW_JOB_PLAN,
+            ResourceTypeEnum.PLAN, planId, pathInfo);
+
+        assertThat(result.isPass()).isFalse();
+
+        PermissionResource resource = extractFirstPermissionResource(result);
+        assertThat(resource.getResourceId()).isEqualTo(planId);
+
+        List<PermissionResource> parents = resource.getParentHierarchicalResources();
+        assertThat(parents).hasSize(2);
+        // 第一层：业务
+        assertThat(parents.get(0).getResourceType()).isEqualTo(ResourceTypeEnum.BUSINESS);
+        assertThat(parents.get(0).getResourceId()).isEqualTo(bizId);
+        assertThat(parents.get(0).getResourceName()).isEqualTo("蓝鲸");
+        // 第二层：模板
+        assertThat(parents.get(1).getResourceType()).isEqualTo(ResourceTypeEnum.TEMPLATE);
+        assertThat(parents.get(1).getResourceId()).isEqualTo(templateId);
+        assertThat(parents.get(1).getResourceName()).isEqualTo("发布模板");
+    }
+
+    @Test
+    @DisplayName("Case3: pathInfo为null — parentHierarchicalResources 不应被设置")
+    void authFail_nullPathInfo_shouldNotSetParentHierarchicalResources() {
+        String scriptId = "300";
+        when(resourceNameQueryService.getResourceName(ResourceTypeEnum.SCRIPT, scriptId))
+            .thenReturn("清理脚本");
+
+        AuthResult result = authService.auth(TEST_USER, ACTION_MANAGE_SCRIPT,
+            ResourceTypeEnum.SCRIPT, scriptId, null);
+
+        assertThat(result.isPass()).isFalse();
+
+        PermissionResource resource = extractFirstPermissionResource(result);
+        assertThat(resource.getResourceId()).isEqualTo(scriptId);
+        assertThat(resource.getParentHierarchicalResources()).isNull();
+    }
+
+    @Test
+    @DisplayName("Case4: pathInfo节点type不在ResourceTypeEnum中 — 该节点应被跳过")
+    void authFail_unknownResourceType_shouldSkipNode() {
+        String accountId = "100";
+        when(resourceNameQueryService.getResourceName(ResourceTypeEnum.ACCOUNT, accountId))
+            .thenReturn("root");
+
+        // 构造一个type不在 ResourceTypeEnum 中的 PathInfoDTO
+        PathInfoDTO pathInfo = new PathInfoDTO();
+        pathInfo.setType("unknown_type");
+        pathInfo.setId("999");
+
+        AuthResult result = authService.auth(TEST_USER, ACTION_MANAGE_ACCOUNT,
+            ResourceTypeEnum.ACCOUNT, accountId, pathInfo);
+
+        assertThat(result.isPass()).isFalse();
+
+        PermissionResource resource = extractFirstPermissionResource(result);
+        assertThat(resource.getResourceId()).isEqualTo(accountId);
+        // 未知type被跳过，parentHierarchicalResources 为空列表 -> 不被设置
+        assertThat(resource.getParentHierarchicalResources()).isNull();
+    }
+
+    @Test
+    @DisplayName("Case5: pathInfo节点id为空 — 该节点应被跳过")
+    void authFail_emptyNodeId_shouldSkipNode() {
+        String accountId = "100";
+        when(resourceNameQueryService.getResourceName(ResourceTypeEnum.ACCOUNT, accountId))
+            .thenReturn("root");
+
+        // 构造一个 id 为空的节点
+        PathInfoDTO pathInfo = new PathInfoDTO();
+        pathInfo.setType(ResourceTypeId.BIZ);
+        pathInfo.setId("");
+
+        AuthResult result = authService.auth(TEST_USER, ACTION_MANAGE_ACCOUNT,
+            ResourceTypeEnum.ACCOUNT, accountId, pathInfo);
+
+        assertThat(result.isPass()).isFalse();
+
+        PermissionResource resource = extractFirstPermissionResource(result);
+        assertThat(resource.getResourceId()).isEqualTo(accountId);
+        // id为空被跳过
+        assertThat(resource.getParentHierarchicalResources()).isNull();
+    }
+
+    /**
+     * 从 AuthResult 中提取第一个 PermissionResource
+     */
+    private PermissionResource extractFirstPermissionResource(AuthResult result) {
+        List<PermissionActionResource> actionResources = result.getRequiredActionResources();
+        assertThat(actionResources).isNotEmpty();
+        List<PermissionResourceGroup> groups = actionResources.get(0).getResourceGroups();
+        assertThat(groups).isNotEmpty();
+        List<PermissionResource> resources = groups.get(0).getPermissionResources();
+        assertThat(resources).isNotEmpty();
+        return resources.get(0);
+    }
+}

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/auth/impl/ExecuteAuthServiceImpl.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/auth/impl/ExecuteAuthServiceImpl.java
@@ -475,8 +475,10 @@ public class ExecuteAuthServiceImpl implements ExecuteAuthService {
         return hostInstanceList;
     }
 
-    private List<PermissionResource> convertBizStaticIpToPermissionResourceList(ExecuteTargetDTO executeTarget) {
+    private List<PermissionResource> convertBizStaticIpToPermissionResourceList(
+        AppResourceScope appResourceScope, ExecuteTargetDTO executeTarget) {
         List<PermissionResource> hostResources = new ArrayList<>();
+        List<PermissionResource> parentResources = Collections.singletonList(buildAppResource(appResourceScope));
         executeTarget.getStaticIpList().forEach(host -> {
             PermissionResource resource = new PermissionResource();
             resource.setResourceId(String.valueOf(host.getHostId()));
@@ -485,6 +487,7 @@ public class ExecuteAuthServiceImpl implements ExecuteAuthService {
             resource.setResourceName(host.getIp());
             resource.setSystemId(SystemId.CMDB);
             resource.setType("host");
+            resource.setParentHierarchicalResources(parentResources);
             hostResources.add(resource);
         });
         return hostResources;
@@ -606,7 +609,8 @@ public class ExecuteAuthServiceImpl implements ExecuteAuthService {
         if (!CollectionUtils.isEmpty(executeTarget.getStaticIpList())) {
             switch (appResourceScope.getType()) {
                 case BIZ:
-                    hostResources.addAll(convertBizStaticIpToPermissionResourceList(executeTarget));
+                    hostResources.addAll(convertBizStaticIpToPermissionResourceList(
+                        appResourceScope, executeTarget));
                     break;
                 case BIZ_SET:
                     hostResources.addAll(


### PR DESCRIPTION
1. 修复鉴权失败时 pathInfo 被丢弃导致权限申请链接中缺少业务拓扑信息的问题；
2. ESB无权限响应中添加资源路径。