### PR TITLE
feat：目标服务器-静态拓扑中的节点列表，支持展示节点所属的集群和模块

### DIFF
--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/ApplicationHostDTO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/ApplicationHostDTO.java
@@ -30,6 +30,7 @@ import com.tencent.bk.job.common.annotation.PersistenceObject;
 import com.tencent.bk.job.common.constant.JobConstants;
 import com.tencent.bk.job.common.model.vo.CloudAreaInfoVO;
 import com.tencent.bk.job.common.model.vo.HostInfoVO;
+import com.tencent.bk.job.common.model.vo.HostTopoPathVO;
 import com.tencent.bk.job.common.util.ip.IpUtils;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -162,6 +163,12 @@ public class ApplicationHostDTO {
      */
     private List<String> ipList = new ArrayList<>();
 
+    /**
+     * 主机所属拓扑路径信息（用于传递给前端展示）
+     */
+    @JsonIgnore
+    private List<HostTopoPathVO> topoPathList;
+
     public String getCloudVendorId() {
         if (cloudVendorId != null && cloudVendorId.length() > 64) {
             return cloudVendorId.substring(0, 64);
@@ -234,6 +241,7 @@ public class ApplicationHostDTO {
         hostInfoVO.setAlive(getAgentAliveValue());
         hostInfoVO.setAgentId(agentId);
         hostInfoVO.setCloudVendorName(cloudVendorName);
+        hostInfoVO.setTopoPathList(topoPathList);
         return hostInfoVO;
     }
 

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/vo/HostInfoVO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/vo/HostInfoVO.java
@@ -36,6 +36,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -90,6 +91,9 @@ public class HostInfoVO {
     @Schema(description = "所属云厂商")
     @JsonProperty("cloudVendor")
     private String cloudVendorName;
+
+    @Schema(description = "所属拓扑路径列表")
+    private List<HostTopoPathVO> topoPathList;
 
     public void validate() throws InvalidParamException {
         if (!JobContextUtil.isAllowMigration() && (hostId == null || hostId <= 0)) {

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/vo/HostTopoPathVO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/vo/HostTopoPathVO.java
@@ -1,0 +1,46 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.model.vo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 主机拓扑路径信息
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "主机拓扑路径信息")
+public class HostTopoPathVO {
+
+    @Schema(description = "集群名称")
+    private String setName;
+
+    @Schema(description = "模块名称")
+    private String moduleName;
+}

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebHostResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebHostResourceImpl.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.manage.api.web.impl;
 
 import com.tencent.bk.job.common.cc.model.InstanceTopologyDTO;
+import com.tencent.bk.job.common.constant.ResourceScopeTypeEnum;
 import com.tencent.bk.job.common.model.PageData;
 import com.tencent.bk.job.common.model.Response;
 import com.tencent.bk.job.common.model.dto.AppResourceScope;
@@ -57,6 +58,7 @@ import com.tencent.bk.job.manage.service.agent.statistics.ScopeAgentStatisticsSe
 import com.tencent.bk.job.manage.service.agent.statistics.ScopeDynamicGroupAgentStatisticsService;
 import com.tencent.bk.job.manage.service.agent.statistics.ScopeNodeAgentStatisticsService;
 import com.tencent.bk.job.manage.service.host.HostDetailService;
+import com.tencent.bk.job.manage.service.host.HostTopoPathService;
 import com.tencent.bk.job.manage.service.host.ScopeDynamicGroupHostService;
 import com.tencent.bk.job.manage.service.host.ScopeHostService;
 import com.tencent.bk.job.manage.service.host.ScopeTopoHostService;
@@ -91,6 +93,7 @@ public class WebHostResourceImpl implements WebHostResource {
     private final ScopeAgentStatisticsService scopeAgentStatisticsService;
     private final AgentStatusService agentStatusService;
     private final HostDetailService hostDetailService;
+    private final HostTopoPathService hostTopoPathService;
     private final ScopeDynamicGroupHostService scopeDynamicGroupHostService;
     private final ScopeDynamicGroupService scopeDynamicGroupService;
 
@@ -104,6 +107,7 @@ public class WebHostResourceImpl implements WebHostResource {
                                ScopeAgentStatisticsService scopeAgentStatisticsService,
                                AgentStatusService agentStatusService,
                                HostDetailService hostDetailService,
+                               HostTopoPathService hostTopoPathService,
                                ScopeDynamicGroupHostService bizDynamicGroupHostService,
                                ScopeDynamicGroupService scopeDynamicGroupService) {
         this.scopeTopoService = scopeTopoService;
@@ -115,6 +119,7 @@ public class WebHostResourceImpl implements WebHostResource {
         this.scopeAgentStatisticsService = scopeAgentStatisticsService;
         this.agentStatusService = agentStatusService;
         this.hostDetailService = hostDetailService;
+        this.hostTopoPathService = hostTopoPathService;
         this.scopeDynamicGroupHostService = bizDynamicGroupHostService;
         this.scopeDynamicGroupService = scopeDynamicGroupService;
     }
@@ -214,6 +219,7 @@ public class WebHostResourceImpl implements WebHostResource {
         );
         String tenantId = JobContextUtil.getTenantId();
         hostDetailService.fillDetailForApplicationHosts(tenantId, pageHostList.getData());
+        fillTopoPathIfBiz(tenantId, appResourceScope, pageHostList.getData());
         return Response.buildSuccessResp(PageUtil.transferPageData(
             pageHostList,
             ApplicationHostDTO::toVO
@@ -319,6 +325,7 @@ public class WebHostResourceImpl implements WebHostResource {
         if (CollectionUtils.isNotEmpty(pageData.getData())) {
             agentStatusService.fillRealTimeAgentStatus(pageData.getData());
         }
+        fillTopoPathIfBiz(tenantId, appResourceScope, pageData.getData());
         return Response.buildSuccessResp(PageUtil.transferPageData(pageData, ApplicationHostDTO::toVO));
     }
 
@@ -336,6 +343,7 @@ public class WebHostResourceImpl implements WebHostResource {
         hostDetailService.fillDetailForApplicationHosts(tenantId, hostDTOList);
         // 填充实时agent状态
         agentStatusService.fillRealTimeAgentStatus(hostDTOList);
+        fillTopoPathIfBiz(tenantId, appResourceScope, hostDTOList);
         List<HostInfoVO> hostList = hostDTOList.stream()
             .map(ApplicationHostDTO::toVO)
             .collect(Collectors.toList());
@@ -355,6 +363,7 @@ public class WebHostResourceImpl implements WebHostResource {
             .collect(Collectors.toList());
         String tenantId = JobContextUtil.getTenantId();
         List<ApplicationHostDTO> hostList = hostDetailService.listHostDetails(tenantId, appResourceScope, hostIds);
+        fillTopoPathIfBiz(tenantId, appResourceScope, hostList);
         // 排序：Agent异常机器在前，Agent正常机器在后
         List<HostInfoVO> hostInfoVOList = hostList.stream()
             .filter(hostDTO -> !hostDTO.getGseAgentAlive())
@@ -365,6 +374,22 @@ public class WebHostResourceImpl implements WebHostResource {
             .map(ApplicationHostDTO::toVO)
             .collect(Collectors.toList()));
         return Response.buildSuccessResp(hostInfoVOList);
+    }
+
+    /**
+     * 如果当前资源范围是业务类型，则为主机列表填充拓扑路径信息
+     */
+    private void fillTopoPathIfBiz(String tenantId,
+                                   AppResourceScope appResourceScope,
+                                   List<ApplicationHostDTO> hostList) {
+        if (CollectionUtils.isEmpty(hostList)) {
+            return;
+        }
+        if (appResourceScope.getType() != ResourceScopeTypeEnum.BIZ) {
+            return;
+        }
+        long bizId = Long.parseLong(appResourceScope.getId());
+        hostTopoPathService.fillTopoPathForHosts(tenantId, bizId, hostList);
     }
 
 }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/HostTopoPathService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/HostTopoPathService.java
@@ -1,0 +1,44 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.service.host;
+
+import com.tencent.bk.job.common.model.dto.ApplicationHostDTO;
+
+import java.util.List;
+
+/**
+ * 主机拓扑路径服务，为主机填充所属集群和模块名称信息
+ */
+public interface HostTopoPathService {
+
+    /**
+     * 为主机列表填充拓扑路径信息（所属集群/模块名称）
+     *
+     * @param tenantId 租户ID
+     * @param bizId    CMDB业务ID
+     * @param hostList 主机列表
+     */
+    void fillTopoPathForHosts(String tenantId, long bizId, List<ApplicationHostDTO> hostList);
+}

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/impl/HostTopoPathServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/impl/HostTopoPathServiceImpl.java
@@ -1,0 +1,134 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.service.host.impl;
+
+import com.tencent.bk.job.common.cc.model.InstanceTopologyDTO;
+import com.tencent.bk.job.common.cc.sdk.IBizCmdbClient;
+import com.tencent.bk.job.common.constant.CcNodeTypeEnum;
+import com.tencent.bk.job.common.model.dto.ApplicationHostDTO;
+import com.tencent.bk.job.common.model.vo.HostTopoPathVO;
+import com.tencent.bk.job.manage.dao.HostTopoDAO;
+import com.tencent.bk.job.manage.model.dto.HostTopoDTO;
+import com.tencent.bk.job.manage.service.host.HostTopoPathService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class HostTopoPathServiceImpl implements HostTopoPathService {
+
+    private final HostTopoDAO hostTopoDAO;
+    private final IBizCmdbClient bizCmdbClient;
+
+    @Autowired
+    public HostTopoPathServiceImpl(HostTopoDAO hostTopoDAO,
+                                   IBizCmdbClient bizCmdbClient) {
+        this.hostTopoDAO = hostTopoDAO;
+        this.bizCmdbClient = bizCmdbClient;
+    }
+
+    @Override
+    public void fillTopoPathForHosts(String tenantId, long bizId, List<ApplicationHostDTO> hostList) {
+        if (CollectionUtils.isEmpty(hostList)) {
+            return;
+        }
+
+        List<Long> hostIds = hostList.stream()
+            .map(ApplicationHostDTO::getHostId)
+            .collect(Collectors.toList());
+
+        // 1. 批量查询主机的拓扑关系
+        List<HostTopoDTO> hostTopoList = hostTopoDAO.listHostTopoByHostIds(hostIds);
+        if (CollectionUtils.isEmpty(hostTopoList)) {
+            return;
+        }
+
+        // 2. 按hostId分组
+        Map<Long, List<HostTopoDTO>> hostTopoMap = hostTopoList.stream()
+            .collect(Collectors.groupingBy(HostTopoDTO::getHostId));
+
+        // 3. 获取业务拓扑树，提取set和module的名称映射
+        Map<Long, String> setNameMap = new HashMap<>();
+        Map<Long, String> moduleNameMap = new HashMap<>();
+        try {
+            InstanceTopologyDTO topoTree = bizCmdbClient.getBizInstCompleteTopology(tenantId, bizId);
+            if (topoTree != null) {
+                extractNodeNames(topoTree, setNameMap, moduleNameMap);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to get biz topology for bizId={}, will fallback to show IDs", bizId, e);
+        }
+
+        // 4. 为每个主机组装拓扑路径信息
+        for (ApplicationHostDTO host : hostList) {
+            List<HostTopoDTO> topoRelations = hostTopoMap.get(host.getHostId());
+            if (CollectionUtils.isEmpty(topoRelations)) {
+                continue;
+            }
+            List<HostTopoPathVO> topoPathList = new ArrayList<>();
+            for (HostTopoDTO topoRelation : topoRelations) {
+                String setName = setNameMap.getOrDefault(
+                    topoRelation.getSetId(),
+                    String.valueOf(topoRelation.getSetId())
+                );
+                String moduleName = moduleNameMap.getOrDefault(
+                    topoRelation.getModuleId(),
+                    String.valueOf(topoRelation.getModuleId())
+                );
+                topoPathList.add(new HostTopoPathVO(setName, moduleName));
+            }
+            host.setTopoPathList(topoPathList);
+        }
+    }
+
+    /**
+     * 递归遍历拓扑树，提取set和module节点的ID→名称映射
+     */
+    private void extractNodeNames(InstanceTopologyDTO node,
+                                  Map<Long, String> setNameMap,
+                                  Map<Long, String> moduleNameMap) {
+        if (node == null) {
+            return;
+        }
+        if (CcNodeTypeEnum.SET.getType().equals(node.getObjectId())) {
+            setNameMap.put(node.getInstanceId(), node.getInstanceName());
+        } else if (CcNodeTypeEnum.MODULE.getType().equals(node.getObjectId())) {
+            moduleNameMap.put(node.getInstanceId(), node.getInstanceName());
+        }
+        if (CollectionUtils.isNotEmpty(node.getChild())) {
+            for (InstanceTopologyDTO child : node.getChild()) {
+                extractNodeNames(child, setNameMap, moduleNameMap);
+            }
+        }
+    }
+}

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/impl/HostTopoPathServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/impl/HostTopoPathServiceImpl.java
@@ -81,7 +81,7 @@ public class HostTopoPathServiceImpl implements HostTopoPathService {
         Map<Long, String> setNameMap = new HashMap<>();
         Map<Long, String> moduleNameMap = new HashMap<>();
         try {
-            InstanceTopologyDTO topoTree = bizCmdbClient.getBizInstCompleteTopology(tenantId, bizId);
+            InstanceTopologyDTO topoTree = bizCmdbClient.getBizInstTopologyPreferCache(tenantId, bizId);
             if (topoTree != null) {
                 extractNodeNames(topoTree, setNameMap, moduleNameMap);
             }


### PR DESCRIPTION
## 问题背景

目标服务器-静态拓扑中的节点列表，当前仅展示主机 IP 等基本信息，不支持展示主机所属的集群和模块，不便于用户识别和管理。

## 修改内容

为 job-manage 模块的 Web API 中所有返回 HostInfoVO 的主机列表接口增加 topoPathList 字段，支持前端展示主机所属拓扑信息（集群/模块名称）。

### 新增
- HostTopoPathVO：主机拓扑路径 VO（setName + moduleName）
- HostTopoPathService / HostTopoPathServiceImpl：拓扑路径查询服务，通过 host_topo 表获取主机拓扑关系，再通过 CMDB 拓扑树将 ID 解析为可读名称

### 修改
- HostInfoVO：新增 List<HostTopoPathVO> topoPathList 字段
- ApplicationHostDTO：新增 topoPathList 字段及 toVO() 映射
- WebHostResourceImpl：注入 HostTopoPathService，在 4 个主机列表接口中增加拓扑信息填充

### 受影响的接口
- 按拓扑节点查主机列表
- 主机详情
- 校验主机
- 动态分组查主机
