### PR TITLE
feat：目标服务器-静态拓扑中的节点列表，支持展示节点所属的集群和模块 #3973

### DIFF
--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/impl/TenantHostServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/host/impl/TenantHostServiceImpl.java
@@ -175,7 +175,7 @@ public class TenantHostServiceImpl extends BaseHostService implements TenantHost
             refreshHostAgentIdIfNeed(tenantId, refreshAgentId, existHosts);
             watch.stop();
 
-            if (CollectionUtils.isNotEmpty(existHosts)) {
+            if (application.isBiz() && CollectionUtils.isNotEmpty(existHosts)) {
                 watch.start("fillHostTopoPathSnapshot");
                 fillHostTopoPathSnapshotForExistHostsWithTimeout(tenantId, appId, application, existHosts);
                 watch.stop();


### PR DESCRIPTION
1.只对普通业务下的任务填充主机拓扑路径快照数据。