### PR TITLE
fix: 高危语句规则相关ESB接口权限校验不正确 #4280

### DIFF
--- a/src/backend/job-file-gateway/service-job-file-gateway/build.gradle
+++ b/src/backend/job-file-gateway/service-job-file-gateway/build.gradle
@@ -36,4 +36,5 @@ dependencies {
     implementation('org.springframework.cloud:spring-cloud-starter-openfeign')
     implementation 'org.apache.httpcomponents:httpclient'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/api/esb/EsbFileSourceV3ResourceImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/api/esb/EsbFileSourceV3ResourceImpl.java
@@ -7,10 +7,14 @@ import com.tencent.bk.job.common.esb.metrics.EsbApiTimed;
 import com.tencent.bk.job.common.esb.model.EsbResp;
 import com.tencent.bk.job.common.exception.FailedPreconditionException;
 import com.tencent.bk.job.common.exception.InvalidParamException;
+import com.tencent.bk.job.common.exception.NotFoundException;
 import com.tencent.bk.job.common.iam.constant.ActionId;
 import com.tencent.bk.job.common.metrics.CommonMetricNames;
+import com.tencent.bk.job.common.model.User;
+import com.tencent.bk.job.common.model.dto.AppResourceScope;
 import com.tencent.bk.job.common.service.AppScopeMappingService;
 import com.tencent.bk.job.common.util.JobContextUtil;
+import com.tencent.bk.job.file_gateway.auth.FileSourceAuthService;
 import com.tencent.bk.job.file_gateway.consts.WorkerSelectModeEnum;
 import com.tencent.bk.job.file_gateway.consts.WorkerSelectScopeEnum;
 import com.tencent.bk.job.file_gateway.model.dto.FileSourceDTO;
@@ -35,14 +39,17 @@ public class EsbFileSourceV3ResourceImpl implements EsbFileSourceV3Resource {
     private final FileSourceService fileSourceService;
     private final AppScopeMappingService appScopeMappingService;
     private final FileSourceValidateService fileSourceValidateService;
+    private final FileSourceAuthService fileSourceAuthService;
 
     @Autowired
     public EsbFileSourceV3ResourceImpl(FileSourceService fileSourceService,
                                        AppScopeMappingService appScopeMappingService,
-                                       FileSourceValidateService fileSourceValidateService) {
+                                       FileSourceValidateService fileSourceValidateService,
+                                       FileSourceAuthService fileSourceAuthService) {
         this.fileSourceService = fileSourceService;
         this.appScopeMappingService = appScopeMappingService;
         this.fileSourceValidateService = fileSourceValidateService;
+        this.fileSourceAuthService = fileSourceAuthService;
     }
 
     @Override
@@ -101,7 +108,26 @@ public class EsbFileSourceV3ResourceImpl implements EsbFileSourceV3Resource {
         String username,
         String appCode,
         @AuditRequestBody EsbGetFileSourceDetailV3Req req) {
-        FileSourceDTO fileSourceDTO = fileSourceService.getFileSourceByCode(req.getAppId(), req.getCode());
+        // POST 直接入口可能未补全 appId（GET 入口已先调用，重复调用幂等且安全）
+        req.fillAppResourceScope(appScopeMappingService);
+        Long appId = req.getAppId();
+
+        // 先按 (appId, code) 拿到文件源，DAO 联合过滤天然保证业务隔离
+        FileSourceDTO fileSourceDTO = fileSourceService.getFileSourceByCode(appId, req.getCode());
+        if (fileSourceDTO == null) {
+            throw new NotFoundException(ErrorCode.FAIL_TO_FIND_FILE_SOURCE_BY_CODE,
+                new String[]{req.getCode()});
+        }
+
+        // IAM view_file_source 校验，与 Web 端 FileSourceServiceImpl#getFileSourceById(user,..) 对齐
+        User user = JobContextUtil.getUser();
+        fileSourceAuthService.authViewFileSource(
+            user,
+            new AppResourceScope(appId),
+            fileSourceDTO.getId(),
+            fileSourceDTO.getAlias()
+        ).denyIfNoPermission();
+
         return EsbResp.buildSuccessResp(FileSourceDTO.toEsbFileSourceV3DTO(fileSourceDTO));
     }
 

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/auth/FileSourceAuthService.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/auth/FileSourceAuthService.java
@@ -96,6 +96,19 @@ public interface FileSourceAuthService {
                                             List<Integer> fileSourceIdList);
 
     /**
+     * 资源范围下使用凭据鉴权（用于文件源绑定凭据时校验 USE_TICKET 权限）
+     *
+     * <p>说明：service-job-file-gateway 模块未依赖 service-job-manage 模块（避免循环依赖），
+     * 因此本地新增 USE_TICKET 校验入口，内部委派至公共 AuthService。</p>
+     *
+     * @param user             用户
+     * @param appResourceScope 资源范围
+     * @param ticketId         凭据ID
+     * @return 鉴权结果
+     */
+    AuthResult authUseTicket(User user, AppResourceScope appResourceScope, String ticketId);
+
+    /**
      * 注册文件源实例
      *
      * @param creator 资源实例创建者

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/auth/impl/FileSourceAuthServiceImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/auth/impl/FileSourceAuthServiceImpl.java
@@ -118,6 +118,19 @@ public class FileSourceAuthServiceImpl implements FileSourceAuthService {
     }
 
     @Override
+    public AuthResult authUseTicket(User user,
+                                    AppResourceScope appResourceScope,
+                                    String ticketId) {
+        return authService.auth(
+            user,
+            ActionId.USE_TICKET,
+            ResourceTypeEnum.TICKET,
+            ticketId,
+            buildAppScopePath(appResourceScope)
+        );
+    }
+
+    @Override
     public boolean registerFileSource(User creator, Integer id, String name) {
         return authService.registerResource(creator, id.toString(), name, ResourceTypeId.FILE_SOURCE, null);
     }

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceServiceImpl.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceServiceImpl.java
@@ -147,6 +147,7 @@ public class FileSourceServiceImpl implements FileSourceService {
     )
     public FileSourceDTO saveFileSource(User user, Long appId, FileSourceDTO fileSource) {
         authCreate(user, appId);
+        authUseTicketIfNeeded(user, appId, fileSource.getCredentialId());
 
         if (existsCode(appId, fileSource.getCode())) {
             throw new FailedPreconditionException(
@@ -185,6 +186,21 @@ public class FileSourceServiceImpl implements FileSourceService {
             fileSourceId, null).denyIfNoPermission();
     }
 
+    /**
+     * 文件源绑定凭据时校验 USE_TICKET 权限。
+     *
+     * <p>当 credentialId 非空时执行校验；为空表示该文件源未绑定凭据，按原行为放行。
+     * 更新场景下不论新旧 credentialId 是否变更，只要绑定了非空凭据就需要校验，
+     * 防止 IAM 权限在生命周期中被回收后仍可继续使用。</p>
+     */
+    private void authUseTicketIfNeeded(User user, long appId, String credentialId) {
+        if (StringUtils.isBlank(credentialId)) {
+            return;
+        }
+        fileSourceAuthService.authUseTicket(user, new AppResourceScope(appId), credentialId)
+            .denyIfNoPermission();
+    }
+
     @Override
     @ActionAuditRecord(
         actionId = ActionId.MANAGE_FILE_SOURCE,
@@ -197,6 +213,7 @@ public class FileSourceServiceImpl implements FileSourceService {
     )
     public FileSourceDTO updateFileSourceById(User user, Long appId, FileSourceDTO fileSource) {
         authManage(user, appId, fileSource.getId());
+        authUseTicketIfNeeded(user, appId, fileSource.getCredentialId());
 
         if (existsCodeExceptId(appId, fileSource.getCode(), fileSource.getId())) {
             throw new FailedPreconditionException(

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/test/java/com/tencent/bk/job/file_gateway/api/esb/EsbFileSourceV3ResourceImplTest.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/test/java/com/tencent/bk/job/file_gateway/api/esb/EsbFileSourceV3ResourceImplTest.java
@@ -1,0 +1,274 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.file_gateway.api.esb;
+
+import com.tencent.bk.job.common.constant.ErrorCode;
+import com.tencent.bk.job.common.constant.ResourceScopeTypeEnum;
+import com.tencent.bk.job.common.esb.model.EsbResp;
+import com.tencent.bk.job.common.exception.NotFoundException;
+import com.tencent.bk.job.common.iam.exception.PermissionDeniedException;
+import com.tencent.bk.job.common.iam.model.AuthResult;
+import com.tencent.bk.job.common.model.User;
+import com.tencent.bk.job.common.model.dto.AppResourceScope;
+import com.tencent.bk.job.common.model.dto.ResourceScope;
+import com.tencent.bk.job.common.service.AppScopeMappingService;
+import com.tencent.bk.job.common.util.ApplicationContextRegister;
+import com.tencent.bk.job.common.util.JobContextUtil;
+import com.tencent.bk.job.file_gateway.auth.FileSourceAuthService;
+import com.tencent.bk.job.file_gateway.model.dto.FileSourceDTO;
+import com.tencent.bk.job.file_gateway.model.req.esb.v3.EsbGetFileSourceDetailV3Req;
+import com.tencent.bk.job.file_gateway.model.resp.esb.v3.EsbFileSourceV3DTO;
+import com.tencent.bk.job.file_gateway.service.FileSourceService;
+import com.tencent.bk.job.file_gateway.service.validation.FileSourceValidateService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 验证 ESB 获取文件源详情接口（GET/POST `/get_file_source_detail`）的 IAM 鉴权与业务隔离，
+ * 与 #4280 同范畴的"权限校验不正确"修复。
+ *
+ * <p>修复要点：</p>
+ * <ul>
+ *     <li>POST 入口先调用 {@code req.fillAppResourceScope(appScopeMappingService)} 补全 appId；</li>
+ *     <li>按 (appId, code) 联合查询 DAO，跨业务/不存在统一抛 {@link NotFoundException}；</li>
+ *     <li>查到文件源后再做 {@link com.tencent.bk.job.common.iam.constant.ActionId#VIEW_FILE_SOURCE} 鉴权，
+ *         未通过即抛 {@link PermissionDeniedException}；</li>
+ *     <li>GET 入口委托给 POST，复用同一份隔离与鉴权逻辑。</li>
+ * </ul>
+ */
+@DisplayName("EsbFileSourceV3ResourceImpl 文件源详情查询鉴权测试")
+class EsbFileSourceV3ResourceImplTest {
+
+    private FileSourceService fileSourceService;
+    private AppScopeMappingService appScopeMappingService;
+    private FileSourceValidateService fileSourceValidateService;
+    private FileSourceAuthService fileSourceAuthService;
+    private EsbFileSourceV3ResourceImpl resource;
+
+    private MockedStatic<ApplicationContextRegister> applicationContextRegisterMock;
+
+    private static final String TENANT_ID = "default";
+    private static final String USERNAME = "test_user";
+    private static final long APP_ID = 100L;
+    private static final long OTHER_APP_ID = 200L;
+    private static final String SCOPE_TYPE = "biz";
+    private static final String SCOPE_ID = "100";
+    private static final String FILE_SOURCE_CODE = "fs_code_1";
+    private static final int FILE_SOURCE_ID = 999;
+    private static final String FILE_SOURCE_ALIAS = "fs_alias";
+    private static final String CREDENTIAL_ID = "credential_1";
+
+    @BeforeEach
+    void setUp() {
+        fileSourceService = mock(FileSourceService.class);
+        appScopeMappingService = mock(AppScopeMappingService.class);
+        fileSourceValidateService = mock(FileSourceValidateService.class);
+        fileSourceAuthService = mock(FileSourceAuthService.class);
+        resource = new EsbFileSourceV3ResourceImpl(
+            fileSourceService,
+            appScopeMappingService,
+            fileSourceValidateService,
+            fileSourceAuthService
+        );
+
+        // appScopeMappingService.getAppIdByScope(scopeType, scopeId) → APP_ID
+        when(appScopeMappingService.getAppIdByScope(eq(SCOPE_TYPE), eq(SCOPE_ID))).thenReturn(APP_ID);
+
+        // toEsbFileSourceV3DTO 内部依赖 ApplicationContextRegister.getBean(AppScopeMappingService.class)
+        // 通过 mockStatic 注入同一份 appScopeMappingService 满足该静态查找
+        applicationContextRegisterMock = Mockito.mockStatic(ApplicationContextRegister.class);
+        when(appScopeMappingService.getScopeByAppId(anyLong()))
+            .thenReturn(new ResourceScope(ResourceScopeTypeEnum.BIZ, SCOPE_ID));
+        applicationContextRegisterMock.when(() -> ApplicationContextRegister.getBean(AppScopeMappingService.class))
+            .thenReturn(appScopeMappingService);
+
+        User user = new User(TENANT_ID, USERNAME, USERNAME);
+        JobContextUtil.setUser(user);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (applicationContextRegisterMock != null) {
+            applicationContextRegisterMock.close();
+        }
+        JobContextUtil.unsetContext();
+    }
+
+    private EsbGetFileSourceDetailV3Req buildReq() {
+        EsbGetFileSourceDetailV3Req req = new EsbGetFileSourceDetailV3Req();
+        req.setScopeType(SCOPE_TYPE);
+        req.setScopeId(SCOPE_ID);
+        req.setCode(FILE_SOURCE_CODE);
+        return req;
+    }
+
+    private FileSourceDTO buildFileSourceDTO() {
+        FileSourceDTO dto = new FileSourceDTO();
+        dto.setId(FILE_SOURCE_ID);
+        dto.setAppId(APP_ID);
+        dto.setCode(FILE_SOURCE_CODE);
+        dto.setAlias(FILE_SOURCE_ALIAS);
+        dto.setCredentialId(CREDENTIAL_ID);
+        dto.setPublicFlag(false);
+        dto.setEnable(true);
+        dto.setCreator(USERNAME);
+        dto.setLastModifyUser(USERNAME);
+        dto.setCreateTime(System.currentTimeMillis());
+        dto.setLastModifyTime(System.currentTimeMillis());
+        return dto;
+    }
+
+    // ============================ POST 入口 ============================
+
+    @Test
+    @DisplayName("POST: 文件源不存在时抛 NotFoundException 且不进入 IAM 鉴权")
+    void postShouldThrowNotFoundWhenFileSourceNotFound() {
+        when(fileSourceService.getFileSourceByCode(eq(APP_ID), eq(FILE_SOURCE_CODE))).thenReturn(null);
+
+        assertThatThrownBy(() -> resource.getFileSourceDetailUsingPost(USERNAME, "appCode", buildReq()))
+            .isInstanceOf(NotFoundException.class);
+
+        verify(fileSourceAuthService, never())
+            .authViewFileSource(any(), any(AppResourceScope.class), anyInt(), anyString());
+        verify(fileSourceAuthService, never())
+            .authViewFileSource(any(), any(AppResourceScope.class), anyInt(), isNull());
+    }
+
+    @Test
+    @DisplayName("POST: 跨业务（错误 appId）查不到文件源同样抛 NotFoundException")
+    void postShouldThrowNotFoundForCrossBusinessQuery() {
+        // 模拟用户传入的 scope 仍解析为 APP_ID，但用户实际想查的是属于 OTHER_APP_ID 的文件源
+        // 由 DAO 层 (appId, code) 联合过滤天然隔离，返回 null
+        when(fileSourceService.getFileSourceByCode(eq(APP_ID), eq(FILE_SOURCE_CODE))).thenReturn(null);
+        FileSourceDTO otherAppFileSource = buildFileSourceDTO();
+        otherAppFileSource.setAppId(OTHER_APP_ID);
+        when(fileSourceService.getFileSourceByCode(eq(OTHER_APP_ID), eq(FILE_SOURCE_CODE)))
+            .thenReturn(otherAppFileSource);
+
+        assertThatThrownBy(() -> resource.getFileSourceDetailUsingPost(USERNAME, "appCode", buildReq()))
+            .isInstanceOf(NotFoundException.class);
+
+        // DAO 层只用请求里的 APP_ID 过滤，永远查不到 OTHER_APP_ID 的数据
+        verify(fileSourceService, times(1)).getFileSourceByCode(eq(APP_ID), eq(FILE_SOURCE_CODE));
+        verify(fileSourceService, never()).getFileSourceByCode(eq(OTHER_APP_ID), anyString());
+        verify(fileSourceAuthService, never())
+            .authViewFileSource(any(), any(AppResourceScope.class), anyInt(), anyString());
+    }
+
+    @Test
+    @DisplayName("POST: 文件源存在但用户无 view_file_source 权限时抛 PermissionDeniedException")
+    void postShouldThrowPermissionDeniedWhenNoViewPermission() {
+        when(fileSourceService.getFileSourceByCode(eq(APP_ID), eq(FILE_SOURCE_CODE)))
+            .thenReturn(buildFileSourceDTO());
+        when(fileSourceAuthService.authViewFileSource(
+            any(), any(AppResourceScope.class), eq(FILE_SOURCE_ID), eq(FILE_SOURCE_ALIAS)))
+            .thenReturn(AuthResult.fail(new User(TENANT_ID, USERNAME, USERNAME)));
+
+        assertThatThrownBy(() -> resource.getFileSourceDetailUsingPost(USERNAME, "appCode", buildReq()))
+            .isInstanceOf(PermissionDeniedException.class);
+
+        verify(fileSourceAuthService, times(1))
+            .authViewFileSource(any(), any(AppResourceScope.class), eq(FILE_SOURCE_ID), eq(FILE_SOURCE_ALIAS));
+    }
+
+    @Test
+    @DisplayName("POST: 文件源存在且用户有权限时正常返回，响应中 credential_id 字段被序列化")
+    void postShouldReturnDetailWhenAuthorized() {
+        when(fileSourceService.getFileSourceByCode(eq(APP_ID), eq(FILE_SOURCE_CODE)))
+            .thenReturn(buildFileSourceDTO());
+        when(fileSourceAuthService.authViewFileSource(
+            any(), any(AppResourceScope.class), eq(FILE_SOURCE_ID), eq(FILE_SOURCE_ALIAS)))
+            .thenReturn(AuthResult.pass(new User(TENANT_ID, USERNAME, USERNAME)));
+
+        EsbResp<EsbFileSourceV3DTO> resp = resource.getFileSourceDetailUsingPost(
+            USERNAME, "appCode", buildReq());
+
+        assertThat(resp).isNotNull();
+        EsbFileSourceV3DTO data = resp.getData();
+        assertThat(data).isNotNull();
+        assertThat(data.getId()).isEqualTo(FILE_SOURCE_ID);
+        assertThat(data.getCode()).isEqualTo(FILE_SOURCE_CODE);
+        assertThat(data.getAlias()).isEqualTo(FILE_SOURCE_ALIAS);
+        // 重点回归：响应体中 credential_id 字段被正确写入（之前缺失鉴权暴露的就是这个字段）
+        assertThat(data.getCredentialId()).isEqualTo(CREDENTIAL_ID);
+
+        verify(fileSourceAuthService, times(1))
+            .authViewFileSource(any(), any(AppResourceScope.class), eq(FILE_SOURCE_ID), eq(FILE_SOURCE_ALIAS));
+    }
+
+    // ============================ GET 入口 ============================
+
+    @Test
+    @DisplayName("GET: 委托给 POST，文件源存在且有权限时同样返回详情")
+    void getShouldDelegateToPostAndReturnDetail() {
+        when(fileSourceService.getFileSourceByCode(eq(APP_ID), eq(FILE_SOURCE_CODE)))
+            .thenReturn(buildFileSourceDTO());
+        when(fileSourceAuthService.authViewFileSource(
+            any(), any(AppResourceScope.class), eq(FILE_SOURCE_ID), eq(FILE_SOURCE_ALIAS)))
+            .thenReturn(AuthResult.pass(new User(TENANT_ID, USERNAME, USERNAME)));
+
+        EsbResp<EsbFileSourceV3DTO> resp = resource.getFileSourceDetail(
+            USERNAME, "appCode", null, SCOPE_TYPE, SCOPE_ID, FILE_SOURCE_CODE);
+
+        assertThat(resp).isNotNull();
+        assertThat(resp.getData()).isNotNull();
+        assertThat(resp.getData().getCredentialId()).isEqualTo(CREDENTIAL_ID);
+
+        verify(fileSourceAuthService, times(1))
+            .authViewFileSource(any(), any(AppResourceScope.class), eq(FILE_SOURCE_ID), eq(FILE_SOURCE_ALIAS));
+    }
+
+    @Test
+    @DisplayName("GET: 委托给 POST，无权限时同样抛 PermissionDeniedException")
+    void getShouldDelegateToPostAndDenyWithoutPermission() {
+        when(fileSourceService.getFileSourceByCode(eq(APP_ID), eq(FILE_SOURCE_CODE)))
+            .thenReturn(buildFileSourceDTO());
+        when(fileSourceAuthService.authViewFileSource(
+            any(), any(AppResourceScope.class), eq(FILE_SOURCE_ID), eq(FILE_SOURCE_ALIAS)))
+            .thenReturn(AuthResult.fail(new User(TENANT_ID, USERNAME, USERNAME)));
+
+        assertThatThrownBy(() -> resource.getFileSourceDetail(
+            USERNAME, "appCode", null, SCOPE_TYPE, SCOPE_ID, FILE_SOURCE_CODE))
+            .isInstanceOf(PermissionDeniedException.class);
+    }
+}

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/test/java/com/tencent/bk/job/file_gateway/auth/impl/FileSourceAuthServiceImplTest.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/test/java/com/tencent/bk/job/file_gateway/auth/impl/FileSourceAuthServiceImplTest.java
@@ -1,0 +1,115 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.file_gateway.auth.impl;
+
+import com.tencent.bk.job.common.constant.ResourceScopeTypeEnum;
+import com.tencent.bk.job.common.iam.constant.ActionId;
+import com.tencent.bk.job.common.iam.constant.ResourceTypeEnum;
+import com.tencent.bk.job.common.iam.model.AuthResult;
+import com.tencent.bk.job.common.iam.service.AppAuthService;
+import com.tencent.bk.job.common.iam.service.AuthService;
+import com.tencent.bk.job.common.model.User;
+import com.tencent.bk.job.common.model.dto.AppResourceScope;
+import com.tencent.bk.sdk.iam.dto.PathInfoDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 验证 FileSourceAuthServiceImpl 中新增的 USE_TICKET 校验路由到 AuthService.auth(USE_TICKET, TICKET, ...)。
+ *
+ * <p>说明：service-job-file-gateway 模块未依赖 service-job-manage 模块，
+ * 因此 USE_TICKET 校验直接在本模块内通过 AuthService 公共能力实现，
+ * 测试需要保证：1) actionId/resourceType 正确；2) 资源路径携带 appResourceScope 信息。</p>
+ */
+@DisplayName("FileSourceAuthServiceImpl USE_TICKET 鉴权路由测试")
+class FileSourceAuthServiceImplTest {
+
+    private AuthService authService;
+    private AppAuthService appAuthService;
+    private FileSourceAuthServiceImpl fileSourceAuthService;
+
+    private static final String TENANT_ID = "default";
+    private static final String USERNAME = "tester";
+    private static final long APP_ID = 100L;
+    private static final String TICKET_ID = "ticket-1";
+
+    @BeforeEach
+    void setUp() {
+        authService = mock(AuthService.class);
+        appAuthService = mock(AppAuthService.class);
+        fileSourceAuthService = new FileSourceAuthServiceImpl(authService, appAuthService);
+    }
+
+    @Test
+    @DisplayName("authUseTicket 应当调用 AuthService.auth 且 actionId=USE_TICKET、resourceType=TICKET")
+    void authUseTicketShouldRouteToAuthServiceWithCorrectActionAndResourceType() {
+        User user = new User(TENANT_ID, USERNAME, USERNAME);
+        AppResourceScope scope = new AppResourceScope(APP_ID);
+        scope.setType(ResourceScopeTypeEnum.BIZ);
+        scope.setId("100");
+        AuthResult expected = AuthResult.pass(user);
+        when(authService.auth(eq(user), eq(ActionId.USE_TICKET), eq(ResourceTypeEnum.TICKET),
+            eq(TICKET_ID), any(PathInfoDTO.class))).thenReturn(expected);
+
+        AuthResult result = fileSourceAuthService.authUseTicket(user, scope, TICKET_ID);
+
+        assertThat(result).isSameAs(expected);
+
+        ArgumentCaptor<PathInfoDTO> pathCaptor = ArgumentCaptor.forClass(PathInfoDTO.class);
+        verify(authService, times(1)).auth(eq(user), eq(ActionId.USE_TICKET), eq(ResourceTypeEnum.TICKET),
+            eq(TICKET_ID), pathCaptor.capture());
+        PathInfoDTO path = pathCaptor.getValue();
+        assertThat(path).isNotNull();
+        assertThat(path.getId()).isEqualTo("100");
+    }
+
+    @Test
+    @DisplayName("authUseTicket 校验失败时透传 AuthResult.fail()")
+    void authUseTicketShouldPropagateFailResult() {
+        User user = new User(TENANT_ID, USERNAME, USERNAME);
+        AppResourceScope scope = new AppResourceScope(APP_ID);
+        scope.setType(ResourceScopeTypeEnum.BIZ);
+        scope.setId("100");
+        AuthResult failResult = AuthResult.fail(user);
+        when(authService.auth(eq(user), eq(ActionId.USE_TICKET), eq(ResourceTypeEnum.TICKET),
+            eq(TICKET_ID), any(PathInfoDTO.class))).thenReturn(failResult);
+
+        AuthResult result = fileSourceAuthService.authUseTicket(user, scope, TICKET_ID);
+
+        assertThat(result.isPass()).isFalse();
+        verify(authService, times(1)).auth(eq(user), eq(ActionId.USE_TICKET), eq(ResourceTypeEnum.TICKET),
+            eq(TICKET_ID), any(PathInfoDTO.class));
+    }
+}

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/test/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceServiceImplTest.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/test/java/com/tencent/bk/job/file_gateway/service/impl/FileSourceServiceImplTest.java
@@ -1,0 +1,288 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.file_gateway.service.impl;
+
+import com.tencent.bk.job.common.constant.ResourceScopeTypeEnum;
+import com.tencent.bk.job.common.iam.exception.PermissionDeniedException;
+import com.tencent.bk.job.common.iam.model.AuthResult;
+import com.tencent.bk.job.common.model.User;
+import com.tencent.bk.job.common.model.dto.AppResourceScope;
+import com.tencent.bk.job.common.service.AppScopeMappingService;
+import com.tencent.bk.job.common.util.ApplicationContextRegister;
+import com.tencent.bk.job.file_gateway.auth.FileSourceAuthService;
+import com.tencent.bk.job.file_gateway.dao.filesource.CurrentTenantFileSourceDAO;
+import com.tencent.bk.job.file_gateway.dao.filesource.FileSourceTypeDAO;
+import com.tencent.bk.job.file_gateway.dao.filesource.FileWorkerDAO;
+import com.tencent.bk.job.file_gateway.model.dto.FileSourceDTO;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 验证文件源创建/更新时对绑定凭据 ID 的 USE_TICKET 权限校验，
+ * 与 #4280 同范畴的"权限校验不正确"修复。
+ *
+ * <p>覆盖维度：</p>
+ * <ul>
+ *     <li>save: credentialId 为空 -> 不校验 USE_TICKET，正常落库</li>
+ *     <li>save: 有 file_source 创建权限但无 use_ticket 权限 -> 抛 PermissionDeniedException 且不写库</li>
+ *     <li>save: 同时具备两类权限 -> 正常落库</li>
+ *     <li>update: credentialId 为空 -> 不校验 USE_TICKET，正常更新</li>
+ *     <li>update: 有 file_source 管理权限但无 use_ticket 权限 -> 抛 PermissionDeniedException 且不写库</li>
+ *     <li>update: 同时具备两类权限 -> 正常更新</li>
+ * </ul>
+ */
+@DisplayName("FileSourceServiceImpl USE_TICKET 校验测试")
+class FileSourceServiceImplTest {
+
+    private FileSourceTypeDAO fileSourceTypeDAO;
+    private CurrentTenantFileSourceDAO currentTenantFileSourceDAO;
+    private FileWorkerDAO fileWorkerDAO;
+    private FileSourceAuthService fileSourceAuthService;
+    private FileSourceServiceImpl fileSourceService;
+
+    private MockedStatic<ApplicationContextRegister> applicationContextRegisterMock;
+
+    private static final String TENANT_ID = "default";
+    private static final String NORMAL_USER = "normal_user";
+    private static final long APP_ID = 100L;
+    private static final String CREDENTIAL_ID = "credential-1";
+    private static final int FILE_SOURCE_ID = 999;
+
+    @BeforeEach
+    void setUp() {
+        fileSourceTypeDAO = mock(FileSourceTypeDAO.class);
+        currentTenantFileSourceDAO = mock(CurrentTenantFileSourceDAO.class);
+        fileWorkerDAO = mock(FileWorkerDAO.class);
+        fileSourceAuthService = mock(FileSourceAuthService.class);
+        fileSourceService = new FileSourceServiceImpl(
+            fileSourceTypeDAO,
+            currentTenantFileSourceDAO,
+            fileWorkerDAO,
+            fileSourceAuthService
+        );
+
+        // updateFileSourceById 中通过 ActionAuditContext.current().setOriginInstance(FileSourceDTO.toEsbFileSourceV3DTO(..))
+        // 间接调用 ApplicationContextRegister.getBean(AppScopeMappingService.class)，
+        // 在纯单测无 Spring 上下文，需 mockStatic 提供 AppScopeMappingService。
+        applicationContextRegisterMock = Mockito.mockStatic(ApplicationContextRegister.class);
+        AppScopeMappingService appScopeMappingService = mock(AppScopeMappingService.class);
+        when(appScopeMappingService.getScopeByAppId(anyLong()))
+            .thenReturn(new com.tencent.bk.job.common.model.dto.ResourceScope(
+                ResourceScopeTypeEnum.BIZ, "100"));
+        applicationContextRegisterMock.when(() -> ApplicationContextRegister.getBean(AppScopeMappingService.class))
+            .thenReturn(appScopeMappingService);
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (applicationContextRegisterMock != null) {
+            applicationContextRegisterMock.close();
+        }
+    }
+
+    private User mockUser() {
+        return new User(TENANT_ID, NORMAL_USER, NORMAL_USER);
+    }
+
+    private FileSourceDTO buildFileSourceDTO(String credentialId, Integer id) {
+        FileSourceDTO dto = new FileSourceDTO();
+        dto.setId(id);
+        dto.setAppId(APP_ID);
+        dto.setCode("file_source_code");
+        dto.setAlias("alias");
+        dto.setCredentialId(credentialId);
+        dto.setCreator(NORMAL_USER);
+        dto.setLastModifyUser(NORMAL_USER);
+        dto.setCreateTime(System.currentTimeMillis());
+        dto.setLastModifyTime(System.currentTimeMillis());
+        // publicFlag/enable 是基础类型字段（Boolean -> boolean 自动拆箱），需显式赋值避免 NPE
+        dto.setPublicFlag(false);
+        dto.setEnable(true);
+        return dto;
+    }
+
+    private void givenFileSourceCreatePermission() {
+        when(fileSourceAuthService.authCreateFileSource(any(), any()))
+            .thenReturn(AuthResult.pass(mockUser()));
+    }
+
+    private void givenFileSourceManagePermission() {
+        when(fileSourceAuthService.authManageFileSource(any(), any(), anyInt(), any()))
+            .thenReturn(AuthResult.pass(mockUser()));
+    }
+
+    private void givenUseTicketPermission() {
+        when(fileSourceAuthService.authUseTicket(any(), any(AppResourceScope.class), anyString()))
+            .thenReturn(AuthResult.pass(mockUser()));
+    }
+
+    private void givenNoUseTicketPermission() {
+        when(fileSourceAuthService.authUseTicket(any(), any(AppResourceScope.class), anyString()))
+            .thenReturn(AuthResult.fail(mockUser()));
+    }
+
+    // ============================ save 场景 ============================
+
+    @Test
+    @DisplayName("save：credentialId 为空时跳过 USE_TICKET 校验，正常入库")
+    void saveWithBlankCredentialIdShouldSkipUseTicketAuth() {
+        User user = mockUser();
+        givenFileSourceCreatePermission();
+        when(currentTenantFileSourceDAO.existsCode(eq(APP_ID), anyString())).thenReturn(false);
+        when(currentTenantFileSourceDAO.checkFileSourceExists(eq(APP_ID), anyString())).thenReturn(false);
+        when(currentTenantFileSourceDAO.insertFileSource(any(FileSourceDTO.class))).thenReturn(FILE_SOURCE_ID);
+        when(currentTenantFileSourceDAO.getFileSourceById(eq(FILE_SOURCE_ID)))
+            .thenReturn(buildFileSourceDTO(null, FILE_SOURCE_ID));
+        when(fileSourceAuthService.registerFileSource(any(), eq(FILE_SOURCE_ID), anyString())).thenReturn(true);
+
+        FileSourceDTO toSave = buildFileSourceDTO(null, null);
+
+        assertThatCode(() -> fileSourceService.saveFileSource(user, APP_ID, toSave))
+            .doesNotThrowAnyException();
+
+        verify(fileSourceAuthService, never())
+            .authUseTicket(any(), any(AppResourceScope.class), anyString());
+        verify(currentTenantFileSourceDAO, times(1)).insertFileSource(any(FileSourceDTO.class));
+    }
+
+    @Test
+    @DisplayName("save：有 file_source 权限但无 use_ticket 权限时被拒，且不写库")
+    void saveWithoutUseTicketPermissionShouldDeny() {
+        User user = mockUser();
+        givenFileSourceCreatePermission();
+        givenNoUseTicketPermission();
+
+        FileSourceDTO toSave = buildFileSourceDTO(CREDENTIAL_ID, null);
+
+        assertThatThrownBy(() -> fileSourceService.saveFileSource(user, APP_ID, toSave))
+            .isInstanceOf(PermissionDeniedException.class);
+
+        verify(fileSourceAuthService, times(1))
+            .authUseTicket(any(), any(AppResourceScope.class), eq(CREDENTIAL_ID));
+        verify(currentTenantFileSourceDAO, never()).insertFileSource(any(FileSourceDTO.class));
+    }
+
+    @Test
+    @DisplayName("save：同时具备 file_source 与 use_ticket 权限时正常入库")
+    void saveWithFullPermissionShouldPass() {
+        User user = mockUser();
+        givenFileSourceCreatePermission();
+        givenUseTicketPermission();
+        when(currentTenantFileSourceDAO.existsCode(eq(APP_ID), anyString())).thenReturn(false);
+        when(currentTenantFileSourceDAO.checkFileSourceExists(eq(APP_ID), anyString())).thenReturn(false);
+        when(currentTenantFileSourceDAO.insertFileSource(any(FileSourceDTO.class))).thenReturn(FILE_SOURCE_ID);
+        when(currentTenantFileSourceDAO.getFileSourceById(eq(FILE_SOURCE_ID)))
+            .thenReturn(buildFileSourceDTO(CREDENTIAL_ID, FILE_SOURCE_ID));
+        when(fileSourceAuthService.registerFileSource(any(), eq(FILE_SOURCE_ID), anyString())).thenReturn(true);
+
+        FileSourceDTO toSave = buildFileSourceDTO(CREDENTIAL_ID, null);
+
+        assertThatCode(() -> fileSourceService.saveFileSource(user, APP_ID, toSave))
+            .doesNotThrowAnyException();
+
+        verify(fileSourceAuthService, times(1))
+            .authUseTicket(any(), any(AppResourceScope.class), eq(CREDENTIAL_ID));
+        verify(currentTenantFileSourceDAO, times(1)).insertFileSource(any(FileSourceDTO.class));
+    }
+
+    // ============================ update 场景 ============================
+
+    @Test
+    @DisplayName("update：credentialId 为空时跳过 USE_TICKET 校验，正常更新")
+    void updateWithBlankCredentialIdShouldSkipUseTicketAuth() {
+        User user = mockUser();
+        givenFileSourceManagePermission();
+        when(currentTenantFileSourceDAO.existsCodeExceptId(eq(APP_ID), anyString(), eq(FILE_SOURCE_ID)))
+            .thenReturn(false);
+        when(currentTenantFileSourceDAO.getFileSourceById(eq(FILE_SOURCE_ID)))
+            .thenReturn(buildFileSourceDTO(null, FILE_SOURCE_ID));
+        when(currentTenantFileSourceDAO.updateFileSource(any(FileSourceDTO.class))).thenReturn(1);
+
+        FileSourceDTO toUpdate = buildFileSourceDTO(null, FILE_SOURCE_ID);
+
+        assertThatCode(() -> fileSourceService.updateFileSourceById(user, APP_ID, toUpdate))
+            .doesNotThrowAnyException();
+
+        verify(fileSourceAuthService, never())
+            .authUseTicket(any(), any(AppResourceScope.class), anyString());
+        verify(currentTenantFileSourceDAO, times(1)).updateFileSource(any(FileSourceDTO.class));
+    }
+
+    @Test
+    @DisplayName("update：有 file_source 权限但无 use_ticket 权限时被拒，且不写库")
+    void updateWithoutUseTicketPermissionShouldDeny() {
+        User user = mockUser();
+        givenFileSourceManagePermission();
+        givenNoUseTicketPermission();
+
+        FileSourceDTO toUpdate = buildFileSourceDTO(CREDENTIAL_ID, FILE_SOURCE_ID);
+
+        assertThatThrownBy(() -> fileSourceService.updateFileSourceById(user, APP_ID, toUpdate))
+            .isInstanceOf(PermissionDeniedException.class);
+
+        verify(fileSourceAuthService, times(1))
+            .authUseTicket(any(), any(AppResourceScope.class), eq(CREDENTIAL_ID));
+        verify(currentTenantFileSourceDAO, never()).updateFileSource(any(FileSourceDTO.class));
+    }
+
+    @Test
+    @DisplayName("update：同时具备 file_source 与 use_ticket 权限时正常更新")
+    void updateWithFullPermissionShouldPass() {
+        User user = mockUser();
+        givenFileSourceManagePermission();
+        givenUseTicketPermission();
+        when(currentTenantFileSourceDAO.existsCodeExceptId(eq(APP_ID), anyString(), eq(FILE_SOURCE_ID)))
+            .thenReturn(false);
+        when(currentTenantFileSourceDAO.getFileSourceById(eq(FILE_SOURCE_ID)))
+            .thenReturn(buildFileSourceDTO(CREDENTIAL_ID, FILE_SOURCE_ID));
+        when(currentTenantFileSourceDAO.updateFileSource(any(FileSourceDTO.class))).thenReturn(1);
+
+        FileSourceDTO toUpdate = buildFileSourceDTO(CREDENTIAL_ID, FILE_SOURCE_ID);
+
+        assertThatCode(() -> fileSourceService.updateFileSourceById(user, APP_ID, toUpdate))
+            .doesNotThrowAnyException();
+
+        verify(fileSourceAuthService, times(1))
+            .authUseTicket(any(), any(AppResourceScope.class), eq(CREDENTIAL_ID));
+        verify(currentTenantFileSourceDAO, times(1)).updateFileSource(any(FileSourceDTO.class));
+    }
+}

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbCredentialResourceV3Impl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbCredentialResourceV3Impl.java
@@ -30,6 +30,7 @@ import com.tencent.bk.job.common.constant.ErrorCode;
 import com.tencent.bk.job.common.esb.metrics.EsbApiTimed;
 import com.tencent.bk.job.common.esb.model.EsbResp;
 import com.tencent.bk.job.common.exception.InvalidParamException;
+import com.tencent.bk.job.common.exception.NotFoundException;
 import com.tencent.bk.job.common.iam.constant.ActionId;
 import com.tencent.bk.job.common.metrics.CommonMetricNames;
 import com.tencent.bk.job.common.model.User;
@@ -136,7 +137,13 @@ public class EsbCredentialResourceV3Impl implements EsbCredentialV3Resource {
         String username,
         String appCode,
         @AuditRequestBody EsbGetCredentialDetailV3Req req) {
-        CredentialDTO credentialDTO = credentialService.getCredentialById(req.getId());
+        // 修复跨业务越权读：必须按 appId 隔离查询，避免普通用户凭任意凭据 id 读取其他业务的凭据。
+        // GET 接口已在转调前补全 appId，POST 直接接收外部请求时也需要在此显式补全一次。
+        req.fillAppResourceScope(appScopeMappingService);
+        CredentialDTO credentialDTO = credentialService.getCredentialById(req.getAppId(), req.getId());
+        if (credentialDTO == null) {
+            throw new NotFoundException(ErrorCode.CREDENTIAL_NOT_EXIST);
+        }
         return EsbResp.buildSuccessResp(credentialDTO.toEsbCredentialV3DTO());
     }
 

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbDangerousRuleV3ResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbDangerousRuleV3ResourceImpl.java
@@ -29,11 +29,14 @@ import com.tencent.bk.audit.annotations.AuditRequestBody;
 import com.tencent.bk.job.common.esb.metrics.EsbApiTimed;
 import com.tencent.bk.job.common.esb.model.EsbResp;
 import com.tencent.bk.job.common.iam.constant.ActionId;
+import com.tencent.bk.job.common.iam.exception.PermissionDeniedException;
+import com.tencent.bk.job.common.iam.model.AuthResult;
 import com.tencent.bk.job.common.metrics.CommonMetricNames;
 import com.tencent.bk.job.common.model.User;
 import com.tencent.bk.job.common.util.JobContextUtil;
 import com.tencent.bk.job.manage.api.common.constants.EnableStatusEnum;
 import com.tencent.bk.job.manage.api.esb.v3.EsbDangerousRuleV3Resource;
+import com.tencent.bk.job.manage.auth.NoResourceScopeAuthService;
 import com.tencent.bk.job.manage.model.dto.globalsetting.DangerousRuleDTO;
 import com.tencent.bk.job.manage.model.esb.v3.request.EsbCreateDangerousRuleV3Req;
 import com.tencent.bk.job.manage.model.esb.v3.request.EsbGetDangerousRuleV3Req;
@@ -57,10 +60,13 @@ import java.util.stream.Collectors;
 @Slf4j
 public class EsbDangerousRuleV3ResourceImpl implements EsbDangerousRuleV3Resource {
     private final CurrentTenantDangerousRuleService currentTenantDangerousRuleService;
+    private final NoResourceScopeAuthService noResourceScopeAuthService;
 
     @Autowired
-    public EsbDangerousRuleV3ResourceImpl(CurrentTenantDangerousRuleService currentTenantDangerousRuleService) {
+    public EsbDangerousRuleV3ResourceImpl(CurrentTenantDangerousRuleService currentTenantDangerousRuleService,
+                                          NoResourceScopeAuthService noResourceScopeAuthService) {
         this.currentTenantDangerousRuleService = currentTenantDangerousRuleService;
+        this.noResourceScopeAuthService = noResourceScopeAuthService;
     }
 
     @Override
@@ -70,6 +76,7 @@ public class EsbDangerousRuleV3ResourceImpl implements EsbDangerousRuleV3Resourc
                                                               String appCode,
                                                               @AuditRequestBody EsbCreateDangerousRuleV3Req request) {
         User user = JobContextUtil.getUser();
+        authHighRiskDetectRule(user);
         AddOrUpdateDangerousRuleReq req = new AddOrUpdateDangerousRuleReq();
         req.setExpression(request.getExpression());
         req.setScriptTypeList(request.getScriptTypeList());
@@ -86,6 +93,7 @@ public class EsbDangerousRuleV3ResourceImpl implements EsbDangerousRuleV3Resourc
                                                               String appCode,
                                                               @AuditRequestBody EsbUpdateDangerousRuleV3Req request) {
         User user = JobContextUtil.getUser();
+        authHighRiskDetectRule(user);
         AddOrUpdateDangerousRuleReq req = new AddOrUpdateDangerousRuleReq();
         DangerousRuleDTO dangerousRuleDTO = currentTenantDangerousRuleService.getDangerousRuleById(request.getId());
         req.setId(request.getId());
@@ -105,6 +113,7 @@ public class EsbDangerousRuleV3ResourceImpl implements EsbDangerousRuleV3Resourc
                                        String appCode,
                                        @AuditRequestBody EsbManageDangerousRuleV3Req request) {
         User user = JobContextUtil.getUser();
+        authHighRiskDetectRule(user);
         currentTenantDangerousRuleService.deleteDangerousRuleById(user, request.getId());
         return EsbResp.buildSuccessResp(null);
     }
@@ -136,6 +145,7 @@ public class EsbDangerousRuleV3ResourceImpl implements EsbDangerousRuleV3Resourc
                                                               String appCode,
                                                               @AuditRequestBody EsbManageDangerousRuleV3Req request) {
         User user = JobContextUtil.getUser();
+        authHighRiskDetectRule(user);
         DangerousRuleDTO dangerousRuleDTO = currentTenantDangerousRuleService.updateDangerousRuleStatus(user,
             request.getId(),
             EnableStatusEnum.ENABLED);
@@ -150,9 +160,22 @@ public class EsbDangerousRuleV3ResourceImpl implements EsbDangerousRuleV3Resourc
         String appCode,
         @AuditRequestBody EsbManageDangerousRuleV3Req request) {
         User user = JobContextUtil.getUser();
+        authHighRiskDetectRule(user);
         DangerousRuleDTO dangerousRuleDTO = currentTenantDangerousRuleService.updateDangerousRuleStatus(user,
             request.getId(),
             EnableStatusEnum.DISABLED);
         return EsbResp.buildSuccessResp(dangerousRuleDTO.toEsbDangerousRuleStatusV3DTO());
+    }
+
+    /**
+     * 高危语句规则管理鉴权，与 Web 接口 {@code /web/dangerousRule/**}
+     * 的 {@code JobManageUriPermissionInterceptor} 保持一致，
+     * 仅放行拥有 {@link ActionId#HIGH_RISK_DETECT_RULE} 权限的用户（默认仅平台管理员）。
+     */
+    private void authHighRiskDetectRule(User user) {
+        AuthResult authResult = noResourceScopeAuthService.authHighRiskDetectRule(user);
+        if (!authResult.isPass()) {
+            throw new PermissionDeniedException(authResult);
+        }
     }
 }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbDangerousRuleV3ResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbDangerousRuleV3ResourceImpl.java
@@ -125,6 +125,8 @@ public class EsbDangerousRuleV3ResourceImpl implements EsbDangerousRuleV3Resourc
         String username,
         String appCode,
         @AuditRequestBody EsbGetDangerousRuleV3Req request) {
+        User user = JobContextUtil.getUser();
+        authHighRiskDetectRule(user);
         DangerousRuleQuery query = DangerousRuleQuery.builder()
             .expression(request.getExpression())
             .description(request.getDescription())

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbServiceInfoV3ResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbServiceInfoV3ResourceImpl.java
@@ -28,9 +28,15 @@ import com.tencent.bk.job.common.constant.ProfileEnum;
 import com.tencent.bk.job.common.discovery.ServiceInfoProvider;
 import com.tencent.bk.job.common.discovery.model.ServiceInstanceInfoDTO;
 import com.tencent.bk.job.common.esb.model.EsbResp;
+import com.tencent.bk.job.common.iam.exception.PermissionDeniedException;
+import com.tencent.bk.job.common.iam.model.AuthResult;
+import com.tencent.bk.job.common.model.User;
 import com.tencent.bk.job.common.util.CompareUtil;
+import com.tencent.bk.job.common.util.JobContextUtil;
 import com.tencent.bk.job.manage.api.esb.v3.EsbServiceInfoV3Resource;
+import com.tencent.bk.job.manage.auth.NoResourceScopeAuthService;
 import com.tencent.bk.job.manage.model.esb.v3.response.EsbServiceVersionV3DTO;
+import com.tencent.bk.job.manage.service.impl.ServiceInfoService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
@@ -44,10 +50,16 @@ import java.util.List;
 public class EsbServiceInfoV3ResourceImpl implements EsbServiceInfoV3Resource {
 
     private final ServiceInfoProvider serviceInfoProvider;
+    private final NoResourceScopeAuthService noResourceScopeAuthService;
+    private final ServiceInfoService serviceInfoService;
 
     @Autowired
-    public EsbServiceInfoV3ResourceImpl(ServiceInfoProvider serviceInfoProvider) {
-        this.serviceInfoProvider = serviceInfoProvider;;
+    public EsbServiceInfoV3ResourceImpl(ServiceInfoProvider serviceInfoProvider,
+                                        NoResourceScopeAuthService noResourceScopeAuthService,
+                                        ServiceInfoService serviceInfoService) {
+        this.serviceInfoProvider = serviceInfoProvider;
+        this.noResourceScopeAuthService = noResourceScopeAuthService;
+        this.serviceInfoService = serviceInfoService;
     }
 
 
@@ -60,6 +72,9 @@ public class EsbServiceInfoV3ResourceImpl implements EsbServiceInfoV3Resource {
     @Override
     public EsbResp<EsbServiceVersionV3DTO> getLatestServiceVersionUsingPost(String username,
                                                                             String appCode) {
+        User user = JobContextUtil.getUser();
+        authViewServiceState(user);
+        serviceInfoService.checkTenantAccess();
         List<ServiceInstanceInfoDTO> instanceInfoDTOList = serviceInfoProvider.listServiceInfo();
         ServiceInstanceInfoDTO latestVersionInstance = findLatestVersionInstance(instanceInfoDTOList);
         EsbServiceVersionV3DTO esbServiceVersionV3DTO = new EsbServiceVersionV3DTO();
@@ -67,6 +82,18 @@ public class EsbServiceInfoV3ResourceImpl implements EsbServiceInfoV3Resource {
             esbServiceVersionV3DTO.setVersion(latestVersionInstance.getVersion());
         }
         return EsbResp.buildSuccessResp(esbServiceVersionV3DTO);
+    }
+
+    /**
+     * 服务状态查看鉴权，与 Web 端 {@code /web/serviceInfo/**}
+     * 的 {@code JobManageUriPermissionInterceptor} 保持一致，
+     * 仅放行拥有 {@link com.tencent.bk.job.common.iam.constant.ActionId#SERVICE_STATE_ACCESS} 权限的用户。
+     */
+    private void authViewServiceState(User user) {
+        AuthResult authResult = noResourceScopeAuthService.authViewServiceState(user);
+        if (!authResult.isPass()) {
+            throw new PermissionDeniedException(authResult);
+        }
     }
 
     private static ServiceInstanceInfoDTO findLatestVersionInstance(List<ServiceInstanceInfoDTO> instanceInfoDTOList) {

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebServiceInfoResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebServiceInfoResourceImpl.java
@@ -27,14 +27,9 @@ package com.tencent.bk.job.manage.api.web.impl;
 import com.tencent.bk.audit.annotations.ActionAuditRecord;
 import com.tencent.bk.audit.annotations.AuditEntry;
 import com.tencent.bk.job.common.audit.constants.EventContentConstants;
-import com.tencent.bk.job.common.constant.ErrorCode;
 import com.tencent.bk.job.common.constant.ProfileEnum;
-import com.tencent.bk.job.common.constant.TenantIdConstants;
-import com.tencent.bk.job.common.exception.NotFoundException;
 import com.tencent.bk.job.common.iam.constant.ActionId;
 import com.tencent.bk.job.common.model.Response;
-import com.tencent.bk.job.common.tenant.TenantEnvService;
-import com.tencent.bk.job.common.util.JobContextUtil;
 import com.tencent.bk.job.manage.api.web.WebServiceInfoResource;
 import com.tencent.bk.job.manage.model.web.vo.serviceinfo.ServiceInfoVO;
 import com.tencent.bk.job.manage.service.impl.ServiceInfoService;
@@ -51,12 +46,10 @@ import java.util.List;
 public class WebServiceInfoResourceImpl implements WebServiceInfoResource {
 
     private final ServiceInfoService serviceInfoService;
-    private final TenantEnvService tenantEnvService;
 
     @Autowired
-    public WebServiceInfoResourceImpl(ServiceInfoService serviceInfoService, TenantEnvService tenantEnvService) {
+    public WebServiceInfoResourceImpl(ServiceInfoService serviceInfoService) {
         this.serviceInfoService = serviceInfoService;
-        this.tenantEnvService = tenantEnvService;
     }
 
     @Override
@@ -66,12 +59,7 @@ public class WebServiceInfoResourceImpl implements WebServiceInfoResource {
         content = EventContentConstants.VIEW_PLATFORM_SERVICE_STAT
     )
     public Response<List<ServiceInfoVO>> listServiceInfo(String username) {
-        if (tenantEnvService.isTenantEnabled()) {
-            String tenantId = JobContextUtil.getTenantId();
-            if (!TenantIdConstants.SYSTEM_TENANT_ID.equals(tenantId)) {
-                throw new NotFoundException(ErrorCode.NOT_SUPPORT_FEATURE);
-            }
-        }
+        serviceInfoService.checkTenantAccess();
         return Response.buildSuccessResp(serviceInfoService.listServiceInfo());
     }
 }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/ServiceInfoService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/ServiceInfoService.java
@@ -24,10 +24,15 @@
 
 package com.tencent.bk.job.manage.service.impl;
 
+import com.tencent.bk.job.common.constant.ErrorCode;
 import com.tencent.bk.job.common.constant.ProfileEnum;
+import com.tencent.bk.job.common.constant.TenantIdConstants;
 import com.tencent.bk.job.common.discovery.ServiceInfoProvider;
 import com.tencent.bk.job.common.discovery.model.ServiceInstanceInfoDTO;
+import com.tencent.bk.job.common.exception.NotFoundException;
+import com.tencent.bk.job.common.tenant.TenantEnvService;
 import com.tencent.bk.job.common.util.CompareUtil;
+import com.tencent.bk.job.common.util.JobContextUtil;
 import com.tencent.bk.job.manage.model.web.vo.serviceinfo.ServiceInfoVO;
 import com.tencent.bk.job.manage.model.web.vo.serviceinfo.ServiceInstanceInfoVO;
 import lombok.extern.slf4j.Slf4j;
@@ -46,10 +51,26 @@ import java.util.Map;
 public class ServiceInfoService {
 
     private final ServiceInfoProvider serviceInfoProvider;
+    private final TenantEnvService tenantEnvService;
 
     @Autowired
-    public ServiceInfoService(ServiceInfoProvider serviceInfoProvider) {
+    public ServiceInfoService(ServiceInfoProvider serviceInfoProvider, TenantEnvService tenantEnvService) {
         this.serviceInfoProvider = serviceInfoProvider;
+        this.tenantEnvService = tenantEnvService;
+    }
+
+    /**
+     * 服务信息相关接口的租户访问校验：开启多租户时仅允许系统租户访问。
+     * 与 Web 端 {@link com.tencent.bk.job.manage.api.web.impl.WebServiceInfoResourceImpl}
+     * 中原有的内联实现保持一致，供 Web/ESB 共用，避免逻辑漂移。
+     */
+    public void checkTenantAccess() {
+        if (tenantEnvService.isTenantEnabled()) {
+            String tenantId = JobContextUtil.getTenantId();
+            if (!TenantIdConstants.SYSTEM_TENANT_ID.equals(tenantId)) {
+                throw new NotFoundException(ErrorCode.NOT_SUPPORT_FEATURE);
+            }
+        }
     }
 
     private static ServiceInstanceInfoVO convert(ServiceInstanceInfoDTO serviceInstanceInfoDTO) {

--- a/src/backend/job-manage/service-job-manage/src/test/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbCredentialResourceV3ImplTest.java
+++ b/src/backend/job-manage/service-job-manage/src/test/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbCredentialResourceV3ImplTest.java
@@ -1,0 +1,155 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.api.esb.impl.v3;
+
+import com.tencent.bk.job.common.constant.ErrorCode;
+import com.tencent.bk.job.common.constant.ResourceScopeTypeEnum;
+import com.tencent.bk.job.common.esb.model.EsbResp;
+import com.tencent.bk.job.common.exception.NotFoundException;
+import com.tencent.bk.job.common.exception.ServiceException;
+import com.tencent.bk.job.common.service.AppScopeMappingService;
+import com.tencent.bk.job.manage.model.dto.CredentialDTO;
+import com.tencent.bk.job.manage.model.esb.v3.request.EsbGetCredentialDetailV3Req;
+import com.tencent.bk.job.manage.model.esb.v3.response.EsbCredentialV3DTO;
+import com.tencent.bk.job.manage.service.CredentialService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 验证 ESB 凭据详情接口必须按 appId 隔离查询，避免跨业务越权读。
+ */
+@DisplayName("EsbCredentialResourceV3Impl 越权读修复测试")
+class EsbCredentialResourceV3ImplTest {
+
+    private CredentialService credentialService;
+    private AppScopeMappingService appScopeMappingService;
+    private EsbCredentialResourceV3Impl resource;
+
+    private static final String CREDENTIAL_ID = "credential-id-001";
+    private static final Long OWNER_APP_ID = 100L;
+    private static final Long ATTACKER_APP_ID = 200L;
+    private static final String SCOPE_TYPE = ResourceScopeTypeEnum.BIZ.getValue();
+    private static final String OWNER_SCOPE_ID = "100";
+    private static final String ATTACKER_SCOPE_ID = "200";
+
+    @BeforeEach
+    void setUp() {
+        credentialService = mock(CredentialService.class);
+        appScopeMappingService = mock(AppScopeMappingService.class);
+        resource = new EsbCredentialResourceV3Impl(credentialService, appScopeMappingService);
+    }
+
+    private EsbGetCredentialDetailV3Req buildReq(String scopeType, String scopeId) {
+        EsbGetCredentialDetailV3Req req = new EsbGetCredentialDetailV3Req();
+        req.setScopeType(scopeType);
+        req.setScopeId(scopeId);
+        req.setId(CREDENTIAL_ID);
+        return req;
+    }
+
+    @Test
+    @DisplayName("跨业务（攻击者 appId 不属于凭据归属业务）查询返回 CREDENTIAL_NOT_EXIST")
+    void getCredentialDetailUsingPostFromAnotherAppShouldFail() {
+        when(appScopeMappingService.getAppIdByScope(eq(SCOPE_TYPE), eq(ATTACKER_SCOPE_ID)))
+            .thenReturn(ATTACKER_APP_ID);
+        // 仿真 service 行为：当 appId 与凭据的真实归属 appId 不一致时返回 null
+        when(credentialService.getCredentialById(eq(ATTACKER_APP_ID), eq(CREDENTIAL_ID)))
+            .thenReturn(null);
+
+        EsbGetCredentialDetailV3Req req = buildReq(SCOPE_TYPE, ATTACKER_SCOPE_ID);
+
+        assertThatThrownBy(() -> resource.getCredentialDetailUsingPost("attacker", "test_app", req))
+            .isInstanceOf(NotFoundException.class)
+            .extracting(e -> ((ServiceException) e).getErrorCode())
+            .isEqualTo(ErrorCode.CREDENTIAL_NOT_EXIST);
+
+        verify(credentialService, times(1)).getCredentialById(eq(ATTACKER_APP_ID), eq(CREDENTIAL_ID));
+    }
+
+    @Test
+    @DisplayName("攻击者直接调用必须使用解析出来的 appId 查询，不再调用无 appId 校验的重载")
+    void getCredentialDetailUsingPostShouldNotCallNoAppIdOverload() {
+        when(appScopeMappingService.getAppIdByScope(eq(SCOPE_TYPE), eq(ATTACKER_SCOPE_ID)))
+            .thenReturn(ATTACKER_APP_ID);
+        when(credentialService.getCredentialById(eq(ATTACKER_APP_ID), eq(CREDENTIAL_ID)))
+            .thenReturn(null);
+
+        EsbGetCredentialDetailV3Req req = buildReq(SCOPE_TYPE, ATTACKER_SCOPE_ID);
+
+        assertThatThrownBy(() -> resource.getCredentialDetailUsingPost("attacker", "test_app", req))
+            .isInstanceOf(NotFoundException.class);
+
+        // 关键：必须走带 appId 的重载，决不能再调用无 appId 的越权重载
+        verify(credentialService, times(1)).getCredentialById(eq(ATTACKER_APP_ID), eq(CREDENTIAL_ID));
+        verify(credentialService, times(0)).getCredentialById(eq(CREDENTIAL_ID));
+    }
+
+    @Test
+    @DisplayName("同业务下查询凭据详情正常返回")
+    void getCredentialDetailUsingPostFromOwnerAppShouldPass() {
+        when(appScopeMappingService.getAppIdByScope(eq(SCOPE_TYPE), eq(OWNER_SCOPE_ID)))
+            .thenReturn(OWNER_APP_ID);
+        CredentialDTO dto = mock(CredentialDTO.class);
+        EsbCredentialV3DTO esbDTO = new EsbCredentialV3DTO();
+        esbDTO.setId(CREDENTIAL_ID);
+        when(dto.toEsbCredentialV3DTO()).thenReturn(esbDTO);
+        when(credentialService.getCredentialById(eq(OWNER_APP_ID), eq(CREDENTIAL_ID)))
+            .thenReturn(dto);
+
+        EsbGetCredentialDetailV3Req req = buildReq(SCOPE_TYPE, OWNER_SCOPE_ID);
+        EsbResp<EsbCredentialV3DTO> resp = resource.getCredentialDetailUsingPost(
+            "owner_user", "test_app", req);
+
+        assertThat(resp.getData()).isNotNull();
+        assertThat(resp.getData().getId()).isEqualTo(CREDENTIAL_ID);
+        verify(credentialService, times(1)).getCredentialById(eq(OWNER_APP_ID), eq(CREDENTIAL_ID));
+    }
+
+    @Test
+    @DisplayName("GET 入口委托给 POST，同样基于 appId 隔离查询")
+    void getCredentialDetailGetShouldUseAppIdScopedQuery() {
+        when(appScopeMappingService.getAppIdByScope(eq(SCOPE_TYPE), eq(ATTACKER_SCOPE_ID)))
+            .thenReturn(ATTACKER_APP_ID);
+        when(credentialService.getCredentialById(eq(ATTACKER_APP_ID), eq(CREDENTIAL_ID)))
+            .thenReturn(null);
+
+        assertThatThrownBy(() -> resource.getCredentialDetail(
+            "attacker", "test_app", null, SCOPE_TYPE, ATTACKER_SCOPE_ID, CREDENTIAL_ID))
+            .isInstanceOf(NotFoundException.class)
+            .extracting(e -> ((ServiceException) e).getErrorCode())
+            .isEqualTo(ErrorCode.CREDENTIAL_NOT_EXIST);
+
+        verify(credentialService, times(1)).getCredentialById(eq(ATTACKER_APP_ID), eq(CREDENTIAL_ID));
+    }
+}

--- a/src/backend/job-manage/service-job-manage/src/test/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbDangerousRuleV3ResourceImplTest.java
+++ b/src/backend/job-manage/service-job-manage/src/test/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbDangerousRuleV3ResourceImplTest.java
@@ -280,17 +280,30 @@ class EsbDangerousRuleV3ResourceImplTest {
     }
 
     @Test
-    @DisplayName("查询高危语句规则列表保持原有行为，不调用本次新增的鉴权")
-    void getDangerousRuleListShouldNotInvokeNewlyAddedAuth() {
-        mockUser(NORMAL_USER);
+    @DisplayName("普通用户查询高危语句规则列表被拒绝且不进入业务逻辑")
+    void normalUserGetDangerousRuleListShouldBeDenied() {
+        User user = mockUser(NORMAL_USER);
+        givenNoPermission(user);
+
+        EsbGetDangerousRuleV3Req req = new EsbGetDangerousRuleV3Req();
+        assertThatThrownBy(() -> resource.getDangerousRuleListUsingPost(NORMAL_USER, "test_app", req))
+            .isInstanceOf(PermissionDeniedException.class);
+
+        verify(currentTenantDangerousRuleService, never()).listDangerousRules(any());
+    }
+
+    @Test
+    @DisplayName("管理员查询高危语句规则列表正常进入业务逻辑")
+    void adminUserGetDangerousRuleListShouldPass() {
+        User user = mockUser(ADMIN_USER);
+        givenHasPermission(user);
         when(currentTenantDangerousRuleService.listDangerousRules(any()))
             .thenReturn(Collections.emptyList());
 
         EsbGetDangerousRuleV3Req req = new EsbGetDangerousRuleV3Req();
-        assertThatCode(() -> resource.getDangerousRuleListUsingPost(NORMAL_USER, "test_app", req))
+        assertThatCode(() -> resource.getDangerousRuleListUsingPost(ADMIN_USER, "test_app", req))
             .doesNotThrowAnyException();
 
-        verify(noResourceScopeAuthService, never()).authHighRiskDetectRule(any());
         verify(currentTenantDangerousRuleService, times(1)).listDangerousRules(any());
     }
 }

--- a/src/backend/job-manage/service-job-manage/src/test/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbDangerousRuleV3ResourceImplTest.java
+++ b/src/backend/job-manage/service-job-manage/src/test/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbDangerousRuleV3ResourceImplTest.java
@@ -1,0 +1,296 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.api.esb.impl.v3;
+
+import com.tencent.bk.job.common.iam.exception.PermissionDeniedException;
+import com.tencent.bk.job.common.iam.model.AuthResult;
+import com.tencent.bk.job.common.model.User;
+import com.tencent.bk.job.common.util.JobContextUtil;
+import com.tencent.bk.job.manage.api.common.constants.EnableStatusEnum;
+import com.tencent.bk.job.manage.auth.NoResourceScopeAuthService;
+import com.tencent.bk.job.manage.model.dto.globalsetting.DangerousRuleDTO;
+import com.tencent.bk.job.manage.model.esb.v3.request.EsbCreateDangerousRuleV3Req;
+import com.tencent.bk.job.manage.model.esb.v3.request.EsbGetDangerousRuleV3Req;
+import com.tencent.bk.job.manage.model.esb.v3.request.EsbManageDangerousRuleV3Req;
+import com.tencent.bk.job.manage.model.esb.v3.request.EsbUpdateDangerousRuleV3Req;
+import com.tencent.bk.job.manage.service.CurrentTenantDangerousRuleService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 验证高危语句规则相关 ESB 接口的权限校验，
+ * 与 Web 接口 /web/dangerousRule/** 的鉴权拦截器保持一致。
+ */
+@DisplayName("EsbDangerousRuleV3ResourceImpl 权限校验测试")
+class EsbDangerousRuleV3ResourceImplTest {
+
+    private CurrentTenantDangerousRuleService currentTenantDangerousRuleService;
+    private NoResourceScopeAuthService noResourceScopeAuthService;
+    private EsbDangerousRuleV3ResourceImpl resource;
+
+    private static final String TENANT_ID = "default";
+    private static final String NORMAL_USER = "normal_user";
+    private static final String ADMIN_USER = "admin_user";
+
+    @BeforeEach
+    void setUp() {
+        currentTenantDangerousRuleService = mock(CurrentTenantDangerousRuleService.class);
+        noResourceScopeAuthService = mock(NoResourceScopeAuthService.class);
+        resource = new EsbDangerousRuleV3ResourceImpl(
+            currentTenantDangerousRuleService,
+            noResourceScopeAuthService
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        JobContextUtil.unsetContext();
+    }
+
+    private User mockUser(String username) {
+        User user = new User(TENANT_ID, username, username);
+        JobContextUtil.setUser(user);
+        return user;
+    }
+
+    private void givenNoPermission(User user) {
+        when(noResourceScopeAuthService.authHighRiskDetectRule(any()))
+            .thenReturn(AuthResult.fail(user));
+    }
+
+    private void givenHasPermission(User user) {
+        when(noResourceScopeAuthService.authHighRiskDetectRule(any()))
+            .thenReturn(AuthResult.pass(user));
+    }
+
+    private EsbCreateDangerousRuleV3Req buildCreateReq() {
+        EsbCreateDangerousRuleV3Req req = new EsbCreateDangerousRuleV3Req();
+        req.setExpression("rm -rf");
+        req.setDescription("desc");
+        req.setScriptTypeList(Collections.singletonList((byte) 1));
+        req.setAction(1);
+        return req;
+    }
+
+    private EsbUpdateDangerousRuleV3Req buildUpdateReq() {
+        EsbUpdateDangerousRuleV3Req req = new EsbUpdateDangerousRuleV3Req();
+        req.setId(1L);
+        req.setExpression("rm -rf");
+        req.setDescription("desc");
+        req.setScriptTypeList(Collections.singletonList((byte) 1));
+        req.setAction(1);
+        return req;
+    }
+
+    private EsbManageDangerousRuleV3Req buildManageReq(long id) {
+        EsbManageDangerousRuleV3Req req = new EsbManageDangerousRuleV3Req();
+        req.setId(id);
+        return req;
+    }
+
+    @Test
+    @DisplayName("普通用户创建高危语句规则被拒绝且不进入业务逻辑")
+    void normalUserCreateDangerousRuleShouldBeDenied() {
+        User user = mockUser(NORMAL_USER);
+        givenNoPermission(user);
+        EsbCreateDangerousRuleV3Req req = buildCreateReq();
+
+        assertThatThrownBy(() -> resource.createDangerousRule(NORMAL_USER, "test_app", req))
+            .isInstanceOf(PermissionDeniedException.class);
+
+        verify(currentTenantDangerousRuleService, never()).createDangerousRule(any(), any());
+    }
+
+    @Test
+    @DisplayName("普通用户更新高危语句规则被拒绝且不进入业务逻辑")
+    void normalUserUpdateDangerousRuleShouldBeDenied() {
+        User user = mockUser(NORMAL_USER);
+        givenNoPermission(user);
+        EsbUpdateDangerousRuleV3Req req = buildUpdateReq();
+
+        assertThatThrownBy(() -> resource.updateDangerousRule(NORMAL_USER, "test_app", req))
+            .isInstanceOf(PermissionDeniedException.class);
+
+        verify(currentTenantDangerousRuleService, never()).getDangerousRuleById(anyLong());
+        verify(currentTenantDangerousRuleService, never()).updateDangerousRule(any(), any());
+    }
+
+    @Test
+    @DisplayName("普通用户删除高危语句规则被拒绝且不进入业务逻辑")
+    void normalUserDeleteDangerousRuleShouldBeDenied() {
+        User user = mockUser(NORMAL_USER);
+        givenNoPermission(user);
+
+        assertThatThrownBy(() -> resource.deleteDangerousRule(NORMAL_USER, "test_app", buildManageReq(1L)))
+            .isInstanceOf(PermissionDeniedException.class);
+
+        verify(currentTenantDangerousRuleService, never()).deleteDangerousRuleById(any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("普通用户启用高危语句规则被拒绝且不进入业务逻辑")
+    void normalUserEnableDangerousRuleShouldBeDenied() {
+        User user = mockUser(NORMAL_USER);
+        givenNoPermission(user);
+
+        assertThatThrownBy(() -> resource.enableDangerousRule(NORMAL_USER, "test_app", buildManageReq(1L)))
+            .isInstanceOf(PermissionDeniedException.class);
+
+        verify(currentTenantDangerousRuleService, never())
+            .updateDangerousRuleStatus(any(), anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("普通用户停用高危语句规则被拒绝且不进入业务逻辑")
+    void normalUserDisableDangerousRuleShouldBeDenied() {
+        User user = mockUser(NORMAL_USER);
+        givenNoPermission(user);
+
+        assertThatThrownBy(() -> resource.disableDangerousRule(NORMAL_USER, "test_app", buildManageReq(1L)))
+            .isInstanceOf(PermissionDeniedException.class);
+
+        verify(currentTenantDangerousRuleService, never())
+            .updateDangerousRuleStatus(any(), anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("管理员创建高危语句规则正常进入业务逻辑")
+    void adminUserCreateDangerousRuleShouldPass() {
+        User user = mockUser(ADMIN_USER);
+        givenHasPermission(user);
+        DangerousRuleDTO dto = buildDangerousRuleDTO();
+        when(currentTenantDangerousRuleService.createDangerousRule(any(), any())).thenReturn(dto);
+
+        assertThatCode(() -> resource.createDangerousRule(ADMIN_USER, "test_app", buildCreateReq()))
+            .doesNotThrowAnyException();
+
+        verify(currentTenantDangerousRuleService, times(1)).createDangerousRule(any(), any());
+    }
+
+    @Test
+    @DisplayName("管理员更新高危语句规则正常进入业务逻辑")
+    void adminUserUpdateDangerousRuleShouldPass() {
+        User user = mockUser(ADMIN_USER);
+        givenHasPermission(user);
+        DangerousRuleDTO dto = buildDangerousRuleDTO();
+        when(currentTenantDangerousRuleService.getDangerousRuleById(anyLong())).thenReturn(dto);
+        when(currentTenantDangerousRuleService.updateDangerousRule(any(), any())).thenReturn(dto);
+
+        assertThatCode(() -> resource.updateDangerousRule(ADMIN_USER, "test_app", buildUpdateReq()))
+            .doesNotThrowAnyException();
+
+        verify(currentTenantDangerousRuleService, times(1)).updateDangerousRule(any(), any());
+    }
+
+    private DangerousRuleDTO buildDangerousRuleDTO() {
+        DangerousRuleDTO dto = new DangerousRuleDTO();
+        dto.setId(1L);
+        dto.setExpression("rm -rf");
+        dto.setDescription("desc");
+        dto.setScriptType(1);
+        dto.setAction(1);
+        dto.setStatus(EnableStatusEnum.DISABLED.getValue());
+        return dto;
+    }
+
+    @Test
+    @DisplayName("管理员删除高危语句规则正常进入业务逻辑")
+    void adminUserDeleteDangerousRuleShouldPass() {
+        User user = mockUser(ADMIN_USER);
+        givenHasPermission(user);
+
+        assertThatCode(() -> resource.deleteDangerousRule(ADMIN_USER, "test_app", buildManageReq(1L)))
+            .doesNotThrowAnyException();
+
+        verify(currentTenantDangerousRuleService, times(1))
+            .deleteDangerousRuleById(any(), eq(1L));
+    }
+
+    @Test
+    @DisplayName("管理员启用高危语句规则正常进入业务逻辑")
+    void adminUserEnableDangerousRuleShouldPass() {
+        User user = mockUser(ADMIN_USER);
+        givenHasPermission(user);
+        DangerousRuleDTO dto = new DangerousRuleDTO();
+        dto.setId(1L);
+        dto.setStatus(EnableStatusEnum.ENABLED.getValue());
+        when(currentTenantDangerousRuleService.updateDangerousRuleStatus(any(), anyLong(), any()))
+            .thenReturn(dto);
+
+        assertThatCode(() -> resource.enableDangerousRule(ADMIN_USER, "test_app", buildManageReq(1L)))
+            .doesNotThrowAnyException();
+
+        verify(currentTenantDangerousRuleService, times(1))
+            .updateDangerousRuleStatus(any(), eq(1L), eq(EnableStatusEnum.ENABLED));
+    }
+
+    @Test
+    @DisplayName("管理员停用高危语句规则正常进入业务逻辑")
+    void adminUserDisableDangerousRuleShouldPass() {
+        User user = mockUser(ADMIN_USER);
+        givenHasPermission(user);
+        DangerousRuleDTO dto = new DangerousRuleDTO();
+        dto.setId(1L);
+        dto.setStatus(EnableStatusEnum.DISABLED.getValue());
+        when(currentTenantDangerousRuleService.updateDangerousRuleStatus(any(), anyLong(), any()))
+            .thenReturn(dto);
+
+        assertThatCode(() -> resource.disableDangerousRule(ADMIN_USER, "test_app", buildManageReq(1L)))
+            .doesNotThrowAnyException();
+
+        verify(currentTenantDangerousRuleService, times(1))
+            .updateDangerousRuleStatus(any(), eq(1L), eq(EnableStatusEnum.DISABLED));
+    }
+
+    @Test
+    @DisplayName("查询高危语句规则列表保持原有行为，不调用本次新增的鉴权")
+    void getDangerousRuleListShouldNotInvokeNewlyAddedAuth() {
+        mockUser(NORMAL_USER);
+        when(currentTenantDangerousRuleService.listDangerousRules(any()))
+            .thenReturn(Collections.emptyList());
+
+        EsbGetDangerousRuleV3Req req = new EsbGetDangerousRuleV3Req();
+        assertThatCode(() -> resource.getDangerousRuleListUsingPost(NORMAL_USER, "test_app", req))
+            .doesNotThrowAnyException();
+
+        verify(noResourceScopeAuthService, never()).authHighRiskDetectRule(any());
+        verify(currentTenantDangerousRuleService, times(1)).listDangerousRules(any());
+    }
+}

--- a/src/backend/job-manage/service-job-manage/src/test/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbServiceInfoV3ResourceImplTest.java
+++ b/src/backend/job-manage/service-job-manage/src/test/java/com/tencent/bk/job/manage/api/esb/impl/v3/EsbServiceInfoV3ResourceImplTest.java
@@ -1,0 +1,199 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.api.esb.impl.v3;
+
+import com.tencent.bk.job.common.constant.ErrorCode;
+import com.tencent.bk.job.common.discovery.ServiceInfoProvider;
+import com.tencent.bk.job.common.discovery.model.ServiceInstanceInfoDTO;
+import com.tencent.bk.job.common.esb.model.EsbResp;
+import com.tencent.bk.job.common.exception.NotFoundException;
+import com.tencent.bk.job.common.exception.ServiceException;
+import com.tencent.bk.job.common.iam.exception.PermissionDeniedException;
+import com.tencent.bk.job.common.iam.model.AuthResult;
+import com.tencent.bk.job.common.model.User;
+import com.tencent.bk.job.common.util.JobContextUtil;
+import com.tencent.bk.job.manage.auth.NoResourceScopeAuthService;
+import com.tencent.bk.job.manage.model.esb.v3.response.EsbServiceVersionV3DTO;
+import com.tencent.bk.job.manage.service.impl.ServiceInfoService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 验证 ESB 服务信息接口的权限校验与多租户校验，
+ * 与 Web 接口 /web/serviceInfo/** 的鉴权拦截器及 WebServiceInfoResourceImpl 原内联租户校验保持一致。
+ */
+@DisplayName("EsbServiceInfoV3ResourceImpl 权限/租户校验测试")
+class EsbServiceInfoV3ResourceImplTest {
+
+    private ServiceInfoProvider serviceInfoProvider;
+    private NoResourceScopeAuthService noResourceScopeAuthService;
+    private ServiceInfoService serviceInfoService;
+    private EsbServiceInfoV3ResourceImpl resource;
+
+    private static final String NORMAL_USER = "normal_user";
+    private static final String ADMIN_USER = "admin_user";
+
+    @BeforeEach
+    void setUp() {
+        serviceInfoProvider = mock(ServiceInfoProvider.class);
+        noResourceScopeAuthService = mock(NoResourceScopeAuthService.class);
+        serviceInfoService = mock(ServiceInfoService.class);
+        resource = new EsbServiceInfoV3ResourceImpl(
+            serviceInfoProvider, noResourceScopeAuthService, serviceInfoService
+        );
+    }
+
+    @AfterEach
+    void tearDown() {
+        JobContextUtil.unsetContext();
+    }
+
+    private User mockUser(String username) {
+        User user = new User("default", username, username);
+        JobContextUtil.setUser(user);
+        return user;
+    }
+
+    private void givenNoPermission(User user) {
+        when(noResourceScopeAuthService.authViewServiceState(any()))
+            .thenReturn(AuthResult.fail(user));
+    }
+
+    private void givenHasPermission(User user) {
+        when(noResourceScopeAuthService.authViewServiceState(any()))
+            .thenReturn(AuthResult.pass(user));
+    }
+
+    private void givenTenantAccessAllowed() {
+        doNothing().when(serviceInfoService).checkTenantAccess();
+    }
+
+    private void givenTenantAccessDenied() {
+        doThrow(new NotFoundException(ErrorCode.NOT_SUPPORT_FEATURE))
+            .when(serviceInfoService).checkTenantAccess();
+    }
+
+    private ServiceInstanceInfoDTO buildInstance(String version) {
+        ServiceInstanceInfoDTO dto = new ServiceInstanceInfoDTO();
+        dto.setVersion(version);
+        return dto;
+    }
+
+    @Test
+    @DisplayName("普通用户调用 POST 获取最新服务版本被拒绝且不进入业务逻辑")
+    void normalUserGetLatestServiceVersionPostShouldBeDenied() {
+        User user = mockUser(NORMAL_USER);
+        givenNoPermission(user);
+
+        assertThatThrownBy(() -> resource.getLatestServiceVersionUsingPost(NORMAL_USER, "test_app"))
+            .isInstanceOf(PermissionDeniedException.class);
+
+        verify(serviceInfoService, never()).checkTenantAccess();
+        verify(serviceInfoProvider, never()).listServiceInfo();
+    }
+
+    @Test
+    @DisplayName("普通用户调用 GET 获取最新服务版本同样被拒绝（GET 委托给 POST）")
+    void normalUserGetLatestServiceVersionGetShouldBeDenied() {
+        User user = mockUser(NORMAL_USER);
+        givenNoPermission(user);
+
+        assertThatThrownBy(() -> resource.getLatestServiceVersion(NORMAL_USER, "test_app"))
+            .isInstanceOf(PermissionDeniedException.class);
+
+        verify(serviceInfoService, never()).checkTenantAccess();
+        verify(serviceInfoProvider, never()).listServiceInfo();
+    }
+
+    @Test
+    @DisplayName("管理员在非系统租户访问被拒（多租户启用且非 system 租户）")
+    void adminUserNonSystemTenantShouldBeDenied() {
+        User user = mockUser(ADMIN_USER);
+        givenHasPermission(user);
+        givenTenantAccessDenied();
+
+        assertThatThrownBy(() -> resource.getLatestServiceVersionUsingPost(ADMIN_USER, "test_app"))
+            .isInstanceOf(NotFoundException.class)
+            .extracting(e -> ((ServiceException) e).getErrorCode())
+            .isEqualTo(ErrorCode.NOT_SUPPORT_FEATURE);
+
+        verify(serviceInfoProvider, never()).listServiceInfo();
+    }
+
+    @Test
+    @DisplayName("管理员在系统租户/未启用多租户场景下成功获取最新服务版本")
+    void adminUserShouldGetLatestServiceVersion() {
+        User user = mockUser(ADMIN_USER);
+        givenHasPermission(user);
+        givenTenantAccessAllowed();
+        when(serviceInfoProvider.listServiceInfo()).thenReturn(Arrays.asList(
+            buildInstance("3.12.1"),
+            buildInstance("3.12.3"),
+            buildInstance("3.12.2")
+        ));
+
+        EsbResp<EsbServiceVersionV3DTO> resp = resource.getLatestServiceVersionUsingPost(
+            ADMIN_USER, "test_app");
+
+        assertThat(resp.getData()).isNotNull();
+        assertThat(resp.getData().getVersion()).isEqualTo("3.12.3");
+        verify(serviceInfoService, times(1)).checkTenantAccess();
+        verify(serviceInfoProvider, times(1)).listServiceInfo();
+    }
+
+    @Test
+    @DisplayName("管理员通过 GET 路径同样会触发鉴权与租户校验，并返回最新版本")
+    void adminUserGetLatestServiceVersionViaGetShouldPass() {
+        User user = mockUser(ADMIN_USER);
+        givenHasPermission(user);
+        givenTenantAccessAllowed();
+        when(serviceInfoProvider.listServiceInfo()).thenReturn(Arrays.asList(
+            buildInstance("3.12.1"),
+            buildInstance("3.12.5")
+        ));
+
+        EsbResp<EsbServiceVersionV3DTO> resp = resource.getLatestServiceVersion(
+            ADMIN_USER, "test_app");
+
+        assertThat(resp.getData().getVersion()).isEqualTo("3.12.5");
+        verify(noResourceScopeAuthService, times(1)).authViewServiceState(any());
+        verify(serviceInfoService, times(1)).checkTenantAccess();
+    }
+}


### PR DESCRIPTION
1. ESB v3 高危语句规则接口此前缺少权限校验，普通用户可绕过 Web 端 JobManageUriPermissionInterceptor 直接调用 ESB 接口完成查询/创建/修改/删除/启停操作，该PR对齐 Web 端 /web/dangerousRule/** 的鉴权逻辑，确保普通用户被拦截、平台管理员可正常调用；
2. 增加相应单元测试；
3. 修复其他类似越权问题。