### PR TITLE
perf: 制品库节点分页接口调用优化 #4210

### DIFF
--- a/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/model/req/ListNodePageReq.java
+++ b/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/model/req/ListNodePageReq.java
@@ -48,4 +48,6 @@ public class ListNodePageReq extends ArtifactoryReq {
     private Boolean deep = false;
     // 非必传，是否排序输出结果
     private Boolean sort = true;
+    // 非必传，是否查询节点总数，默认为true；在不需要总数的场景设置为false可提升接口性能
+    private Boolean includeTotalRecords;
 }

--- a/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
+++ b/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
@@ -441,12 +441,18 @@ public class ArtifactoryClient {
 
     public PageData<NodeDTO> listNode(String projectId, String repoName, String fullPath, int pageNumber,
                                       int pageSize) {
+        return listNode(projectId, repoName, fullPath, pageNumber, pageSize, null);
+    }
+
+    public PageData<NodeDTO> listNode(String projectId, String repoName, String fullPath, int pageNumber,
+                                      int pageSize, Boolean includeTotalRecords) {
         ListNodePageReq req = new ListNodePageReq();
         req.setProjectId(projectId);
         req.setRepoName(repoName);
         req.setFullPath(fullPath);
         req.setPageNumber(pageNumber);
         req.setPageSize(pageSize);
+        req.setIncludeTotalRecords(includeTotalRecords);
         ArtifactoryResp<PageData<NodeDTO>> resp = getArtifactoryRespByReq(HttpGet.METHOD_NAME, URL_LIST_NODE_PAGE,
             req, new TypeReference<ArtifactoryResp<PageData<NodeDTO>>>() {
             }, httpHelper);

--- a/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
+++ b/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
@@ -439,13 +439,20 @@ public class ArtifactoryClient {
         return resp.getData();
     }
 
-    public PageData<NodeDTO> listNode(String projectId, String repoName, String fullPath, int pageNumber,
+    public PageData<NodeDTO> listNode(String projectId,
+                                      String repoName,
+                                      String fullPath,
+                                      int pageNumber,
                                       int pageSize) {
         return listNode(projectId, repoName, fullPath, pageNumber, pageSize, null);
     }
 
-    public PageData<NodeDTO> listNode(String projectId, String repoName, String fullPath, int pageNumber,
-                                      int pageSize, Boolean includeTotalRecords) {
+    public PageData<NodeDTO> listNode(String projectId,
+                                      String repoName,
+                                      String fullPath,
+                                      int pageNumber,
+                                      int pageSize,
+                                      Boolean includeTotalRecords) {
         ListNodePageReq req = new ListNodePageReq();
         req.setProjectId(projectId);
         req.setRepoName(repoName);
@@ -454,7 +461,7 @@ public class ArtifactoryClient {
         req.setPageSize(pageSize);
         req.setIncludeTotalRecords(includeTotalRecords);
         ArtifactoryResp<PageData<NodeDTO>> resp = getArtifactoryRespByReq(HttpGet.METHOD_NAME, URL_LIST_NODE_PAGE,
-            req, new TypeReference<ArtifactoryResp<PageData<NodeDTO>>>() {
+            req, new TypeReference<>() {
             }, httpHelper);
         return resp.getData();
     }

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/task/LogExportFileCleanTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/task/LogExportFileCleanTask.java
@@ -134,7 +134,8 @@ public class LogExportFileCleanTask {
                 logExportConfig.getLogExportRepo(),
                 "/",
                 start,
-                pageSize
+                pageSize,
+                false
             );
             if (nodePage == null) {
                 log.warn("nodePage is null");

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/task/UserUploadFileCleanTask.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/task/UserUploadFileCleanTask.java
@@ -198,7 +198,8 @@ public class UserUploadFileCleanTask {
                 localFileConfigForManage.getLocalUploadRepo(),
                 node.getFullPath(),
                 pageNumber,
-                pageSize
+                pageSize,
+                false
             );
             if (isEmpty(nodePage)) {
                 break;
@@ -250,7 +251,8 @@ public class UserUploadFileCleanTask {
             localFileConfigForManage.getLocalUploadRepo(),
             dirNode.getFullPath(),
             1,
-            1
+            1,
+            false
         );
         return nodePage != null && (nodePage.getRecords() == null || nodePage.getRecords().isEmpty());
     }


### PR DESCRIPTION
listNode 接口增加 includeTotalRecords 参数（非必传，默认 null 由接口自行处理）， 在不需要节点总数的场景（日志导出文件清理、用户上传文件清理、空目录判断）统一传入 false，避免不必要的 COUNT 查询，提升制品库接口调用性能。

涉及文件：
- ListNodePageReq: 新增 includeTotalRecords 字段
- ArtifactoryClient: listNode 增加重载方法，支持传入 includeTotalRecords
- LogExportFileCleanTask: 传入 includeTotalRecords=false
- UserUploadFileCleanTask: 两处 listNode 调用传入 includeTotalRecords=false