### PR TITLE
perf: 服务状态接口性能优化 #2613

### DIFF
--- a/op-tools/bk-job-op/support-files/Dockerfile
+++ b/op-tools/bk-job-op/support-files/Dockerfile
@@ -1,7 +1,7 @@
-FROM bkjob/jdk17:3.11.11
+FROM bkjob/jdk17:3.12.3
 
 LABEL maintainer="Tencent BlueKing Job"
-LABEL dockerfile.version="1.0.0"
+LABEL dockerfile.version="1.0.1"
 
 ARG MODULE=bk-job-op
 

--- a/src/backend/commons/common-k8s/build.gradle
+++ b/src/backend/commons/common-k8s/build.gradle
@@ -27,4 +27,6 @@ dependencies {
     api 'org.apache.httpcomponents:httpcore'
     api "org.springframework.cloud:spring-cloud-starter-kubernetes-client-all"
     api 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.mockito:mockito-core'
 }

--- a/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/config/K8sServiceInfoServiceAutoConfiguration.java
+++ b/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/config/K8sServiceInfoServiceAutoConfiguration.java
@@ -1,22 +1,56 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
 package com.tencent.bk.job.common.k8s.config;
 
 import com.tencent.bk.job.common.discovery.ServiceInfoProvider;
 import com.tencent.bk.job.common.k8s.provider.K8SServiceInfoProvider;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.cloud.CloudPlatform;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.kubernetes.client.KubernetesClientAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * K8S 服务实例信息提供器自动装配。
+ * <p>
+ * 复用 {@link KubernetesClientAutoConfiguration} 暴露的单例 CoreV1Api（背后是单例 ApiClient/OkHttpClient），
+ * 避免在高频健康检查场景下反复 new ApiClient 导致 OkHttp 线程池/连接池累积。
+ */
 @Configuration
 @ConditionalOnMissingClass("org.springframework.cloud.consul.discovery.ConsulDiscoveryClient")
 @ConditionalOnCloudPlatform(CloudPlatform.KUBERNETES)
