### PR TITLE
perf: 容器化部署Role权限优化 #4277

### DIFF
--- a/support-files/kubernetes/charts/bk-job/templates/role.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/role.yaml
@@ -16,7 +16,6 @@ rules:
       - "apps"
     resources:
       - jobs
-      - secrets
       - configmaps
       - services
       - pods


### PR DESCRIPTION
1. 从 bk-job Helm Chart 的 Role 中移除 secrets 资源的 get/list/watch 权限。