### PR TITLE
feat：目标服务器-静态拓扑中的节点列表，支持展示节点所属的集群和模块 #3973

### DIFF
--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizCmdbClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizCmdbClient.java
@@ -247,7 +247,7 @@ public class BizCmdbClient extends BaseCmdbClient implements IBizCmdbClient {
     }
 
     @Override
-    public InstanceTopologyDTO getBizInstTopology(String tenantId, long bizId) {
+    public InstanceTopologyDTO getBizInstTopologyPreferCache(String tenantId, long bizId) {
         return getCachedBizInstCompleteTopology(tenantId, bizId);
     }
 

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/IBizCmdbClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/IBizCmdbClient.java
@@ -61,15 +61,15 @@ import java.util.Set;
  */
 public interface IBizCmdbClient {
     /**
-     * 获取业务topo
+     * 优先从缓存获取业务完整拓扑树（含空闲机/故障机模块）
      *
      * @param tenantId 租户ID
      * @param bizId    cmdb业务ID
      */
-    InstanceTopologyDTO getBizInstTopology(String tenantId, long bizId);
+    InstanceTopologyDTO getBizInstTopologyPreferCache(String tenantId, long bizId);
 
     /**
-     * 获取业务完整拓扑树（含空闲机/故障机模块）
+     * 从CMDB接口获取业务完整拓扑树（含空闲机/故障机模块）
      *
      * @param tenantId 租户ID
      * @param bizId    cmdb业务ID

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/RetryableBizCmdbClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/RetryableBizCmdbClient.java
@@ -88,9 +88,9 @@ public class RetryableBizCmdbClient implements IBizCmdbClient {
     }
 
     @Override
-    public InstanceTopologyDTO getBizInstTopology(String tenantId, long bizId) {
+    public InstanceTopologyDTO getBizInstTopologyPreferCache(String tenantId, long bizId) {
         return retryExecutor.executeWithRetry(
-            () -> delegate.getBizInstTopology(tenantId, bizId),
+            () -> delegate.getBizInstTopologyPreferCache(tenantId, bizId),
             "getBizInstTopology"
         );
     }

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/RetryableBizCmdbClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/RetryableBizCmdbClient.java
@@ -91,7 +91,7 @@ public class RetryableBizCmdbClient implements IBizCmdbClient {
     public InstanceTopologyDTO getBizInstTopologyPreferCache(String tenantId, long bizId) {
         return retryExecutor.executeWithRetry(
             () -> delegate.getBizInstTopologyPreferCache(tenantId, bizId),
-            "getBizInstTopology"
+            "getBizInstTopologyPreferCache"
         );
     }
 

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/ApplicationHostDTO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/ApplicationHostDTO.java
@@ -329,6 +329,11 @@ public class ApplicationHostDTO {
         host.setOsType(osType);
         host.setOsTypeName(osTypeName);
         host.setHostname(hostName);
+        if (CollectionUtils.isNotEmpty(topoPathList)) {
+            host.setTopoPathList(topoPathList.stream()
+                .map(p -> new HostTopoPathDTO(p.getSetName(), p.getModuleName()))
+                .collect(Collectors.toList()));
+        }
         return host;
     }
 

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/ApplicationHostDTO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/ApplicationHostDTO.java
@@ -30,6 +30,8 @@ import com.tencent.bk.job.common.annotation.PersistenceObject;
 import com.tencent.bk.job.common.constant.JobConstants;
 import com.tencent.bk.job.common.model.vo.CloudAreaInfoVO;
 import com.tencent.bk.job.common.model.vo.HostInfoVO;
+import com.tencent.bk.job.common.model.vo.HostTopoPathVO;
+import org.apache.commons.collections4.CollectionUtils;
 import com.tencent.bk.job.common.util.ip.IpUtils;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -162,6 +164,12 @@ public class ApplicationHostDTO {
      */
     private List<String> ipList = new ArrayList<>();
 
+    /**
+     * 主机所属拓扑路径信息
+     */
+    @JsonIgnore
+    private List<HostTopoPathDTO> topoPathList;
+
     public String getCloudVendorId() {
         if (cloudVendorId != null && cloudVendorId.length() > 64) {
             return cloudVendorId.substring(0, 64);
@@ -234,6 +242,12 @@ public class ApplicationHostDTO {
         hostInfoVO.setAlive(getAgentAliveValue());
         hostInfoVO.setAgentId(agentId);
         hostInfoVO.setCloudVendorName(cloudVendorName);
+        if (CollectionUtils.isNotEmpty(topoPathList)) {
+            List<HostTopoPathVO> topoPathVOList = topoPathList.stream()
+                .map(dto -> new HostTopoPathVO(dto.getSetName(), dto.getModuleName()))
+                .collect(Collectors.toList());
+            hostInfoVO.setTopoPathList(topoPathVOList);
+        }
         return hostInfoVO;
     }
 

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/HostDTO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/HostDTO.java
@@ -32,16 +32,21 @@ import com.tencent.bk.job.common.model.HostCompositeKey;
 import com.tencent.bk.job.common.model.openapi.v4.OpenApiHostDTO;
 import com.tencent.bk.job.common.model.vo.CloudAreaInfoVO;
 import com.tencent.bk.job.common.model.vo.HostInfoVO;
+import com.tencent.bk.job.common.model.vo.HostTopoPathVO;
 import com.tencent.bk.job.common.util.ip.IpUtils;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.stream.Collectors;
 
 /**
  * 作业执行对象-主机模型
@@ -125,6 +130,11 @@ public class HostDTO implements Cloneable {
      * 所属云厂商名称
      */
     private String cloudVendorName;
+
+    /**
+     * 主机拓扑快照（集群名、模块名），随作业步骤/变量等执行目标 JSON 持久化，供历史展示
+     */
+    private List<HostTopoPathDTO> topoPathList;
 
     /**
      * 管控区域:IPv4
@@ -218,6 +228,11 @@ public class HostDTO implements Cloneable {
         hostInfoVO.setAlive(alive);
         hostInfoVO.setAgentId(agentId);
         hostInfoVO.setCloudVendorName(cloudVendorName);
+        if (CollectionUtils.isNotEmpty(topoPathList)) {
+            hostInfoVO.setTopoPathList(topoPathList.stream()
+                .map(dto -> new HostTopoPathVO(dto.getSetName(), dto.getModuleName()))
+                .collect(Collectors.toList()));
+        }
         return hostInfoVO;
     }
 
@@ -237,6 +252,12 @@ public class HostDTO implements Cloneable {
         hostDTO.setAlive(hostInfoVO.getAgentStatus());
         hostDTO.setOsName(hostInfoVO.getOsName());
         hostDTO.setOsTypeName(hostInfoVO.getOsTypeName());
+        if (CollectionUtils.isNotEmpty(hostInfoVO.getTopoPathList())) {
+            List<HostTopoPathDTO> pathList = hostInfoVO.getTopoPathList().stream()
+                .map(vo -> new HostTopoPathDTO(vo.getSetName(), vo.getModuleName()))
+                .collect(Collectors.toList());
+            hostDTO.setTopoPathList(pathList);
+        }
         return hostDTO;
     }
 
@@ -276,6 +297,11 @@ public class HostDTO implements Cloneable {
         clone.setIp(ip);
         clone.setIpv6(ipv6);
         clone.setAlive(alive);
+        if (CollectionUtils.isNotEmpty(topoPathList)) {
+            List<HostTopoPathDTO> pathClone = new ArrayList<>(topoPathList.size());
+            topoPathList.forEach(p -> pathClone.add(new HostTopoPathDTO(p.getSetName(), p.getModuleName())));
+            clone.setTopoPathList(pathClone);
+        }
         return clone;
     }
 
@@ -335,6 +361,7 @@ public class HostDTO implements Cloneable {
         this.cloudVendorId = host.getCloudVendorId();
         this.cloudVendorName = host.getCloudVendorName();
         this.hostname = host.getHostname();
+        this.topoPathList = host.getTopoPathList();
     }
 
     public OpenApiHostDTO toOpenApiHostDTO() {

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/HostTopoPathDTO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/dto/HostTopoPathDTO.java
@@ -1,0 +1,48 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 主机拓扑路径信息
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class HostTopoPathDTO {
+
+    /**
+     * 集群名称
+     */
+    private String setName;
+
+    /**
+     * 模块名称
+     */
+    private String moduleName;
+}

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/vo/HostInfoVO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/vo/HostInfoVO.java
@@ -36,6 +36,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -90,6 +91,9 @@ public class HostInfoVO {
     @Schema(description = "所属云厂商")
     @JsonProperty("cloudVendor")
     private String cloudVendorName;
+
+    @Schema(description = "所属拓扑路径列表")
+    private List<HostTopoPathVO> topoPathList;
 
     public void validate() throws InvalidParamException {
         if (!JobContextUtil.isAllowMigration() && (hostId == null || hostId <= 0)) {

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/vo/HostTopoPathVO.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/model/vo/HostTopoPathVO.java
@@ -1,0 +1,46 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.model.vo;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 主机拓扑路径信息
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "主机拓扑路径信息")
+public class HostTopoPathVO {
+
+    @Schema(description = "集群名称")
+    private String setName;
+
+    @Schema(description = "模块名称")
+    private String moduleName;
+}

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebHostResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebHostResourceImpl.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.manage.api.web.impl;
 
 import com.tencent.bk.job.common.cc.model.InstanceTopologyDTO;
+import com.tencent.bk.job.common.constant.ResourceScopeTypeEnum;
 import com.tencent.bk.job.common.model.PageData;
 import com.tencent.bk.job.common.model.Response;
 import com.tencent.bk.job.common.model.dto.AppResourceScope;
@@ -57,6 +58,7 @@ import com.tencent.bk.job.manage.service.agent.statistics.ScopeAgentStatisticsSe
 import com.tencent.bk.job.manage.service.agent.statistics.ScopeDynamicGroupAgentStatisticsService;
 import com.tencent.bk.job.manage.service.agent.statistics.ScopeNodeAgentStatisticsService;
 import com.tencent.bk.job.manage.service.host.HostDetailService;
+import com.tencent.bk.job.manage.service.host.HostTopoPathService;
 import com.tencent.bk.job.manage.service.host.ScopeDynamicGroupHostService;
 import com.tencent.bk.job.manage.service.host.ScopeHostService;
 import com.tencent.bk.job.manage.service.host.ScopeTopoHostService;
@@ -91,6 +93,7 @@ public class WebHostResourceImpl implements WebHostResource {
     private final ScopeAgentStatisticsService scopeAgentStatisticsService;
     private final AgentStatusService agentStatusService;
     private final HostDetailService hostDetailService;
+    private final HostTopoPathService hostTopoPathService;
     private final ScopeDynamicGroupHostService scopeDynamicGroupHostService;
     private final ScopeDynamicGroupService scopeDynamicGroupService;
 
@@ -104,6 +107,7 @@ public class WebHostResourceImpl implements WebHostResource {
                                ScopeAgentStatisticsService scopeAgentStatisticsService,
                                AgentStatusService agentStatusService,
                                HostDetailService hostDetailService,
+                               HostTopoPathService hostTopoPathService,
                                ScopeDynamicGroupHostService bizDynamicGroupHostService,
                                ScopeDynamicGroupService scopeDynamicGroupService) {
         this.scopeTopoService = scopeTopoService;
@@ -115,6 +119,7 @@ public class WebHostResourceImpl implements WebHostResource {
         this.scopeAgentStatisticsService = scopeAgentStatisticsService;
         this.agentStatusService = agentStatusService;
         this.hostDetailService = hostDetailService;
+        this.hostTopoPathService = hostTopoPathService;
         this.scopeDynamicGroupHostService = bizDynamicGroupHostService;
         this.scopeDynamicGroupService = scopeDynamicGroupService;
     }
@@ -214,6 +219,7 @@ public class WebHostResourceImpl implements WebHostResource {
         );
         String tenantId = JobContextUtil.getTenantId();
         hostDetailService.fillDetailForApplicationHosts(tenantId, pageHostList.getData());
+        fillTopoPathIfBiz(tenantId, appResourceScope, pageHostList.getData());
         return Response.buildSuccessResp(PageUtil.transferPageData(
             pageHostList,
             ApplicationHostDTO::toVO
@@ -319,6 +325,7 @@ public class WebHostResourceImpl implements WebHostResource {
         if (CollectionUtils.isNotEmpty(pageData.getData())) {
             agentStatusService.fillRealTimeAgentStatus(pageData.getData());
         }
+        fillTopoPathIfBiz(tenantId, appResourceScope, pageData.getData());
         return Response.buildSuccessResp(PageUtil.transferPageData(pageData, ApplicationHostDTO::toVO));
     }
 
@@ -336,6 +343,7 @@ public class WebHostResourceImpl implements WebHostResource {
         hostDetailService.fillDetailForApplicationHosts(tenantId, hostDTOList);
         // 填充实时agent状态
         agentStatusService.fillRealTimeAgentStatus(hostDTOList);
+        fillTopoPathIfBiz(tenantId, appResourceScope, hostDTOList);
         List<HostInfoVO> hostList = hostDTOList.stream()
             .map(ApplicationHostDTO::toVO)
             .collect(Collectors.toList());
@@ -355,6 +363,7 @@ public class WebHostResourceImpl implements WebHostResource {
             .collect(Collectors.toList());
         String tenantId = JobContextUtil.getTenantId();
         List<ApplicationHostDTO> hostList = hostDetailService.listHostDetails(tenantId, appResourceScope, hostIds);
+        fillTopoPathIfBiz(tenantId, appResourceScope, hostList);
         // 排序：Agent异常机器在前，Agent正常机器在后
         List<HostInfoVO> hostInfoVOList = hostList.stream()
             .filter(hostDTO -> !hostDTO.getGseAgentAlive())
@@ -365,6 +374,22 @@ public class WebHostResourceImpl implements WebHostResource {
             .map(ApplicationHostDTO::toVO)
             .collect(Collectors.toList()));
         return Response.buildSuccessResp(hostInfoVOList);
+    }
+
+    /**
+     * 如果当前资源范围是业务类型，则为主机列表填充拓扑路径信息
+     */
+    private void fillTopoPathIfBiz(String tenantId,
+                                   AppResourceScope appResourceScope,
+                                   List<ApplicationHostDTO> hostList) {
+        if (CollectionUtils.isEmpty(hostList)) {
+            return;
+        }
+        if (appResourceScope.getType() != ResourceScopeTypeEnum.BIZ) {
+            return;
+        }
+        long bizId = Long.parseLong(appResourceScope.getId());
+        hostTopoPathService.fillTopoPathForHosts(tenantId, bizId, hostList);
     }
 
 }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/common/TopologyHelper.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/common/TopologyHelper.java
@@ -184,7 +184,7 @@ public class TopologyHelper {
     }
 
     public InstanceTopologyDTO getTopologyTreeByApplication(ApplicationDTO applicationInfo) {
-        InstanceTopologyDTO instanceTopology = bizCmdbClient.getBizInstTopology(
+        InstanceTopologyDTO instanceTopology = bizCmdbClient.getBizInstTopologyPreferCache(
             applicationInfo.getTenantId(),
             Long.parseLong(applicationInfo.getScope().getId())
         );

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/config/ExecutorConfiguration.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/config/ExecutorConfiguration.java
@@ -33,6 +33,8 @@ import org.springframework.context.annotation.Configuration;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -41,6 +43,31 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Slf4j
 @Configuration(value = "jobManageExecutorConfig")
 public class ExecutorConfiguration {
+
+    /**
+     * 主机拓扑快照填充专用线程池：core=0、max=100、同步队列；满载时拒绝并打错误日志。
+     */
+    @Bean("hostTopoSnapshotExecutor")
+    public ThreadPoolExecutor hostTopoSnapshotExecutor(MeterRegistry meterRegistry) {
+        RejectedExecutionHandler rejectedHandler = (r, executor) -> log.error(
+            "hostTopoSnapshotExecutor task rejected, poolSize={}, activeCount={}, queueSize={}, completedTaskCount={}",
+            executor.getPoolSize(),
+            executor.getActiveCount(),
+            executor.getQueue().size(),
+            executor.getCompletedTaskCount()
+        );
+        return new WatchableThreadPoolExecutor(
+            meterRegistry,
+            "hostTopoSnapshotExecutor",
+            0,
+            100,
+            60L,
+            TimeUnit.SECONDS,
+            new SynchronousQueue<>(),
+            getThreadFactoryByNameAndSeq("hostTopoSnapshot-", new AtomicInteger(1)),
+            rejectedHandler
+        );
+    }
 
     @Bean("syncHostExecutor")
     public ThreadPoolExecutor syncHostExecutor(MeterRegistry meterRegistry) {

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/HostTopoPathService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/HostTopoPathService.java
@@ -1,0 +1,44 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.service.host;
+
+import com.tencent.bk.job.common.model.dto.ApplicationHostDTO;
+
+import java.util.List;
+
+/**
+ * 主机拓扑路径服务，为主机填充所属集群和模块名称信息
+ */
+public interface HostTopoPathService {
+
+    /**
+     * 为主机列表填充拓扑路径信息（所属集群/模块名称）
+     *
+     * @param tenantId 租户ID
+     * @param bizId    CMDB业务ID
+     * @param hostList 主机列表
+     */
+    void fillTopoPathForHosts(String tenantId, long bizId, List<ApplicationHostDTO> hostList);
+}

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/impl/HostTopoPathServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/impl/HostTopoPathServiceImpl.java
@@ -1,0 +1,135 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.service.host.impl;
+
+import com.tencent.bk.job.common.cc.model.InstanceTopologyDTO;
+import com.tencent.bk.job.common.cc.sdk.IBizCmdbClient;
+import com.tencent.bk.job.common.constant.CcNodeTypeEnum;
+import com.tencent.bk.job.common.model.dto.ApplicationHostDTO;
+import com.tencent.bk.job.common.model.dto.HostTopoPathDTO;
+import com.tencent.bk.job.manage.dao.HostTopoDAO;
+import com.tencent.bk.job.manage.model.dto.HostTopoDTO;
+import com.tencent.bk.job.manage.service.host.HostTopoPathService;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class HostTopoPathServiceImpl implements HostTopoPathService {
+
+    private final HostTopoDAO hostTopoDAO;
+    private final IBizCmdbClient bizCmdbClient;
+
+    @Autowired
+    public HostTopoPathServiceImpl(HostTopoDAO hostTopoDAO,
+                                   IBizCmdbClient bizCmdbClient) {
+        this.hostTopoDAO = hostTopoDAO;
+        this.bizCmdbClient = bizCmdbClient;
+    }
+
+    @Override
+    public void fillTopoPathForHosts(String tenantId, long bizId, List<ApplicationHostDTO> hostList) {
+        if (CollectionUtils.isEmpty(hostList)) {
+            return;
+        }
+
+        List<Long> hostIds = hostList.stream()
+            .map(ApplicationHostDTO::getHostId)
+            .collect(Collectors.toList());
+
+        // 1. 批量查询主机的拓扑关系
+        List<HostTopoDTO> hostTopoList = hostTopoDAO.listHostTopoByHostIds(hostIds);
+        if (CollectionUtils.isEmpty(hostTopoList)) {
+            return;
+        }
+
+        // 2. 按hostId分组
+        Map<Long, List<HostTopoDTO>> hostTopoMap = hostTopoList.stream()
+            .collect(Collectors.groupingBy(HostTopoDTO::getHostId));
+
+        // 3. 获取业务拓扑树，提取set和module的名称映射
+        Map<Long, String> setNameMap = new HashMap<>();
+        Map<Long, String> moduleNameMap = new HashMap<>();
+        try {
+            InstanceTopologyDTO topoTree = bizCmdbClient.getBizInstTopologyPreferCache(tenantId, bizId);
+            if (topoTree != null) {
+                extractNodeNames(topoTree, setNameMap, moduleNameMap);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to get biz topology for bizId={}, will fallback to show IDs", bizId, e);
+        }
+
+        // 4. 为每个主机组装拓扑路径信息
+        for (ApplicationHostDTO host : hostList) {
+            List<HostTopoDTO> topoRelations = hostTopoMap.get(host.getHostId());
+            if (CollectionUtils.isEmpty(topoRelations)) {
+                continue;
+            }
+            List<HostTopoPathDTO> topoPathList = new ArrayList<>();
+            for (HostTopoDTO topoRelation : topoRelations) {
+                // 拓扑树种不存在的主机可能为IP白名单主机，不展示其拓扑路径
+                String setName = setNameMap.getOrDefault(
+                    topoRelation.getSetId(),
+                    "-"
+                );
+                String moduleName = moduleNameMap.getOrDefault(
+                    topoRelation.getModuleId(),
+                    "-"
+                );
+                topoPathList.add(new HostTopoPathDTO(setName, moduleName));
+            }
+            host.setTopoPathList(topoPathList);
+        }
+    }
+
+    /**
+     * 递归遍历拓扑树，提取set和module节点的ID→名称映射
+     */
+    private void extractNodeNames(InstanceTopologyDTO node,
+                                  Map<Long, String> setNameMap,
+                                  Map<Long, String> moduleNameMap) {
+        if (node == null) {
+            return;
+        }
+        if (CcNodeTypeEnum.SET.getType().equals(node.getObjectId())) {
+            setNameMap.put(node.getInstanceId(), node.getInstanceName());
+        } else if (CcNodeTypeEnum.MODULE.getType().equals(node.getObjectId())) {
+            moduleNameMap.put(node.getInstanceId(), node.getInstanceName());
+        }
+        if (CollectionUtils.isNotEmpty(node.getChild())) {
+            for (InstanceTopologyDTO child : node.getChild()) {
+                extractNodeNames(child, setNameMap, moduleNameMap);
+            }
+        }
+    }
+}

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/impl/HostTopoPathServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/impl/HostTopoPathServiceImpl.java
@@ -97,7 +97,7 @@ public class HostTopoPathServiceImpl implements HostTopoPathService {
             }
             List<HostTopoPathDTO> topoPathList = new ArrayList<>();
             for (HostTopoDTO topoRelation : topoRelations) {
-                // 拓扑树种不存在的主机可能为IP白名单主机，不展示其拓扑路径
+                // 拓扑树中不存在的主机可能为IP白名单主机，不展示其拓扑路径
                 String setName = setNameMap.getOrDefault(
                     topoRelation.getSetId(),
                     "-"

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/impl/TenantHostServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/impl/TenantHostServiceImpl.java
@@ -32,6 +32,7 @@ import com.tencent.bk.job.common.util.ip.IpUtils;
 import com.tencent.bk.job.manage.dao.TenantHostDAO;
 import com.tencent.bk.job.manage.model.inner.ServiceListAppHostResultDTO;
 import com.tencent.bk.job.manage.service.ApplicationService;
+import com.tencent.bk.job.manage.service.host.HostTopoPathService;
 import com.tencent.bk.job.manage.service.host.TenantHostService;
 import com.tencent.bk.job.manage.service.host.strategy.TenantListHostStrategy;
 import com.tencent.bk.job.manage.service.host.strategy.TenantListHostStrategyService;
@@ -40,6 +41,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StopWatch;
 
@@ -50,6 +52,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 /**
@@ -60,21 +68,29 @@ import java.util.stream.Collectors;
 @Service
 public class TenantHostServiceImpl extends BaseHostService implements TenantHostService {
 
+    private static final long FILL_HOST_TOPO_SNAPSHOT_TIMEOUT_SEC = 5L;
+
     private final TenantHostDAO tenantHostDAO;
     private final ApplicationService applicationService;
     private final IBizCmdbClient bizCmdbClient;
     private final TenantListHostStrategyService tenantListHostStrategyService;
+    private final HostTopoPathService hostTopoPathService;
+    private final ThreadPoolExecutor hostTopoSnapshotExecutor;
 
     @Autowired
     public TenantHostServiceImpl(TenantHostDAO tenantHostDAO,
                                  ApplicationService applicationService,
                                  IBizCmdbClient bizCmdbClient,
-                                 TenantListHostStrategyService tenantListHostStrategyService) {
+                                 TenantListHostStrategyService tenantListHostStrategyService,
+                                 HostTopoPathService hostTopoPathService,
+                                 @Qualifier("hostTopoSnapshotExecutor") ThreadPoolExecutor hostTopoSnapshotExecutor) {
         super(tenantListHostStrategyService);
         this.tenantHostDAO = tenantHostDAO;
         this.applicationService = applicationService;
         this.bizCmdbClient = bizCmdbClient;
         this.tenantListHostStrategyService = tenantListHostStrategyService;
+        this.hostTopoPathService = hostTopoPathService;
+        this.hostTopoSnapshotExecutor = hostTopoSnapshotExecutor;
     }
 
     private List<Long> buildIncludeBizIdList(ApplicationDTO application) {
@@ -158,6 +174,12 @@ public class TenantHostServiceImpl extends BaseHostService implements TenantHost
             watch.start("refreshHostAgentIdIfNeed");
             refreshHostAgentIdIfNeed(tenantId, refreshAgentId, existHosts);
             watch.stop();
+
+            if (CollectionUtils.isNotEmpty(existHosts)) {
+                watch.start("fillHostTopoPathSnapshot");
+                fillHostTopoPathSnapshotForExistHostsWithTimeout(tenantId, appId, application, existHosts);
+                watch.stop();
+            }
 
             List<HostDTO> validHosts = new ArrayList<>();
             List<HostDTO> notInAppHosts = new ArrayList<>();
@@ -264,6 +286,72 @@ public class TenantHostServiceImpl extends BaseHostService implements TenantHost
                     cmdbValidHosts
                 );
             }
+        }
+    }
+
+    /**
+     * 使用独立线程池提交拓扑快照填充，主线程最多等待 5 秒；
+     * 超时或异常时取消任务并跳过，不影响任务执行主流程。
+     */
+    private void fillHostTopoPathSnapshotForExistHostsWithTimeout(String tenantId,
+                                                                  Long appId,
+                                                                  ApplicationDTO application,
+                                                                  List<ApplicationHostDTO> existHosts) {
+        Future<?> future = null;
+        try {
+            future = hostTopoSnapshotExecutor.submit(() ->
+                fillHostTopoPathSnapshotForExistHosts(tenantId, application, existHosts));
+            future.get(FILL_HOST_TOPO_SNAPSHOT_TIMEOUT_SEC, TimeUnit.SECONDS);
+        } catch (RejectedExecutionException e) {
+            log.error("fillHostTopoPathSnapshot task rejected by hostTopoSnapshotExecutor, appId={}", appId, e);
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            log.warn(
+                "fillHostTopoPathSnapshot exceeded {}s, cancelled. appId={}",
+                FILL_HOST_TOPO_SNAPSHOT_TIMEOUT_SEC,
+                appId,
+                e
+            );
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            if (!future.isDone()) {
+                future.cancel(true);
+            }
+            log.warn("fillHostTopoPathSnapshot interrupted, skipped. appId={}", appId, e);
+        } catch (ExecutionException e) {
+            log.warn("fillHostTopoPathSnapshot execution failed, skipped. appId={}", appId, e.getCause());
+        } catch (Exception e) {
+            if (future != null && !future.isDone()) {
+                future.cancel(true);
+            }
+            log.warn("fillHostTopoPathSnapshot failed, skipped. appId={}", appId, e);
+        }
+    }
+
+    /**
+     * 在 listHostsFromCacheOrCmdb 已返回的主机详情上填充拓扑路径（集群/模块名），供下游序列化为执行目标快照；
+     * 仅处理当前 Job 应用范围内的 CMDB 业务（与 {@link #buildIncludeBizIdList} 一致），其他业务下的主机（如白名单）不填充。
+     */
+    private void fillHostTopoPathSnapshotForExistHosts(String tenantId,
+                                                       ApplicationDTO application,
+                                                       List<ApplicationHostDTO> existHosts) {
+        List<Long> includeBizIds = buildIncludeBizIdList(application);
+        if (CollectionUtils.isEmpty(includeBizIds)) {
+            return;
+        }
+        List<ApplicationHostDTO> hostsInCurrentApp = existHosts.stream()
+            .filter(hostDTO ->
+                hostDTO.getBizId() != null
+                    && hostDTO.getBizId() > 0
+                    && includeBizIds.contains(hostDTO.getBizId())
+            ).collect(Collectors.toList());
+        if (CollectionUtils.isEmpty(hostsInCurrentApp)) {
+            return;
+        }
+        Map<Long, List<ApplicationHostDTO>> hostsByCmdbBizId =
+            hostsInCurrentApp.stream().collect(Collectors.groupingBy(ApplicationHostDTO::getBizId));
+        for (Map.Entry<Long, List<ApplicationHostDTO>> entry : hostsByCmdbBizId.entrySet()) {
+            hostTopoPathService.fillTopoPathForHosts(tenantId, entry.getKey(), entry.getValue());
         }
     }
 

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/topo/impl/BizTopoServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/topo/impl/BizTopoServiceImpl.java
@@ -56,7 +56,7 @@ public class BizTopoServiceImpl implements BizTopoService {
                                                              Long bizId,
                                                              List<InstanceTopologyDTO> nodeList) {
         // 查业务拓扑树
-        InstanceTopologyDTO appTopologyTree = bizCmdbClient.getBizInstTopology(tenantId, bizId);
+        InstanceTopologyDTO appTopologyTree = bizCmdbClient.getBizInstTopologyPreferCache(tenantId, bizId);
         // 搜索路径
         return TopologyHelper.findTopoPaths(appTopologyTree, nodeList);
     }
@@ -78,7 +78,7 @@ public class BizTopoServiceImpl implements BizTopoService {
         }
         List<Long> moduleIds = new ArrayList<>();
         // 查业务拓扑树
-        InstanceTopologyDTO appTopologyTree = bizCmdbClient.getBizInstTopology(tenantId, bizId);
+        InstanceTopologyDTO appTopologyTree = bizCmdbClient.getBizInstTopologyPreferCache(tenantId, bizId);
         for (BizTopoNode treeNode : appTopoNodeList) {
             CcInstanceDTO ccInstanceDTO = new CcInstanceDTO(treeNode.getObjectId(), treeNode.getInstanceId());
             // 查拓扑节点完整信息


### PR DESCRIPTION
## 问题背景

目标服务器-静态拓扑中的节点列表，当前仅展示主机 IP 等基本信息，不支持展示主机所属的集群和模块，不便于用户识别和管理。

## 修改内容

1. 为 job-manage 模块的 Web API 中所有返回 HostInfoVO 的主机列表接口增加 topoPathList 字段，支持前端展示主机所属拓扑信息（集群/模块名称）；
2. 步骤快照数据添加主机拓扑路径。