+@AutoConfigureAfter(KubernetesClientAutoConfiguration.class)
 public class K8sServiceInfoServiceAutoConfiguration {
 
     @Bean
-    public ServiceInfoProvider k8sServiceInfoService(DiscoveryClient discoveryClient) {
-        return new K8SServiceInfoProvider(discoveryClient);
+    public ServiceInfoProvider k8sServiceInfoService(DiscoveryClient discoveryClient, CoreV1Api coreV1Api) {
+        return new K8SServiceInfoProvider(discoveryClient, coreV1Api);
     }
 
 }

--- a/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/config/K8sServiceInfoServiceAutoConfiguration.java
+++ b/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/config/K8sServiceInfoServiceAutoConfiguration.java
@@ -26,7 +26,11 @@ package com.tencent.bk.job.common.k8s.config;
 
 import com.tencent.bk.job.common.discovery.ServiceInfoProvider;
 import com.tencent.bk.job.common.k8s.provider.K8SServiceInfoProvider;
+import io.kubernetes.client.informer.cache.Lister;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Service;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnCloudPlatform;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
@@ -40,17 +44,35 @@ import org.springframework.context.annotation.Configuration;
  * K8S 服务实例信息提供器自动装配。
  * <p>
  * 复用 {@link KubernetesClientAutoConfiguration} 暴露的单例 CoreV1Api（背后是单例 ApiClient/OkHttpClient），
- * 避免在高频健康检查场景下反复 new ApiClient 导致 OkHttp 线程池/连接池累积。
+ * 避免在高频健康检查场景下反复 new ApiClient 导致 OkHttp 线程池/连接池累积；
+ * 同时复用 {@link JobK8sDiscoveryClientAutoConfiguration} 注入的 {@code servicesLister} 本地缓存，
+ * 用于按 {@code app.kubernetes.io/name=bk-job} 标签精确筛选作业平台 Service。
  */
 @Configuration
 @ConditionalOnMissingClass("org.springframework.cloud.consul.discovery.ConsulDiscoveryClient")
 @ConditionalOnCloudPlatform(CloudPlatform.KUBERNETES)
-@AutoConfigureAfter(KubernetesClientAutoConfiguration.class)
+@AutoConfigureAfter({KubernetesClientAutoConfiguration.class, JobK8sDiscoveryClientAutoConfiguration.class})
 public class K8sServiceInfoServiceAutoConfiguration {
 
+    /**
+     * 装配 {@link K8SServiceInfoProvider}：使用 {@link ObjectProvider} 包装 {@code servicesLister}，
+     * 即使该 Bean 在某些条件下不可用（informer 装配链路被关闭等），仍可降级到名称兜底路径，
+     * 避免装配失败影响其它健康检查能力。
+     */
     @Bean
-    public ServiceInfoProvider k8sServiceInfoService(DiscoveryClient discoveryClient, CoreV1Api coreV1Api) {
-        return new K8SServiceInfoProvider(discoveryClient, coreV1Api);
+    public ServiceInfoProvider k8sServiceInfoService(
+        DiscoveryClient discoveryClient,
+        CoreV1Api coreV1Api,
+        @Qualifier("servicesLister") ObjectProvider<Lister<V1Service>> servicesListerProvider
+    ) {
+        Lister<V1Service> servicesLister = servicesListerProvider.getIfAvailable();
+        return new K8SServiceInfoProvider(
+            discoveryClient,
+            coreV1Api,
+            K8SServiceInfoProvider.DEFAULT_POD_CACHE_TTL_MS,
+            K8SServiceInfoProvider.DEFAULT_POD_LABEL_SELECTOR,
+            servicesLister
+        );
     }
 
 }

--- a/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/provider/K8SServiceInfoProvider.java
+++ b/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/provider/K8SServiceInfoProvider.java
@@ -27,12 +27,14 @@ package com.tencent.bk.job.common.k8s.provider;
 import com.tencent.bk.job.common.discovery.ServiceInfoProvider;
 import com.tencent.bk.job.common.discovery.model.ServiceInstanceInfoDTO;
 import com.tencent.bk.job.common.util.json.JsonUtils;
+import io.kubernetes.client.informer.cache.Lister;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1PodStatus;
+import io.kubernetes.client.openapi.models.V1Service;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -59,7 +61,12 @@ import java.util.stream.Collectors;
  * 2. 每次 listServiceInfo 在每个命名空间内仅触发一次 listNamespacedPod；
  * 3. 命名空间维度的进程内 TTL 缓存（默认 5 秒），TTL 内重复触发命中缓存；
  * 4. listNamespacedPod 透传 labelSelector（默认 {@link #DEFAULT_POD_LABEL_SELECTOR}），
- *    apiserver 侧即裁剪掉非作业平台 Pod，减少返回体积与本进程反序列化开销。
+ *    apiserver 侧即裁剪掉非作业平台 Pod，减少返回体积与本进程反序列化开销；
+ * 5. 服务过滤主路径直接复用 spring-cloud-kubernetes 的 informer 本地缓存
+ *    （{@link Lister}&lt;{@link V1Service}&gt;），按 {@value #SERVICE_LABEL_APP_KUBERNETES_IO_NAME}=
+ *    {@value #SERVICE_LABEL_APP_KUBERNETES_IO_NAME_VALUE_BK_JOB} 标签精确筛选作业平台 Service，
+ *    避免按服务名 contains("job-") 误命中其它项目；informer 未注入或未 sync 完成时回退到
+ *    {@link DiscoveryClient#getServices()} + 名称前缀兜底，避免启动期短暂空窗。
  */
 @Slf4j
 public class K8SServiceInfoProvider implements ServiceInfoProvider {
@@ -82,6 +89,27 @@ public class K8SServiceInfoProvider implements ServiceInfoProvider {
      */
     public static final String DEFAULT_POD_LABEL_SELECTOR = "app.kubernetes.io/name=bk-job";
 
+    /**
+     * 作业平台 Service / Pod 共享的 {@code app.kubernetes.io/name} 标签 key，
+     * 与 Helm Chart 中 {@code _helpers.tpl} 的 selectorLabels 保持一致。
+     */
+    public static final String SERVICE_LABEL_APP_KUBERNETES_IO_NAME = "app.kubernetes.io/name";
+    /**
+     * 作业平台 Service 的 {@code app.kubernetes.io/name} 标签值，与 {@link #DEFAULT_POD_LABEL_SELECTOR}
+     * 中的取值保持同源。
+     */
+    public static final String SERVICE_LABEL_APP_KUBERNETES_IO_NAME_VALUE_BK_JOB = "bk-job";
+
+    /**
+     * 兜底路径（informer 未启动 / 未 sync 时）使用的服务名包含子串，与历史实现保持一致。
+     */
+    public static final String FALLBACK_JOB_SERVICE_NAME_KEYWORD = "job-";
+
+    /**
+     * 主路径与兜底路径都需过滤掉的网关管理服务名子串。
+     */
+    public static final String SERVICE_NAME_GATEWAY_MANAGEMENT = "job-gateway-management";
+
     private final DiscoveryClient discoveryClient;
     private final CoreV1Api coreV1Api;
     private final long podCacheTtlMs;
@@ -90,27 +118,42 @@ public class K8SServiceInfoProvider implements ServiceInfoProvider {
      * 允许通过构造器在装配/测试时覆写，未传时使用 {@link #DEFAULT_POD_LABEL_SELECTOR}。
      */
     private final String podLabelSelector;
+    /**
+     * spring-cloud-kubernetes informer 维护的 Service 本地缓存。可为 {@code null}：
+     * 表示当前装配链路下无可用 Lister（如 ConsulDiscoveryClient 场景或测试场景），
+     * 此时主路径自动降级到旧的名称兜底逻辑。
+     */
+    private final Lister<V1Service> servicesLister;
     private final ConcurrentHashMap<String, PodCacheEntry> podCacheByNamespace = new ConcurrentHashMap<>();
 
     public K8SServiceInfoProvider(DiscoveryClient discoveryClient, CoreV1Api coreV1Api) {
-        this(discoveryClient, coreV1Api, DEFAULT_POD_CACHE_TTL_MS, DEFAULT_POD_LABEL_SELECTOR);
+        this(discoveryClient, coreV1Api, DEFAULT_POD_CACHE_TTL_MS, DEFAULT_POD_LABEL_SELECTOR, null);
     }
 
     public K8SServiceInfoProvider(DiscoveryClient discoveryClient, CoreV1Api coreV1Api, long podCacheTtlMs) {
-        this(discoveryClient, coreV1Api, podCacheTtlMs, DEFAULT_POD_LABEL_SELECTOR);
+        this(discoveryClient, coreV1Api, podCacheTtlMs, DEFAULT_POD_LABEL_SELECTOR, null);
     }
 
     public K8SServiceInfoProvider(DiscoveryClient discoveryClient,
                                   CoreV1Api coreV1Api,
                                   long podCacheTtlMs,
                                   String podLabelSelector) {
+        this(discoveryClient, coreV1Api, podCacheTtlMs, podLabelSelector, null);
+    }
+
+    public K8SServiceInfoProvider(DiscoveryClient discoveryClient,
+                                  CoreV1Api coreV1Api,
+                                  long podCacheTtlMs,
+                                  String podLabelSelector,
+                                  Lister<V1Service> servicesLister) {
         this.discoveryClient = discoveryClient;
         this.coreV1Api = coreV1Api;
         this.podCacheTtlMs = podCacheTtlMs;
         this.podLabelSelector = podLabelSelector;
+        this.servicesLister = servicesLister;
         log.info(
-            "K8SServiceInfoProvider inited, podCacheTtlMs={}, podLabelSelector={}",
-            podCacheTtlMs, podLabelSelector
+            "K8SServiceInfoProvider inited, podCacheTtlMs={}, podLabelSelector={}, servicesListerInjected={}",
+            podCacheTtlMs, podLabelSelector, servicesLister != null
         );
     }
 
@@ -143,12 +186,112 @@ public class K8SServiceInfoProvider implements ServiceInfoProvider {
             .collect(Collectors.toList());
     }
 
+    /**
+     * 列出作业平台所有服务实例。
+     * <p>
+     * 主路径：从 informer 本地 Service 缓存按 {@value #SERVICE_LABEL_APP_KUBERNETES_IO_NAME}=
+     * {@value #SERVICE_LABEL_APP_KUBERNETES_IO_NAME_VALUE_BK_JOB} 标签筛选 Service，再用每个命中
+     * Service 的 metadata.name 作为 serviceId 调用 {@link DiscoveryClient#getInstances(String)}；
+     * 主路径内即过滤掉 {@value #SERVICE_NAME_GATEWAY_MANAGEMENT}（与现状一致），后续
+     * {@link #isJobServiceInstance(ServiceInstance)} 还会再次确认。
+     * <p>
+     * 兜底路径：当 informer 未启动 / 未 sync 完成（servicesLister 为 null、抛异常或 list 返回空）时，
+     * 回退到 {@link DiscoveryClient#getServices()} + 服务名 contains
+     * {@value #FALLBACK_JOB_SERVICE_NAME_KEYWORD} 的旧逻辑，避免启动期短暂空窗导致 listAll 返回空。
+     */
     private List<ServiceInstance> listJobServiceInstances() {
-        String jobServiceSymbol = "job-";
+        List<String> jobServiceIds = listJobServiceIdsByLabel();
+        if (jobServiceIds == null) {
+            return listJobServiceInstancesByNameFallback();
+        }
+        List<ServiceInstance> serviceInstanceList = new ArrayList<>();
+        for (String serviceId : jobServiceIds) {
+            serviceInstanceList.addAll(discoveryClient.getInstances(serviceId));
+        }
+        return serviceInstanceList;
+    }
+
+    /**
+     * 通过 servicesLister 按标签筛选作业平台 Service，返回服务名列表。
+     * <ul>
+     *   <li>返回 {@code null}：lister 为 null / list() 抛异常 / list() 返回 null 或空集合，
+     *       说明 informer 未注入或未 sync 完成，调用方需走兜底路径；</li>
+     *   <li>返回非 null 列表（即使为空）：说明 lister 可读，空列表是合法结果（确实没有匹配 Service）。</li>
+     * </ul>
+     */
+    private List<String> listJobServiceIdsByLabel() {
+        if (servicesLister == null) {
+            log.warn(
+                "servicesLister is not injected, fallback to discoveryClient.getServices() + name contains \"{}\"",
+                FALLBACK_JOB_SERVICE_NAME_KEYWORD
+            );
+            return null;
+        }
+        List<V1Service> services;
+        try {
+            services = servicesLister.list();
+        } catch (Throwable t) {
+            log.warn(
+                "Fail to list services from servicesLister, "
+                    + "fallback to discoveryClient.getServices() + name contains \"{}\"",
+                FALLBACK_JOB_SERVICE_NAME_KEYWORD, t
+            );
+            return null;
+        }
+        if (CollectionUtils.isEmpty(services)) {
+            log.warn(
+                "servicesLister returned empty result (informer not synced?), "
+                    + "fallback to discoveryClient.getServices() + name contains \"{}\"",
+                FALLBACK_JOB_SERVICE_NAME_KEYWORD
+            );
+            return null;
+        }
+        List<String> serviceIds = new ArrayList<>();
+        for (V1Service service : services) {
+            String serviceId = extractBkJobServiceName(service);
+            if (serviceId == null) {
+                continue;
+            }
+            // 主路径与兜底路径一致：保留对 job-gateway-management 的过滤
+            if (serviceId.contains(SERVICE_NAME_GATEWAY_MANAGEMENT)) {
+                continue;
+            }
+            serviceIds.add(serviceId);
+        }
+        return serviceIds;
+    }
+
+    /**
+     * 提取 V1Service 中带 {@value #SERVICE_LABEL_APP_KUBERNETES_IO_NAME}=
+     * {@value #SERVICE_LABEL_APP_KUBERNETES_IO_NAME_VALUE_BK_JOB} 标签的服务名；
+     * 标签缺失或值不匹配返回 {@code null}。
+     */
+    private String extractBkJobServiceName(V1Service service) {
+        if (service == null) {
+            return null;
+        }
+        V1ObjectMeta metadata = service.getMetadata();
+        if (metadata == null
+            || metadata.getLabels() == null
+            || StringUtils.isBlank(metadata.getName())) {
+            return null;
+        }
+        String labelValue = metadata.getLabels().get(SERVICE_LABEL_APP_KUBERNETES_IO_NAME);
+        if (!SERVICE_LABEL_APP_KUBERNETES_IO_NAME_VALUE_BK_JOB.equals(labelValue)) {
+            return null;
+        }
+        return metadata.getName();
+    }
+
+    /**
+     * 兜底路径：保留历史的 {@code discoveryClient.getServices()} + 服务名 contains
+     * {@value #FALLBACK_JOB_SERVICE_NAME_KEYWORD} 的过滤逻辑。仅在 servicesLister 不可用时触发。
+     */
+    private List<ServiceInstance> listJobServiceInstancesByNameFallback() {
         List<String> serviceIdList = discoveryClient.getServices();
         List<ServiceInstance> serviceInstanceList = new ArrayList<>();
         for (String serviceId : serviceIdList) {
-            if (serviceId != null && serviceId.contains(jobServiceSymbol)) {
+            if (serviceId != null && serviceId.contains(FALLBACK_JOB_SERVICE_NAME_KEYWORD)) {
                 serviceInstanceList.addAll(discoveryClient.getInstances(serviceId));
             }
         }
@@ -158,7 +301,7 @@ public class K8SServiceInfoProvider implements ServiceInfoProvider {
     private boolean isJobServiceInstance(ServiceInstance serviceInstance) {
         return serviceInstance != null
             && StringUtils.isNotBlank(serviceInstance.getServiceId())
-            && !serviceInstance.getServiceId().contains("job-gateway-management")
+            && !serviceInstance.getServiceId().contains(SERVICE_NAME_GATEWAY_MANAGEMENT)
             && StringUtils.isNotBlank(getNameSpace(serviceInstance));
     }
 

--- a/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/provider/K8SServiceInfoProvider.java
+++ b/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/provider/K8SServiceInfoProvider.java
@@ -57,7 +57,9 @@ import java.util.stream.Collectors;
  * 高频触发（默认每 5s 一次）下避免直连 apiserver 风暴：
  * 1. 复用 spring-cloud-kubernetes 提供的单例 CoreV1Api（背后是单例 ApiClient/OkHttpClient）；
  * 2. 每次 listServiceInfo 在每个命名空间内仅触发一次 listNamespacedPod；
- * 3. 命名空间维度的进程内 TTL 缓存（默认 5 秒），TTL 内重复触发命中缓存。
+ * 3. 命名空间维度的进程内 TTL 缓存（默认 5 秒），TTL 内重复触发命中缓存；
+ * 4. listNamespacedPod 透传 labelSelector（默认 {@link #DEFAULT_POD_LABEL_SELECTOR}），
+ *    apiserver 侧即裁剪掉非作业平台 Pod，减少返回体积与本进程反序列化开销。
  */
 @Slf4j
 public class K8SServiceInfoProvider implements ServiceInfoProvider {
@@ -74,26 +76,42 @@ public class K8SServiceInfoProvider implements ServiceInfoProvider {
      */
     public static final long DEFAULT_POD_CACHE_TTL_MS = 5_000L;
 
+    /**
+     * 仅拉取作业平台自身的 Pod，避免在共享 namespace 下把整个 namespace 内的 Pod 全部 List 回来，
+     * 显著降低 apiserver 与本进程的传输/反序列化开销。
+     */
+    public static final String DEFAULT_POD_LABEL_SELECTOR = "app.kubernetes.io/name=bk-job";
+
     private final DiscoveryClient discoveryClient;
     private final CoreV1Api coreV1Api;
     private final long podCacheTtlMs;
     /**
-     * namespace -> 缓存条目；条目内 podMap 的 key 为 pod uid。
-     * 使用 ConcurrentHashMap 保证多线程并发触发时的可见性，
-     * 单个命名空间的缓存失效后并发竞争允许多次 list（最多 1 次/线程），
-     * 不引入额外锁以避免阻塞 apiserver 响应慢时的健康检查请求。
+     * 调用 {@code listNamespacedPod} 时透传给 apiserver 的 labelSelector。
+     * 允许通过构造器在装配/测试时覆写，未传时使用 {@link #DEFAULT_POD_LABEL_SELECTOR}。
      */
+    private final String podLabelSelector;
     private final ConcurrentHashMap<String, PodCacheEntry> podCacheByNamespace = new ConcurrentHashMap<>();
 
     public K8SServiceInfoProvider(DiscoveryClient discoveryClient, CoreV1Api coreV1Api) {
-        this(discoveryClient, coreV1Api, DEFAULT_POD_CACHE_TTL_MS);
+        this(discoveryClient, coreV1Api, DEFAULT_POD_CACHE_TTL_MS, DEFAULT_POD_LABEL_SELECTOR);
     }
 
     public K8SServiceInfoProvider(DiscoveryClient discoveryClient, CoreV1Api coreV1Api, long podCacheTtlMs) {
+        this(discoveryClient, coreV1Api, podCacheTtlMs, DEFAULT_POD_LABEL_SELECTOR);
+    }
+
+    public K8SServiceInfoProvider(DiscoveryClient discoveryClient,
+                                  CoreV1Api coreV1Api,
+                                  long podCacheTtlMs,
+                                  String podLabelSelector) {
         this.discoveryClient = discoveryClient;
         this.coreV1Api = coreV1Api;
         this.podCacheTtlMs = podCacheTtlMs;
-        log.info("K8SServiceInfoProvider inited, podCacheTtlMs={}", podCacheTtlMs);
+        this.podLabelSelector = podLabelSelector;
+        log.info(
+            "K8SServiceInfoProvider inited, podCacheTtlMs={}, podLabelSelector={}",
+            podCacheTtlMs, podLabelSelector
+        );
     }
 
     /**
@@ -173,9 +191,13 @@ public class K8SServiceInfoProvider implements ServiceInfoProvider {
             return cached.podMapByUid;
         }
         try {
+            // io.kubernetes:client-java 19.0.0 中 listNamespacedPod 的 labelSelector 是第 6 个形参
+            // (0-based index 5)：namespace, pretty, allowWatchBookmarks, _continue, fieldSelector,
+            //  labelSelector, limit, resourceVersion, resourceVersionMatch, sendInitialEvents,
+            //  timeoutSeconds, watch
             V1PodList podList = coreV1Api.listNamespacedPod(
                 namespace, null, null, null,
-                null, null, null, null,
+                null, podLabelSelector, null, null,
                 null, null, null, null
             );
             Map<String, V1Pod> podMapByUid = buildPodMapByUid(podList);

--- a/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/provider/K8SServiceInfoProvider.java
+++ b/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/provider/K8SServiceInfoProvider.java
@@ -27,128 +27,73 @@ package com.tencent.bk.job.common.k8s.provider;
 import com.tencent.bk.job.common.discovery.ServiceInfoProvider;
 import com.tencent.bk.job.common.discovery.model.ServiceInstanceInfoDTO;
 import com.tencent.bk.job.common.util.json.JsonUtils;
-import io.kubernetes.client.openapi.ApiClient;
 import io.kubernetes.client.openapi.ApiException;
-import io.kubernetes.client.openapi.Configuration;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1PodStatus;
-import io.kubernetes.client.util.Config;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.kubernetes.commons.discovery.KubernetesServiceInstance;
 
-import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
+/**
+ * 基于 K8s API 的服务实例信息提供器
+ * <p>
+ * 高频触发（默认每 5s 一次）下避免直连 apiserver 风暴：
+ * 1. 复用 spring-cloud-kubernetes 提供的单例 CoreV1Api（背后是单例 ApiClient/OkHttpClient）；
+ * 2. 每次 listServiceInfo 在每个命名空间内仅触发一次 listNamespacedPod；
+ * 3. 命名空间维度的进程内 TTL 缓存（默认 5 秒），TTL 内重复触发命中缓存。
+ */
 @Slf4j
 public class K8SServiceInfoProvider implements ServiceInfoProvider {
 
-    public final String KEY_HELM_NAMESPACE = "meta.helm.sh/release-namespace";
-    public final String KEY_JOB_MS_VERSION = "bk.job.image/tag";
-    public final String VERSION_UNKNOWN = "-";
-    public final String PHASE_RUNNING = "Running";
+    public static final String KEY_HELM_NAMESPACE = "meta.helm.sh/release-namespace";
+    public static final String KEY_JOB_MS_VERSION = "bk.job.image/tag";
+    public static final String VERSION_UNKNOWN = "-";
+    public static final String PHASE_RUNNING = "Running";
+
+    /**
+     * Pod 缓存默认 TTL，单位毫秒。
+     * 当前 listServiceInfo 由健康检查接口高频触发（约 5s/次），TTL 略小于触发间隔，
+     * 既能合并同一轮内的多次 namespace 查询，也避免数据陈旧。
+     */
+    public static final long DEFAULT_POD_CACHE_TTL_MS = 5_000L;
+
     private final DiscoveryClient discoveryClient;
+    private final CoreV1Api coreV1Api;
+    private final long podCacheTtlMs;
+    /**
+     * namespace -> 缓存条目；条目内 podMap 的 key 为 pod uid。
+     * 使用 ConcurrentHashMap 保证多线程并发触发时的可见性，
+     * 单个命名空间的缓存失效后并发竞争允许多次 list（最多 1 次/线程），
+     * 不引入额外锁以避免阻塞 apiserver 响应慢时的健康检查请求。
+     */
+    private final ConcurrentHashMap<String, PodCacheEntry> podCacheByNamespace = new ConcurrentHashMap<>();
 
-    public K8SServiceInfoProvider(DiscoveryClient discoveryClient) {
+    public K8SServiceInfoProvider(DiscoveryClient discoveryClient, CoreV1Api coreV1Api) {
+        this(discoveryClient, coreV1Api, DEFAULT_POD_CACHE_TTL_MS);
+    }
+
+    public K8SServiceInfoProvider(DiscoveryClient discoveryClient, CoreV1Api coreV1Api, long podCacheTtlMs) {
         this.discoveryClient = discoveryClient;
-        log.debug("K8sServiceInfoServiceImpl inited");
-    }
-
-    /**
-     * 从服务实例元数据中提取命名空间
-     *
-     * @param serviceInstance 服务实例
-     * @return 命名空间
-     */
-    private String getNameSpace(ServiceInstance serviceInstance) {
-        KubernetesServiceInstance k8sServiceInstance = (KubernetesServiceInstance) serviceInstance;
-        String namespace = k8sServiceInstance.getNamespace();
-        if (StringUtils.isNotBlank(namespace)) return namespace;
-        return serviceInstance.getMetadata().getOrDefault(KEY_HELM_NAMESPACE, null);
-    }
-
-    private V1Pod findPodByUid(V1PodList podList, String uid) {
-        if (podList == null) return null;
-        for (V1Pod pod : podList.getItems()) {
-            V1ObjectMeta metaData = pod.getMetadata();
-            if (metaData != null && uid.equals(metaData.getUid())) {
-                return pod;
-            }
-        }
-        return null;
-    }
-
-    private Byte convertPodStatus(V1PodStatus podStatus) {
-        if (podStatus == null) return ServiceInstanceInfoDTO.STATUS_UNKNOWN;
-        String phase = podStatus.getPhase();
-        if (StringUtils.isNotBlank(phase)) {
-            if (phase.equals(PHASE_RUNNING))
-                return ServiceInstanceInfoDTO.STATUS_OK;
-            else
-                return ServiceInstanceInfoDTO.STATUS_ERROR;
-        }
-        return ServiceInstanceInfoDTO.STATUS_UNKNOWN;
-    }
-
-    /**
-     * 通过K8s API获取服务实例（pod）状态等详细信息
-     *
-     * @param serviceInstance 服务实例
-     * @return 服务实例详细信息
-     */
-    private ServiceInstanceInfoDTO getDetailFromK8s(
-        ServiceInstance serviceInstance
-    ) {
-        ServiceInstanceInfoDTO serviceInstanceInfoDTO = new ServiceInstanceInfoDTO();
-        serviceInstanceInfoDTO.setServiceName(serviceInstance.getServiceId());
-        serviceInstanceInfoDTO.setIp(serviceInstance.getHost());
-        serviceInstanceInfoDTO.setPort(serviceInstance.getPort());
-        String namespace = getNameSpace(serviceInstance);
-        V1PodList podList;
-        try {
-            ApiClient client = Config.defaultClient();
-            Configuration.setDefaultApiClient(client);
-
-            CoreV1Api api = new CoreV1Api();
-            podList = api.listNamespacedPod(
-                namespace, null, null, null,
-                null, null, null, null,
-                null, null, null, null);
-        } catch (ApiException | IOException e) {
-            log.error("Fail to get pod info from k8s API", e);
-            serviceInstanceInfoDTO.setName(serviceInstance.getInstanceId());
-            serviceInstanceInfoDTO.setVersion(VERSION_UNKNOWN);
-            serviceInstanceInfoDTO.setStatusCode(convertPodStatus(null));
-            serviceInstanceInfoDTO.setStatusMessage("Fail to get pod info from k8s");
-            return serviceInstanceInfoDTO;
-        }
-        V1Pod pod = findPodByUid(podList, serviceInstance.getInstanceId());
-        V1ObjectMeta metaData = pod.getMetadata();
-        if (metaData != null) {
-            serviceInstanceInfoDTO.setName(metaData.getName());
-        }
-        if (metaData != null && metaData.getLabels() != null) {
-            String version = metaData.getLabels().getOrDefault(KEY_JOB_MS_VERSION, VERSION_UNKNOWN);
-            serviceInstanceInfoDTO.setVersion(version);
-            log.debug("namespace={},version={}", namespace, version);
-        }
-        V1PodStatus podStatus = pod.getStatus();
-        if (podStatus != null) {
-            serviceInstanceInfoDTO.setStatusCode(convertPodStatus(podStatus));
-            serviceInstanceInfoDTO.setStatusMessage(podStatus.getReason());
-        }
-        if (log.isDebugEnabled()) {
-            log.debug("podStatus={}", JsonUtils.toJson(podStatus));
-        }
-        return serviceInstanceInfoDTO;
+        this.coreV1Api = coreV1Api;
+        this.podCacheTtlMs = podCacheTtlMs;
+        log.info("K8SServiceInfoProvider inited, podCacheTtlMs={}", podCacheTtlMs);
     }
 
     /**
@@ -158,19 +103,179 @@ public class K8SServiceInfoProvider implements ServiceInfoProvider {
      */
     @Override
     public List<ServiceInstanceInfoDTO> listServiceInfo() {
+        List<ServiceInstance> serviceInstanceList = listJobServiceInstances();
+        tryToLogServiceInstanceList(serviceInstanceList);
+        List<ServiceInstance> validInstances = serviceInstanceList.stream()
+            .filter(this::isJobServiceInstance)
+            .toList();
+        if (validInstances.isEmpty()) {
+            return Collections.emptyList();
+        }
+        // 收集本轮涉及的 namespace 集合，每个 namespace 在一轮内最多触发 1 次 listNamespacedPod
+        Set<String> namespaces = validInstances.stream()
+            .map(this::getNameSpace)
+            .filter(StringUtils::isNotBlank)
+            .collect(Collectors.toCollection(HashSet::new));
+        Map<String, Map<String, V1Pod>> podMapByNamespace = new HashMap<>(namespaces.size());
+        for (String namespace : namespaces) {
+            podMapByNamespace.put(namespace, getOrLoadPodMap(namespace));
+        }
+        return validInstances.stream()
+            .map(serviceInstance -> buildServiceInstanceInfo(serviceInstance, podMapByNamespace))
+            .collect(Collectors.toList());
+    }
+
+    private List<ServiceInstance> listJobServiceInstances() {
         String jobServiceSymbol = "job-";
         List<String> serviceIdList = discoveryClient.getServices();
         List<ServiceInstance> serviceInstanceList = new ArrayList<>();
         for (String serviceId : serviceIdList) {
-            if (serviceId.contains(jobServiceSymbol)) {
+            if (serviceId != null && serviceId.contains(jobServiceSymbol)) {
                 serviceInstanceList.addAll(discoveryClient.getInstances(serviceId));
             }
         }
-        tryToLogServiceInstanceList(serviceInstanceList);
-        return serviceInstanceList.stream().filter(
-                serviceInstance -> !serviceInstance.getServiceId().contains("job-gateway-management")
-            ).filter(serviceInstance -> getNameSpace(serviceInstance) != null)
-            .map(this::getDetailFromK8s).collect(Collectors.toList());
+        return serviceInstanceList;
+    }
+
+    private boolean isJobServiceInstance(ServiceInstance serviceInstance) {
+        return serviceInstance != null
+            && StringUtils.isNotBlank(serviceInstance.getServiceId())
+            && !serviceInstance.getServiceId().contains("job-gateway-management")
+            && StringUtils.isNotBlank(getNameSpace(serviceInstance));
+    }
+
+    /**
+     * 从服务实例中提取命名空间：优先使用 KubernetesServiceInstance.getNamespace()，
+     * 兜底读取 helm 注解。
+     */
+    private String getNameSpace(ServiceInstance serviceInstance) {
+        if (serviceInstance instanceof KubernetesServiceInstance) {
+            String namespace = ((KubernetesServiceInstance) serviceInstance).getNamespace();
+            if (StringUtils.isNotBlank(namespace)) {
+                return namespace;
+            }
+        }
+        Map<String, String> metadata = serviceInstance.getMetadata();
+        if (metadata == null) {
+            return null;
+        }
+        return metadata.get(KEY_HELM_NAMESPACE);
+    }
+
+    /**
+     * 从缓存读取或重新拉取指定 namespace 下所有 Pod，并按 uid 建立索引。
+     * 拉取异常时优先返回上一份缓存（即便已过期），避免短暂 apiserver 抖动放大成全量 UNKNOWN。
+     */
+    private Map<String, V1Pod> getOrLoadPodMap(String namespace) {
+        long now = System.currentTimeMillis();
+        PodCacheEntry cached = podCacheByNamespace.get(namespace);
+        if (cached != null && cached.expiryEpochMs > now) {
+            return cached.podMapByUid;
+        }
+        try {
+            V1PodList podList = coreV1Api.listNamespacedPod(
+                namespace, null, null, null,
+                null, null, null, null,
+                null, null, null, null
+            );
+            Map<String, V1Pod> podMapByUid = buildPodMapByUid(podList);
+            podCacheByNamespace.put(namespace, new PodCacheEntry(now + podCacheTtlMs, podMapByUid));
+            return podMapByUid;
+        } catch (ApiException e) {
+            log.error(
+                "Fail to listNamespacedPod, namespace={}, code={}, body={}",
+                namespace, e.getCode(), e.getResponseBody(), e
+            );
+        } catch (Throwable t) {
+            log.error("Fail to listNamespacedPod, namespace={}", namespace, t);
+        }
+        // listNamespacedPod 失败：返回上一份（即便已过期）保持兜底语义；都没有则返回空 map
+        return cached != null ? cached.podMapByUid : Collections.emptyMap();
+    }
+
+    private Map<String, V1Pod> buildPodMapByUid(V1PodList podList) {
+        if (podList == null || CollectionUtils.isEmpty(podList.getItems())) {
+            return Collections.emptyMap();
+        }
+        Map<String, V1Pod> podMapByUid = new LinkedHashMap<>(podList.getItems().size());
+        for (V1Pod pod : podList.getItems()) {
+            V1ObjectMeta metadata = pod.getMetadata();
+            if (metadata == null || StringUtils.isBlank(metadata.getUid())) {
+                continue;
+            }
+            podMapByUid.put(metadata.getUid(), pod);
+        }
+        return podMapByUid;
+    }
+
+    private ServiceInstanceInfoDTO buildServiceInstanceInfo(ServiceInstance serviceInstance,
+                                                            Map<String, Map<String, V1Pod>> podMapByNamespace) {
+        ServiceInstanceInfoDTO dto = new ServiceInstanceInfoDTO();
+        dto.setServiceName(serviceInstance.getServiceId());
+        dto.setIp(serviceInstance.getHost());
+        dto.setPort(serviceInstance.getPort());
+        String namespace = getNameSpace(serviceInstance);
+        Map<String, V1Pod> podMap = podMapByNamespace.getOrDefault(namespace, Collections.emptyMap());
+        V1Pod pod = podMap.get(serviceInstance.getInstanceId());
+        if (pod == null) {
+            fillFallback(dto, serviceInstance, "Pod not found in namespace cache");
+            return dto;
+        }
+        try {
+            fillFromPod(dto, serviceInstance, pod);
+        } catch (Throwable t) {
+            log.warn(
+                "Fail to extract pod detail, serviceId={}, instanceId={}",
+                serviceInstance.getServiceId(), serviceInstance.getInstanceId(), t
+            );
+            fillFallback(dto, serviceInstance, "Fail to parse pod detail");
+        }
+        return dto;
+    }
+
+    private void fillFromPod(ServiceInstanceInfoDTO dto, ServiceInstance serviceInstance, V1Pod pod) {
+        V1ObjectMeta metadata = pod.getMetadata();
+        if (metadata != null && StringUtils.isNotBlank(metadata.getName())) {
+            dto.setName(metadata.getName());
+        } else {
+            dto.setName(serviceInstance.getInstanceId());
+        }
+        dto.setVersion(extractVersion(metadata));
+        V1PodStatus podStatus = pod.getStatus();
+        dto.setStatusCode(convertPodStatus(podStatus));
+        dto.setStatusMessage(podStatus == null ? null : podStatus.getReason());
+        if (log.isDebugEnabled()) {
+            log.debug("podStatus={}", JsonUtils.toJson(podStatus));
+        }
+    }
+
+    private String extractVersion(V1ObjectMeta metadata) {
+        if (metadata == null || metadata.getLabels() == null) {
+            return VERSION_UNKNOWN;
+        }
+        String version = metadata.getLabels().get(KEY_JOB_MS_VERSION);
+        return StringUtils.isBlank(version) ? VERSION_UNKNOWN : version;
+    }
+
+    private Byte convertPodStatus(V1PodStatus podStatus) {
+        if (podStatus == null) {
+            return ServiceInstanceInfoDTO.STATUS_UNKNOWN;
+        }
+        String phase = podStatus.getPhase();
+        if (StringUtils.isBlank(phase)) {
+            return ServiceInstanceInfoDTO.STATUS_UNKNOWN;
+        }
+        if (PHASE_RUNNING.equalsIgnoreCase(phase)) {
+            return ServiceInstanceInfoDTO.STATUS_OK;
+        }
+        return ServiceInstanceInfoDTO.STATUS_ERROR;
+    }
+
+    private void fillFallback(ServiceInstanceInfoDTO dto, ServiceInstance serviceInstance, String message) {
+        dto.setName(serviceInstance.getInstanceId());
+        dto.setVersion(VERSION_UNKNOWN);
+        dto.setStatusCode(ServiceInstanceInfoDTO.STATUS_UNKNOWN);
+        dto.setStatusMessage(message);
     }
 
     private void tryToLogServiceInstanceList(List<ServiceInstance> serviceInstanceList) {
@@ -188,6 +293,19 @@ public class K8SServiceInfoProvider implements ServiceInfoProvider {
             }
         } catch (Throwable t) {
             log.warn("Fail to logServiceInstanceList", t);
+        }
+    }
+
+    /**
+     * Pod 缓存条目：携带过期时间戳与按 uid 索引的 Pod Map。
+     */
+    private static final class PodCacheEntry {
+        private final long expiryEpochMs;
+        private final Map<String, V1Pod> podMapByUid;
+
+        private PodCacheEntry(long expiryEpochMs, Map<String, V1Pod> podMapByUid) {
+            this.expiryEpochMs = expiryEpochMs;
+            this.podMapByUid = podMapByUid;
         }
     }
 

--- a/src/backend/commons/common-k8s/src/test/java/com/tencent/bk/job/common/k8s/provider/K8SServiceInfoProviderTest.java
+++ b/src/backend/commons/common-k8s/src/test/java/com/tencent/bk/job/common/k8s/provider/K8SServiceInfoProviderTest.java
@@ -24,33 +24,46 @@
 
 package com.tencent.bk.job.common.k8s.provider;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.tencent.bk.job.common.discovery.model.ServiceInstanceInfoDTO;
+import io.kubernetes.client.informer.cache.Lister;
 import io.kubernetes.client.openapi.ApiException;
 import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.V1ObjectMeta;
 import io.kubernetes.client.openapi.models.V1Pod;
 import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1PodStatus;
+import io.kubernetes.client.openapi.models.V1Service;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.slf4j.LoggerFactory;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.kubernetes.commons.discovery.DefaultKubernetesServiceInstance;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -60,10 +73,24 @@ class K8SServiceInfoProviderTest {
     private static final String NAMESPACE = "bk-job";
 
     private CoreV1Api coreV1Api;
+    private Logger providerLogger;
+    private ListAppender<ILoggingEvent> logAppender;
 
     @BeforeEach
     void setUp() {
         coreV1Api = mock(CoreV1Api.class);
+        providerLogger = (Logger) LoggerFactory.getLogger(K8SServiceInfoProvider.class);
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        providerLogger.addAppender(logAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (providerLogger != null && logAppender != null) {
+            providerLogger.detachAppender(logAppender);
+            logAppender.stop();
+        }
     }
 
     @Test
@@ -284,6 +311,248 @@ class K8SServiceInfoProviderTest {
             isNull(), isNull(), isNull(), isNull()
         );
         assertEquals(customSelector, labelSelectorCaptor.getValue());
+    }
+
+    @Test
+    void shouldFilterServicesByAppKubernetesIoNameLabelOnMainPath() throws Exception {
+        // 主路径命中：3 个 Service，2 个带 app.kubernetes.io/name=bk-job 标签（job-manage、job-execute），
+        // 1 个标签为其它值（monitor-foo），断言只对前两个调用 getInstances，最终聚合只来自前两个
+        ServiceInstance manageInstance = createKubernetesServiceInstance(
+            "uid-manage", "job-manage", "127.0.0.1", 19801, NAMESPACE
+        );
+        ServiceInstance executeInstance = createKubernetesServiceInstance(
+            "uid-execute", "job-execute", "127.0.0.2", 19803, NAMESPACE
+        );
+        // 故意准备一个 monitor-foo 实例：即使被错误命中也能通过断言暴露问题
+        ServiceInstance monitorInstance = createKubernetesServiceInstance(
+            "uid-monitor", "monitor-foo", "127.0.0.3", 9090, NAMESPACE
+        );
+
+        DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
+        when(discoveryClient.getInstances("job-manage"))
+            .thenReturn(Collections.singletonList(manageInstance));
+        when(discoveryClient.getInstances("job-execute"))
+            .thenReturn(Collections.singletonList(executeInstance));
+        when(discoveryClient.getInstances("monitor-foo"))
+            .thenReturn(Collections.singletonList(monitorInstance));
+
+        Lister<V1Service> servicesLister = mockServicesLister(Arrays.asList(
+            buildBkJobService("job-manage"),
+            buildBkJobService("job-execute"),
+            buildServiceWithLabelValue("monitor-foo", "monitoring-app")
+        ));
+        mockListNamespacedPod(NAMESPACE, Arrays.asList(
+            buildPod("uid-manage", "job-manage-0", "v3.9.0", "Running", null),
+            buildPod("uid-execute", "job-execute-0", "v3.9.0", "Running", null)
+        ));
+
+        K8SServiceInfoProvider provider = newProviderWithLister(discoveryClient, servicesLister);
+        Map<String, ServiceInstanceInfoDTO> resultMap = provider.listServiceInfo().stream()
+            .collect(Collectors.toMap(ServiceInstanceInfoDTO::getServiceName, dto -> dto));
+
+        // 主路径只对带 bk-job 标签的 service 调用 getInstances
+        verify(discoveryClient, times(1)).getInstances("job-manage");
+        verify(discoveryClient, times(1)).getInstances("job-execute");
+        verify(discoveryClient, never()).getInstances("monitor-foo");
+        // 主路径不会再走兜底 getServices()
+        verify(discoveryClient, never()).getServices();
+
+        assertEquals(2, resultMap.size());
+        assertTrue(resultMap.containsKey("job-manage"));
+        assertTrue(resultMap.containsKey("job-execute"));
+        assertFalse(resultMap.containsKey("monitor-foo"));
+        assertEquals(ServiceInstanceInfoDTO.STATUS_OK, resultMap.get("job-manage").getStatusCode());
+        assertEquals(ServiceInstanceInfoDTO.STATUS_OK, resultMap.get("job-execute").getStatusCode());
+    }
+
+    @Test
+    void shouldStillFilterGatewayManagementOnMainPath() throws Exception {
+        // 主路径同时命中 job-gateway-management（同样带 app.kubernetes.io/name=bk-job 标签），
+        // 断言它仍被过滤掉，不会出现在最终结果中
+        ServiceInstance manageInstance = createKubernetesServiceInstance(
+            "uid-manage", "job-manage", "127.0.0.1", 19801, NAMESPACE
+        );
+        ServiceInstance gatewayManagementInstance = createKubernetesServiceInstance(
+            "uid-gw-mgmt", "job-gateway-management", "127.0.0.2", 19810, NAMESPACE
+        );
+
+        DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
+        when(discoveryClient.getInstances("job-manage"))
+            .thenReturn(Collections.singletonList(manageInstance));
+        when(discoveryClient.getInstances("job-gateway-management"))
+            .thenReturn(Collections.singletonList(gatewayManagementInstance));
+
+        Lister<V1Service> servicesLister = mockServicesLister(Arrays.asList(
+            buildBkJobService("job-manage"),
+            buildBkJobService("job-gateway-management")
+        ));
+        mockListNamespacedPod(NAMESPACE, Collections.singletonList(
+            buildPod("uid-manage", "job-manage-0", "v3.9.0", "Running", null)
+        ));
+
+        K8SServiceInfoProvider provider = newProviderWithLister(discoveryClient, servicesLister);
+        List<ServiceInstanceInfoDTO> result = provider.listServiceInfo();
+
+        // 主路径在 listJobServiceIdsByLabel 阶段已剔除 job-gateway-management，不会触发 getInstances
+        verify(discoveryClient, never()).getInstances("job-gateway-management");
+        verify(discoveryClient, times(1)).getInstances("job-manage");
+
+        assertEquals(1, result.size());
+        assertEquals("job-manage", result.get(0).getServiceName());
+    }
+
+    @Test
+    void shouldFallbackToNameKeywordWhenServicesListerThrows() throws Exception {
+        // 兜底路径：servicesLister.list() 抛异常，断言走旧的 getServices() + contains("job-") 逻辑
+        ServiceInstance manageInstance = createKubernetesServiceInstance(
+            "uid-manage", "job-manage", "127.0.0.1", 19801, NAMESPACE
+        );
+        ServiceInstance otherInstance = createKubernetesServiceInstance(
+            "uid-monitor", "monitor-foo", "127.0.0.3", 9090, NAMESPACE
+        );
+
+        DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
+        when(discoveryClient.getServices()).thenReturn(Arrays.asList("job-manage", "monitor-foo"));
+        when(discoveryClient.getInstances("job-manage"))
+            .thenReturn(Collections.singletonList(manageInstance));
+        when(discoveryClient.getInstances("monitor-foo"))
+            .thenReturn(Collections.singletonList(otherInstance));
+
+        @SuppressWarnings("unchecked")
+        Lister<V1Service> servicesLister = (Lister<V1Service>) mock(Lister.class);
+        when(servicesLister.list()).thenThrow(new RuntimeException("informer not synced"));
+
+        mockListNamespacedPod(NAMESPACE, Collections.singletonList(
+            buildPod("uid-manage", "job-manage-0", "v3.9.0", "Running", null)
+        ));
+
+        K8SServiceInfoProvider provider = newProviderWithLister(discoveryClient, servicesLister);
+        List<ServiceInstanceInfoDTO> result = provider.listServiceInfo();
+
+        // 兜底确实触发了 getServices()
+        verify(discoveryClient, times(1)).getServices();
+        // 兜底路径只对名称含 "job-" 的 service 调用 getInstances，monitor-foo 不命中
+        verify(discoveryClient, times(1)).getInstances("job-manage");
+        verify(discoveryClient, never()).getInstances("monitor-foo");
+
+        assertEquals(1, result.size());
+        assertEquals("job-manage", result.get(0).getServiceName());
+        assertTrue(containsWarnLog("fallback to discoveryClient.getServices()"),
+            "expected WARN log when servicesLister.list() throws");
+    }
+
+    @Test
+    void shouldFallbackToNameKeywordWhenServicesListerReturnsEmpty() throws Exception {
+        // 兜底路径：servicesLister.list() 返回空集合（informer 未 sync 完成），断言走兜底逻辑
+        ServiceInstance manageInstance = createKubernetesServiceInstance(
+            "uid-manage", "job-manage", "127.0.0.1", 19801, NAMESPACE
+        );
+
+        DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
+        when(discoveryClient.getServices()).thenReturn(Collections.singletonList("job-manage"));
+        when(discoveryClient.getInstances("job-manage"))
+            .thenReturn(Collections.singletonList(manageInstance));
+
+        Lister<V1Service> servicesLister = mockServicesLister(Collections.emptyList());
+
+        mockListNamespacedPod(NAMESPACE, Collections.singletonList(
+            buildPod("uid-manage", "job-manage-0", "v3.9.0", "Running", null)
+        ));
+
+        K8SServiceInfoProvider provider = newProviderWithLister(discoveryClient, servicesLister);
+        List<ServiceInstanceInfoDTO> result = provider.listServiceInfo();
+
+        verify(discoveryClient, times(1)).getServices();
+        verify(discoveryClient, times(1)).getInstances("job-manage");
+
+        assertEquals(1, result.size());
+        assertEquals("job-manage", result.get(0).getServiceName());
+        assertTrue(containsWarnLog("informer not synced"),
+            "expected WARN log when servicesLister.list() returns empty");
+    }
+
+    @Test
+    void shouldFallbackToNameKeywordWhenServicesListerNotInjected() throws Exception {
+        // 兜底路径：servicesLister 为 null（默认 3 参构造器场景），断言走兜底逻辑且记 WARN
+        ServiceInstance manageInstance = createKubernetesServiceInstance(
+            "uid-manage", "job-manage", "127.0.0.1", 19801, NAMESPACE
+        );
+        DiscoveryClient discoveryClient = createDiscoveryClient(Collections.singletonList(manageInstance));
+        mockListNamespacedPod(NAMESPACE, Collections.singletonList(
+            buildPod("uid-manage", "job-manage-0", "v3.9.0", "Running", null)
+        ));
+
+        // 不传 servicesLister：使用默认 2 参构造器
+        K8SServiceInfoProvider provider = new K8SServiceInfoProvider(discoveryClient, coreV1Api);
+        List<ServiceInstanceInfoDTO> result = provider.listServiceInfo();
+
+        assertEquals(1, result.size());
+        assertEquals("job-manage", result.get(0).getServiceName());
+        assertTrue(containsWarnLog("servicesLister is not injected"),
+            "expected WARN log when servicesLister is null");
+    }
+
+    @Test
+    void shouldNotFallbackWhenListerHasNonEmptyResultButNoBkJobLabel() throws Exception {
+        // 主路径成功但过滤后无命中：lister 返回非空集合（仅含其它项目 service），主路径返回空列表也是合法结果，
+        // 不应再走兜底，最终聚合结果为空
+        DiscoveryClient discoveryClient = mock(DiscoveryClient.class);
+
+        Lister<V1Service> servicesLister = mockServicesLister(Collections.singletonList(
+            buildServiceWithLabelValue("monitor-foo", "monitoring-app")
+        ));
+
+        K8SServiceInfoProvider provider = newProviderWithLister(discoveryClient, servicesLister);
+        List<ServiceInstanceInfoDTO> result = provider.listServiceInfo();
+
+        assertEquals(0, result.size());
+        // 主路径 lister 可读，不应再触发兜底的 getServices()
+        verify(discoveryClient, never()).getServices();
+        verify(discoveryClient, never()).getInstances("monitor-foo");
+    }
+
+    private K8SServiceInfoProvider newProviderWithLister(DiscoveryClient discoveryClient,
+                                                        Lister<V1Service> servicesLister) {
+        return new K8SServiceInfoProvider(
+            discoveryClient,
+            coreV1Api,
+            K8SServiceInfoProvider.DEFAULT_POD_CACHE_TTL_MS,
+            K8SServiceInfoProvider.DEFAULT_POD_LABEL_SELECTOR,
+            servicesLister
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private Lister<V1Service> mockServicesLister(List<V1Service> services) {
+        Lister<V1Service> lister = (Lister<V1Service>) mock(Lister.class);
+        when(lister.list()).thenReturn(new ArrayList<>(services));
+        return lister;
+    }
+
+    private V1Service buildBkJobService(String name) {
+        return buildServiceWithLabelValue(
+            name, K8SServiceInfoProvider.SERVICE_LABEL_APP_KUBERNETES_IO_NAME_VALUE_BK_JOB
+        );
+    }
+
+    private V1Service buildServiceWithLabelValue(String name, String appKubernetesIoNameLabelValue) {
+        V1ObjectMeta metadata = new V1ObjectMeta().name(name);
+        if (appKubernetesIoNameLabelValue != null) {
+            Map<String, String> labels = new HashMap<>();
+            labels.put(
+                K8SServiceInfoProvider.SERVICE_LABEL_APP_KUBERNETES_IO_NAME,
+                appKubernetesIoNameLabelValue
+            );
+            metadata.setLabels(labels);
+        }
+        return new V1Service().metadata(metadata);
+    }
+
+    private boolean containsWarnLog(String fragment) {
+        Set<Level> warnLevels = Collections.singleton(Level.WARN);
+        return logAppender.list.stream()
+            .filter(event -> warnLevels.contains(event.getLevel()))
+            .anyMatch(event -> event.getFormattedMessage().contains(fragment));
     }
 
     private void mockListNamespacedPod(String namespace, List<V1Pod> pods) throws ApiException {

--- a/src/backend/commons/common-k8s/src/test/java/com/tencent/bk/job/common/k8s/provider/K8SServiceInfoProviderTest.java
+++ b/src/backend/commons/common-k8s/src/test/java/com/tencent/bk/job/common/k8s/provider/K8SServiceInfoProviderTest.java
@@ -33,6 +33,7 @@ import io.kubernetes.client.openapi.models.V1PodList;
 import io.kubernetes.client.openapi.models.V1PodStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.kubernetes.commons.discovery.DefaultKubernetesServiceInstance;
@@ -48,6 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -90,13 +92,13 @@ class K8SServiceInfoProviderTest {
     @Test
     void shouldMapPodPhaseAndReasonCorrectly() throws Exception {
         ServiceInstance running = createKubernetesServiceInstance(
-            "uid-running", "job-execute", "10.0.0.1", 19803, NAMESPACE
+            "uid-running", "job-execute", "127.0.0.1", 19803, NAMESPACE
         );
         ServiceInstance failed = createKubernetesServiceInstance(
-            "uid-failed", "job-crontab", "10.0.0.2", 19809, NAMESPACE
+            "uid-failed", "job-crontab", "127.0.0.2", 19809, NAMESPACE
         );
         ServiceInstance phaseBlank = createKubernetesServiceInstance(
-            "uid-blank", "job-logsvr", "10.0.0.3", 19808, NAMESPACE
+            "uid-blank", "job-logsvr", "127.0.0.3", 19808, NAMESPACE
         );
         DiscoveryClient discoveryClient = createDiscoveryClient(Arrays.asList(running, failed, phaseBlank));
         List<V1Pod> pods = Arrays.asList(
@@ -161,9 +163,9 @@ class K8SServiceInfoProviderTest {
 
     @Test
     void shouldOnlyCallListNamespacedPodOncePerCycle() throws Exception {
-        ServiceInstance a = createKubernetesServiceInstance("uid-a", "job-manage", "10.0.0.1", 19801, NAMESPACE);
-        ServiceInstance b = createKubernetesServiceInstance("uid-b", "job-execute", "10.0.0.2", 19803, NAMESPACE);
-        ServiceInstance c = createKubernetesServiceInstance("uid-c", "job-crontab", "10.0.0.3", 19809, NAMESPACE);
+        ServiceInstance a = createKubernetesServiceInstance("uid-a", "job-manage", "127.0.0.1", 19801, NAMESPACE);
+        ServiceInstance b = createKubernetesServiceInstance("uid-b", "job-execute", "127.0.0.2", 19803, NAMESPACE);
+        ServiceInstance c = createKubernetesServiceInstance("uid-c", "job-crontab", "127.0.0.3", 19809, NAMESPACE);
         DiscoveryClient discoveryClient = createDiscoveryClient(Arrays.asList(a, b, c));
         List<V1Pod> pods = Arrays.asList(
             buildPod("uid-a", "job-manage-0", "v3.9.0", "Running", null),
@@ -182,7 +184,7 @@ class K8SServiceInfoProviderTest {
     @Test
     void shouldHitCacheWithinTtl() throws Exception {
         ServiceInstance instance = createKubernetesServiceInstance(
-            "uid-a", "job-manage", "10.0.0.1", 19801, NAMESPACE
+            "uid-a", "job-manage", "127.0.0.1", 19801, NAMESPACE
         );
         DiscoveryClient discoveryClient = createDiscoveryClient(Collections.singletonList(instance));
         mockListNamespacedPod(NAMESPACE, Collections.singletonList(
@@ -201,7 +203,7 @@ class K8SServiceInfoProviderTest {
     @Test
     void shouldRefreshAfterTtlExpired() throws Exception {
         ServiceInstance instance = createKubernetesServiceInstance(
-            "uid-a", "job-manage", "10.0.0.1", 19801, NAMESPACE
+            "uid-a", "job-manage", "127.0.0.1", 19801, NAMESPACE
         );
         DiscoveryClient discoveryClient = createDiscoveryClient(Collections.singletonList(instance));
         mockListNamespacedPod(NAMESPACE, Collections.singletonList(
@@ -220,10 +222,10 @@ class K8SServiceInfoProviderTest {
     @Test
     void shouldFilterNonJobOrMissingNamespaceInstances() throws Exception {
         ServiceInstance noNamespace = createKubernetesServiceInstance(
-            "uid-no-ns", "job-manage", "10.0.0.1", 19801, null
+            "uid-no-ns", "job-manage", "127.0.0.1", 19801, null
         );
         ServiceInstance gatewayManagement = createKubernetesServiceInstance(
-            "uid-gw", "job-gateway-management", "10.0.0.2", 19810, NAMESPACE
+            "uid-gw", "job-gateway-management", "127.0.0.2", 19810, NAMESPACE
         );
         DiscoveryClient discoveryClient = createDiscoveryClient(Arrays.asList(noNamespace, gatewayManagement));
 
@@ -233,6 +235,55 @@ class K8SServiceInfoProviderTest {
         assertEquals(0, result.size());
         verify(coreV1Api, times(0)).listNamespacedPod(any(), any(), any(), any(), any(), any(),
             any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldPassDefaultLabelSelectorWhenInstantiatedByDefaultConstructor() throws Exception {
+        ServiceInstance instance = createKubernetesServiceInstance(
+            "uid-a", "job-manage", "127.0.0.1", 19801, NAMESPACE
+        );
+        DiscoveryClient discoveryClient = createDiscoveryClient(Collections.singletonList(instance));
+        mockListNamespacedPod(NAMESPACE, Collections.singletonList(
+            buildPod("uid-a", "job-manage-0", "v3.9.0", "Running", null)
+        ));
+
+        K8SServiceInfoProvider provider = new K8SServiceInfoProvider(discoveryClient, coreV1Api);
+        provider.listServiceInfo();
+
+        // 显式断言：listNamespacedPod 的第 6 形参（labelSelector）等于默认值 app.kubernetes.io/name=bk-job
+        // 其它形参保持 null，避免任何形参被错误带值
+        verify(coreV1Api).listNamespacedPod(
+            eq(NAMESPACE), isNull(), isNull(), isNull(),
+            isNull(), eq(K8SServiceInfoProvider.DEFAULT_POD_LABEL_SELECTOR), isNull(), isNull(),
+            isNull(), isNull(), isNull(), isNull()
+        );
+        assertEquals("app.kubernetes.io/name=bk-job", K8SServiceInfoProvider.DEFAULT_POD_LABEL_SELECTOR);
+    }
+
+    @Test
+    void shouldPassCustomLabelSelectorWhenInjectedViaConstructor() throws Exception {
+        ServiceInstance instance = createKubernetesServiceInstance(
+            "uid-a", "job-manage", "127.0.0.1", 19801, NAMESPACE
+        );
+        DiscoveryClient discoveryClient = createDiscoveryClient(Collections.singletonList(instance));
+        mockListNamespacedPod(NAMESPACE, Collections.singletonList(
+            buildPod("uid-a", "job-manage-0", "v3.9.0", "Running", null)
+        ));
+
+        String customSelector = "app.kubernetes.io/name=custom-job,app.kubernetes.io/instance=ut-instance";
+        K8SServiceInfoProvider provider = new K8SServiceInfoProvider(
+            discoveryClient, coreV1Api, K8SServiceInfoProvider.DEFAULT_POD_CACHE_TTL_MS, customSelector
+        );
+        provider.listServiceInfo();
+
+        // 通过 ArgumentCaptor 取出第 6 形参，断言自定义 selector 被原样透传，未被默认值覆盖
+        ArgumentCaptor<String> labelSelectorCaptor = ArgumentCaptor.forClass(String.class);
+        verify(coreV1Api).listNamespacedPod(
+            eq(NAMESPACE), isNull(), isNull(), isNull(),
+            isNull(), labelSelectorCaptor.capture(), isNull(), isNull(),
+            isNull(), isNull(), isNull(), isNull()
+        );
+        assertEquals(customSelector, labelSelectorCaptor.getValue());
     }
 
     private void mockListNamespacedPod(String namespace, List<V1Pod> pods) throws ApiException {

--- a/src/backend/commons/common-k8s/src/test/java/com/tencent/bk/job/common/k8s/provider/K8SServiceInfoProviderTest.java
+++ b/src/backend/commons/common-k8s/src/test/java/com/tencent/bk/job/common/k8s/provider/K8SServiceInfoProviderTest.java
@@ -1,0 +1,294 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.k8s.provider;
+
+import com.tencent.bk.job.common.discovery.model.ServiceInstanceInfoDTO;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1ObjectMeta;
+import io.kubernetes.client.openapi.models.V1Pod;
+import io.kubernetes.client.openapi.models.V1PodList;
+import io.kubernetes.client.openapi.models.V1PodStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.kubernetes.commons.discovery.DefaultKubernetesServiceInstance;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class K8SServiceInfoProviderTest {
+
+    private static final String NAMESPACE = "bk-job";
+
+    private CoreV1Api coreV1Api;
+
+    @BeforeEach
+    void setUp() {
+        coreV1Api = mock(CoreV1Api.class);
+    }
+
+    @Test
+    void shouldBuildServiceInfoFromPodMetadata() throws Exception {
+        ServiceInstance instance = createKubernetesServiceInstance(
+            "pod-uid-1", "job-manage", "127.0.0.1", 19801, NAMESPACE
+        );
+        DiscoveryClient discoveryClient = createDiscoveryClient(Collections.singletonList(instance));
+        V1Pod pod = buildPod("pod-uid-1", "job-manage-0", "v3.9.0", "Running", null);
+        mockListNamespacedPod(NAMESPACE, Collections.singletonList(pod));
+
+        K8SServiceInfoProvider provider = new K8SServiceInfoProvider(discoveryClient, coreV1Api);
+        List<ServiceInstanceInfoDTO> result = provider.listServiceInfo();
+
+        assertEquals(1, result.size());
+        ServiceInstanceInfoDTO detail = result.get(0);
+        assertEquals("job-manage", detail.getServiceName());
+        assertEquals("job-manage-0", detail.getName());
+        assertEquals("v3.9.0", detail.getVersion());
+        assertEquals(ServiceInstanceInfoDTO.STATUS_OK, detail.getStatusCode());
+        assertNull(detail.getStatusMessage());
+        assertEquals("127.0.0.1", detail.getIp());
+        assertEquals(19801, detail.getPort());
+    }
+
+    @Test
+    void shouldMapPodPhaseAndReasonCorrectly() throws Exception {
+        ServiceInstance running = createKubernetesServiceInstance(
+            "uid-running", "job-execute", "10.0.0.1", 19803, NAMESPACE
+        );
+        ServiceInstance failed = createKubernetesServiceInstance(
+            "uid-failed", "job-crontab", "10.0.0.2", 19809, NAMESPACE
+        );
+        ServiceInstance phaseBlank = createKubernetesServiceInstance(
+            "uid-blank", "job-logsvr", "10.0.0.3", 19808, NAMESPACE
+        );
+        DiscoveryClient discoveryClient = createDiscoveryClient(Arrays.asList(running, failed, phaseBlank));
+        List<V1Pod> pods = Arrays.asList(
+            buildPod("uid-running", "job-execute-0", "v3.9.0", "Running", null),
+            buildPod("uid-failed", "job-crontab-0", "v3.9.0", "Failed", "CrashLoopBackOff"),
+            buildPod("uid-blank", "job-logsvr-0", null, null, null)
+        );
+        mockListNamespacedPod(NAMESPACE, pods);
+
+        K8SServiceInfoProvider provider = new K8SServiceInfoProvider(discoveryClient, coreV1Api);
+        Map<String, ServiceInstanceInfoDTO> resultMap = provider.listServiceInfo().stream()
+            .collect(Collectors.toMap(ServiceInstanceInfoDTO::getServiceName, dto -> dto));
+
+        assertEquals(ServiceInstanceInfoDTO.STATUS_OK, resultMap.get("job-execute").getStatusCode());
+        assertNull(resultMap.get("job-execute").getStatusMessage());
+
+        assertEquals(ServiceInstanceInfoDTO.STATUS_ERROR, resultMap.get("job-crontab").getStatusCode());
+        assertEquals("CrashLoopBackOff", resultMap.get("job-crontab").getStatusMessage());
+
+        assertEquals(ServiceInstanceInfoDTO.STATUS_UNKNOWN, resultMap.get("job-logsvr").getStatusCode());
+        assertEquals(K8SServiceInfoProvider.VERSION_UNKNOWN, resultMap.get("job-logsvr").getVersion());
+    }
+
+    @Test
+    void shouldFallbackWhenPodUidNotFound() throws Exception {
+        ServiceInstance instance = createKubernetesServiceInstance(
+            "missing-uid", "job-manage", "127.0.0.1", 19801, NAMESPACE
+        );
+        DiscoveryClient discoveryClient = createDiscoveryClient(Collections.singletonList(instance));
+        // Pod uid 与服务实例 uid 不匹配，触发 fallback
+        V1Pod otherPod = buildPod("some-other-uid", "job-manage-0", "v3.9.0", "Running", null);
+        mockListNamespacedPod(NAMESPACE, Collections.singletonList(otherPod));
+
+        K8SServiceInfoProvider provider = new K8SServiceInfoProvider(discoveryClient, coreV1Api);
+        List<ServiceInstanceInfoDTO> result = provider.listServiceInfo();
+
+        assertEquals(1, result.size());
+        ServiceInstanceInfoDTO detail = result.get(0);
+        assertEquals("missing-uid", detail.getName());
+        assertEquals(K8SServiceInfoProvider.VERSION_UNKNOWN, detail.getVersion());
+        assertEquals(ServiceInstanceInfoDTO.STATUS_UNKNOWN, detail.getStatusCode());
+    }
+
+    @Test
+    void shouldFallbackWhenListNamespacedPodThrows() throws Exception {
+        ServiceInstance instance = createKubernetesServiceInstance(
+            "pod-uid-1", "job-manage", "127.0.0.1", 19801, NAMESPACE
+        );
+        DiscoveryClient discoveryClient = createDiscoveryClient(Collections.singletonList(instance));
+        when(coreV1Api.listNamespacedPod(eq(NAMESPACE), any(), any(), any(), any(), any(), any(), any(),
+            any(), any(), any(), any())).thenThrow(new ApiException(500, "boom"));
+
+        K8SServiceInfoProvider provider = new K8SServiceInfoProvider(discoveryClient, coreV1Api);
+        List<ServiceInstanceInfoDTO> result = provider.listServiceInfo();
+
+        assertEquals(1, result.size());
+        ServiceInstanceInfoDTO detail = result.get(0);
+        assertEquals("pod-uid-1", detail.getName());
+        assertEquals(K8SServiceInfoProvider.VERSION_UNKNOWN, detail.getVersion());
+        assertEquals(ServiceInstanceInfoDTO.STATUS_UNKNOWN, detail.getStatusCode());
+    }
+
+    @Test
+    void shouldOnlyCallListNamespacedPodOncePerCycle() throws Exception {
+        ServiceInstance a = createKubernetesServiceInstance("uid-a", "job-manage", "10.0.0.1", 19801, NAMESPACE);
+        ServiceInstance b = createKubernetesServiceInstance("uid-b", "job-execute", "10.0.0.2", 19803, NAMESPACE);
+        ServiceInstance c = createKubernetesServiceInstance("uid-c", "job-crontab", "10.0.0.3", 19809, NAMESPACE);
+        DiscoveryClient discoveryClient = createDiscoveryClient(Arrays.asList(a, b, c));
+        List<V1Pod> pods = Arrays.asList(
+            buildPod("uid-a", "job-manage-0", "v3.9.0", "Running", null),
+            buildPod("uid-b", "job-execute-0", "v3.9.0", "Running", null),
+            buildPod("uid-c", "job-crontab-0", "v3.9.0", "Running", null)
+        );
+        mockListNamespacedPod(NAMESPACE, pods);
+
+        K8SServiceInfoProvider provider = new K8SServiceInfoProvider(discoveryClient, coreV1Api);
+        provider.listServiceInfo();
+
+        verify(coreV1Api, times(1)).listNamespacedPod(eq(NAMESPACE), any(), any(), any(), any(), any(),
+            any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldHitCacheWithinTtl() throws Exception {
+        ServiceInstance instance = createKubernetesServiceInstance(
+            "uid-a", "job-manage", "10.0.0.1", 19801, NAMESPACE
+        );
+        DiscoveryClient discoveryClient = createDiscoveryClient(Collections.singletonList(instance));
+        mockListNamespacedPod(NAMESPACE, Collections.singletonList(
+            buildPod("uid-a", "job-manage-0", "v3.9.0", "Running", null)
+        ));
+
+        K8SServiceInfoProvider provider = new K8SServiceInfoProvider(discoveryClient, coreV1Api, 60_000L);
+        provider.listServiceInfo();
+        provider.listServiceInfo();
+        provider.listServiceInfo();
+
+        verify(coreV1Api, times(1)).listNamespacedPod(eq(NAMESPACE), any(), any(), any(), any(), any(),
+            any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldRefreshAfterTtlExpired() throws Exception {
+        ServiceInstance instance = createKubernetesServiceInstance(
+            "uid-a", "job-manage", "10.0.0.1", 19801, NAMESPACE
+        );
+        DiscoveryClient discoveryClient = createDiscoveryClient(Collections.singletonList(instance));
+        mockListNamespacedPod(NAMESPACE, Collections.singletonList(
+            buildPod("uid-a", "job-manage-0", "v3.9.0", "Running", null)
+        ));
+
+        // 0ms TTL：每次调用都视为已过期，强制刷新
+        K8SServiceInfoProvider provider = new K8SServiceInfoProvider(discoveryClient, coreV1Api, 0L);
+        provider.listServiceInfo();
+        provider.listServiceInfo();
+
+        verify(coreV1Api, times(2)).listNamespacedPod(eq(NAMESPACE), any(), any(), any(), any(), any(),
+            any(), any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldFilterNonJobOrMissingNamespaceInstances() throws Exception {
+        ServiceInstance noNamespace = createKubernetesServiceInstance(
+            "uid-no-ns", "job-manage", "10.0.0.1", 19801, null
+        );
+        ServiceInstance gatewayManagement = createKubernetesServiceInstance(
+            "uid-gw", "job-gateway-management", "10.0.0.2", 19810, NAMESPACE
+        );
+        DiscoveryClient discoveryClient = createDiscoveryClient(Arrays.asList(noNamespace, gatewayManagement));
+
+        K8SServiceInfoProvider provider = new K8SServiceInfoProvider(discoveryClient, coreV1Api);
+        List<ServiceInstanceInfoDTO> result = provider.listServiceInfo();
+
+        assertEquals(0, result.size());
+        verify(coreV1Api, times(0)).listNamespacedPod(any(), any(), any(), any(), any(), any(),
+            any(), any(), any(), any(), any(), any());
+    }
+
+    private void mockListNamespacedPod(String namespace, List<V1Pod> pods) throws ApiException {
+        V1PodList podList = new V1PodList().items(pods);
+        when(coreV1Api.listNamespacedPod(eq(namespace), any(), any(), any(), any(), any(), any(), any(),
+            any(), any(), any(), any())).thenReturn(podList);
+    }
+
+    private V1Pod buildPod(String uid, String name, String versionLabel, String phase, String reason) {
+        V1ObjectMeta metadata = new V1ObjectMeta()
+            .uid(uid)
+            .name(name);
+        if (versionLabel != null) {
+            Map<String, String> labels = new HashMap<>();
+            labels.put(K8SServiceInfoProvider.KEY_JOB_MS_VERSION, versionLabel);
+            metadata.setLabels(labels);
+        }
+        V1PodStatus status = new V1PodStatus().phase(phase).reason(reason);
+        return new V1Pod().metadata(metadata).status(status);
+    }
+
+    private ServiceInstance createKubernetesServiceInstance(String instanceId,
+                                                            String serviceId,
+                                                            String host,
+                                                            int port,
+                                                            String namespace) {
+        return new DefaultKubernetesServiceInstance(
+            instanceId, serviceId, host, port, new HashMap<>(), false, namespace, null
+        );
+    }
+
+    private DiscoveryClient createDiscoveryClient(List<ServiceInstance> serviceInstances) {
+        return new DiscoveryClient() {
+            private final Map<String, List<ServiceInstance>> serviceInstanceMap = serviceInstances.stream()
+                .collect(Collectors.groupingBy(ServiceInstance::getServiceId));
+
+            @Override
+            public String description() {
+                return "fake-k8s-discovery-client";
+            }
+
+            @Override
+            public List<ServiceInstance> getInstances(String serviceId) {
+                return serviceInstanceMap.getOrDefault(serviceId, Collections.emptyList());
+            }
+
+            @Override
+            public List<String> getServices() {
+                return serviceInstanceMap.keySet().stream().sorted().collect(Collectors.toList());
+            }
+
+            @Override
+            public int getOrder() {
+                return 0;
+            }
+        };
+    }
+
+}

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -2273,7 +2273,7 @@ k8sConfigWatcherConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-config-watcher
-    tag: "3.11.11"
+    tag: "3.12.3"
     pullPolicy: IfNotPresent
     pullSecrets: []
   hostAliases: []

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -2273,7 +2273,7 @@ k8sConfigWatcherConfig:
   image:
     registry: hub.bktencent.com
     repository: blueking/job-config-watcher
-    tag: "3.12.3"
+    tag: "3.12.4"
     pullPolicy: IfNotPresent
     pullSecrets: []
   hostAliases: []

--- a/support-files/kubernetes/images/backend/backend.Dockerfile
+++ b/support-files/kubernetes/images/backend/backend.Dockerfile
@@ -1,7 +1,7 @@
-FROM bkjob/jdk17:3.12.2
+FROM bkjob/jdk17:3.12.3
 
 LABEL maintainer="Tencent BlueKing Job"
-LABEL dockerfile.version="3.12.2"
+LABEL dockerfile.version="3.12.3"
 
 ENV BK_JOB_HOME=/data/job/exec
 

--- a/support-files/kubernetes/images/backend/jdk17.Dockerfile
+++ b/support-files/kubernetes/images/backend/jdk17.Dockerfile
@@ -1,7 +1,7 @@
 FROM bkjob/os:3.12.2
 
 LABEL maintainer="Tencent BlueKing Job"
-LABEL dockerfile.version="3.12.2"
+LABEL dockerfile.version="3.12.3"
 
 RUN mkdir -p /data && \
     cd /data/ &&\

--- a/support-files/kubernetes/images/backend/jdk17.Dockerfile
+++ b/support-files/kubernetes/images/backend/jdk17.Dockerfile
@@ -19,4 +19,4 @@ RUN mkdir -p /data/tools && \
     dnf install -y unzip && \
     unzip arthas-bin.zip arthas-boot.jar && \
     rm -rf arthas-bin* && \
-    echo 'alias arthas="java -jar /data/tools/arthas-boot.jar"' >> ~/.bashrc
+    echo 'alias arthas="java -jar /data/tools/arthas-boot.jar --repo-mirror aliyun --use-http"' >> ~/.bashrc

--- a/support-files/kubernetes/images/backend/job-config-watcher.Dockerfile
+++ b/support-files/kubernetes/images/backend/job-config-watcher.Dockerfile
@@ -1,7 +1,7 @@
-FROM bkjob/jdk17:3.12.2
+FROM bkjob/jdk17:3.12.3
 
 LABEL maintainer="Tencent BlueKing Job"
-LABEL dockerfile.version="3.12.2"
+LABEL dockerfile.version="3.12.3"
 
 ARG VERSION=3.0.0
 RUN curl -L -o /app.jar \

--- a/support-files/kubernetes/images/backend/job-config-watcher.Dockerfile
+++ b/support-files/kubernetes/images/backend/job-config-watcher.Dockerfile
@@ -1,7 +1,7 @@
 FROM bkjob/jdk17:3.12.3
 
 LABEL maintainer="Tencent BlueKing Job"
-LABEL dockerfile.version="3.12.3"
+LABEL dockerfile.version="3.12.4"
 
 ARG VERSION=3.0.0
 RUN curl -L -o /app.jar \

--- a/support-files/kubernetes/images/backend/tool-set.Dockerfile
+++ b/support-files/kubernetes/images/backend/tool-set.Dockerfile
@@ -1,7 +1,7 @@
-FROM bkjob/jdk17:3.12.2
+FROM bkjob/jdk17:3.12.3
 
 LABEL maintainer="Tencent BlueKing Job"
-LABEL dockerfile.version="3.12.4"
+LABEL dockerfile.version="3.12.5"
 
 ## 安装MySQL与兼容库
 RUN curl -o mysql-8.4.6-linux-glibc2.17-x86_64-minimal.tar.xz https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.6-linux-glibc2.17-x86_64-minimal.tar.xz \

--- a/support-files/kubernetes/images/migration/migration.Dockerfile
+++ b/support-files/kubernetes/images/migration/migration.Dockerfile
@@ -1,4 +1,4 @@
-FROM bkjob/tool-set:3.12.4
+FROM bkjob/tool-set:3.12.5
 
 LABEL maintainer="Tencent BlueKing Job"
 LABEL dockerfile.version="3.12.4"

--- a/support-files/kubernetes/images/startup-controller/startupController.Dockerfile
+++ b/support-files/kubernetes/images/startup-controller/startupController.Dockerfile
@@ -1,7 +1,7 @@
-FROM bkjob/jdk17:3.12.2
+FROM bkjob/jdk17:3.12.3
 
 LABEL maintainer="Tencent BlueKing Job"
-LABEL dockerfile.version="3.12.2"
+LABEL dockerfile.version="3.12.3"
 
 ENV BK_JOB_HOME=/data/job/exec
 


### PR DESCRIPTION
1. K8sServiceInfoServiceAutoConfiguration 改为复用 spring-cloud-kubernetes 暴露的单例 CoreV1Api（背后是单例 ApiClient/OkHttpClient），避免每次调用都通过 Config.defaultClient() 新建 ApiClient 与 OkHttp Dispatcher/连接池导致线程持续累积，增加缓存逻辑；
2. 新增单元测试K8SServiceInfoProviderTest；
3. 更新JDK镜像中的arthas启动命令，解决从Maven中央仓库下载403问题。