### PR TITLE
perf: 跨业务共享文件源优化 #4257

### DIFF
--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/api/inner/ServiceFileSourceResourceImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/api/inner/ServiceFileSourceResourceImpl.java
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 
 @Slf4j
 @RestController
@@ -51,9 +52,24 @@ public class ServiceFileSourceResourceImpl implements ServiceFileSourceResource 
         if (null != fileSourceDTO) {
             return InternalResponse.buildSuccessResp(fileSourceDTO.getId());
         }
-        fileSourceDTO = noTenantFileSourceDAO.getFileSourceByCode(code);
-        if (null != fileSourceDTO && fileSourceDTO.canUseByAppId(appId)) {
-            return InternalResponse.buildSuccessResp(fileSourceDTO.getId());
+        List<FileSourceDTO> fileSourceDTOList = noTenantFileSourceDAO.listFileSourceByCode(code);
+        FileSourceDTO matchedFileSource = null;
+        int matchCount = 0;
+        for (FileSourceDTO source : fileSourceDTOList) {
+            if (source.canUseByAppId(appId)) {
+                matchCount++;
+                if (matchedFileSource == null) {
+                    matchedFileSource = source;
+                }
+            }
+        }
+        if (matchedFileSource != null) {
+            if (matchCount > 1) {
+                log.warn("Multiple file-sources matched by appId and code, appId={}, code={}, matchCount={},"
+                        + " use fileSourceId={}",
+                    appId, code, matchCount, matchedFileSource.getId());
+            }
+            return InternalResponse.buildSuccessResp(matchedFileSource.getId());
         }
         throw new NotFoundException(ErrorCode.FAIL_TO_FIND_FILE_SOURCE_BY_CODE, new String[]{code});
     }

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/NoTenantFileSourceDAO.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/NoTenantFileSourceDAO.java
@@ -39,6 +39,8 @@ public interface NoTenantFileSourceDAO {
 
     FileSourceDTO getFileSourceByCode(String code);
 
+    List<FileSourceDTO> listFileSourceByCode(String code);
+
     FileSourceDTO getFileSourceByCode(Long appId, String code);
 
     List<FileSourceDTO> listEnabledFileSource(Integer start, Integer pageSize);

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/NoTenantFileSourceDAO.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/NoTenantFileSourceDAO.java
@@ -37,8 +37,6 @@ public interface NoTenantFileSourceDAO {
 
     FileSourceDTO getFileSourceById(Integer id);
 
-    FileSourceDTO getFileSourceByCode(String code);
-
     List<FileSourceDTO> listFileSourceByCode(String code);
 
     FileSourceDTO getFileSourceByCode(Long appId, String code);

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/impl/NoTenantFileSourceDAOImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/impl/NoTenantFileSourceDAOImpl.java
@@ -92,15 +92,21 @@ public class NoTenantFileSourceDAOImpl extends BaseFileSourceDAOImpl implements 
 
     @Override
     public FileSourceDTO getFileSourceByCode(String code) {
-        val record = dslContext.select(ALL_FIELDS)
+        List<FileSourceDTO> fileSources = listFileSourceByCode(code);
+        if (fileSources.isEmpty()) {
+            return null;
+        }
+        return fileSources.get(0);
+    }
+
+    @Override
+    public List<FileSourceDTO> listFileSourceByCode(String code) {
+        val records = dslContext.select(ALL_FIELDS)
             .from(defaultTable)
             .where(buildCodeConditions(code))
-            .fetchOne();
-        if (record == null) {
-            return null;
-        } else {
-            return convertRecordToDto(record);
-        }
+            .orderBy(defaultTable.ID.asc())
+            .fetch();
+        return records.map(this::convertRecordToDto);
     }
 
     private List<Condition> buildCodeConditions(String code) {

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/impl/NoTenantFileSourceDAOImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/dao/filesource/impl/NoTenantFileSourceDAOImpl.java
@@ -91,15 +91,6 @@ public class NoTenantFileSourceDAOImpl extends BaseFileSourceDAOImpl implements 
     }
 
     @Override
-    public FileSourceDTO getFileSourceByCode(String code) {
-        List<FileSourceDTO> fileSources = listFileSourceByCode(code);
-        if (fileSources.isEmpty()) {
-            return null;
-        }
-        return fileSources.get(0);
-    }
-
-    @Override
     public List<FileSourceDTO> listFileSourceByCode(String code) {
         val records = dslContext.select(ALL_FIELDS)
             .from(defaultTable)


### PR DESCRIPTION
## 问题背景
需要支持多个业务向同一个业务共享 code 相同的文件源，避免同 code 多条记录时查询异常，并确保按业务可用性命中正确文件源。

## 修改内容
- DAO 新增按 code 查询列表能力，规避同 code 多条记录触发单条查询异常。
- 内部接口改为从同 code 候选中按 appId 可用性筛选命中，并在多匹配时输出告警日志。