### PR TITLE
perf: 提供编译构建镜像 #4342

### DIFF
--- a/support-files/kubernetes/images/backend/jdk17.Dockerfile
+++ b/support-files/kubernetes/images/backend/jdk17.Dockerfile
@@ -1,22 +1,22 @@
 FROM bkjob/os:3.12.2
 
 LABEL maintainer="Tencent BlueKing Job"
-LABEL dockerfile.version="3.12.3"
+LABEL dockerfile.version="3.12.4"
 
-RUN mkdir -p /data && \
-    cd /data/ &&\
+RUN mkdir -p /bk_job_data && \
+    cd /bk_job_data/ &&\
     curl -OL https://github.com/Tencent/TencentKona-17/releases/download/TencentKona-17.0.16/TencentKona-17.0.16.b1-jdk_linux-x86_64.tar.gz &&\
     tar -xzf TencentKona-17.0.16.b1-jdk_linux-x86_64.tar.gz &&\
     rm -f TencentKona-17.0.16.b1-jdk_linux-x86_64.tar.gz
-ENV JAVA_HOME=/data/TencentKona-17.0.16.b1
+ENV JAVA_HOME=/bk_job_data/TencentKona-17.0.16.b1
 ENV PATH=${JAVA_HOME}/bin:$PATH
 ENV CLASSPATH=.:${JAVA_HOME}/lib
 
 ## 安装在线诊断工具arthas
-RUN mkdir -p /data/tools && \
-    cd /data/tools && \
+RUN mkdir -p /bk_job_data/tools && \
+    cd /bk_job_data/tools && \
     curl -OL https://github.com/alibaba/arthas/releases/download/arthas-all-4.0.5/arthas-bin.zip && \
     dnf install -y unzip && \
     unzip arthas-bin.zip arthas-boot.jar && \
     rm -rf arthas-bin* && \
-    echo 'alias arthas="java -jar /data/tools/arthas-boot.jar --repo-mirror aliyun --use-http"' >> ~/.bashrc
+    echo 'alias arthas="java -jar /bk_job_data/tools/arthas-boot.jar --repo-mirror aliyun --use-http"' >> ~/.bashrc

--- a/support-files/kubernetes/images/backend/jdk17.Dockerfile
+++ b/support-files/kubernetes/images/backend/jdk17.Dockerfile
@@ -1,11 +1,15 @@
 FROM bkjob/os:3.12.2
 
+ARG KONA_JDK17_SHA256=2112d20af7bde476afd4cc3a7cd7b5f523eab97867ab9b4dc7467e2cb7d92417
+ARG ARTHAS_SHA256=231f1d4f8ceb1c0ff8ece67b117b107ddaad7bec1765c15ffe1b77d7fdf0f19b
+
 LABEL maintainer="Tencent BlueKing Job"
 LABEL dockerfile.version="3.12.4"
 
 RUN mkdir -p /bk_job_data && \
     cd /bk_job_data/ &&\
     curl -OL https://github.com/Tencent/TencentKona-17/releases/download/TencentKona-17.0.16/TencentKona-17.0.16.b1-jdk_linux-x86_64.tar.gz &&\
+    echo "${KONA_JDK17_SHA256}  TencentKona-17.0.16.b1-jdk_linux-x86_64.tar.gz" | sha256sum -c - &&\
     tar -xzf TencentKona-17.0.16.b1-jdk_linux-x86_64.tar.gz &&\
     rm -f TencentKona-17.0.16.b1-jdk_linux-x86_64.tar.gz
 ENV JAVA_HOME=/bk_job_data/TencentKona-17.0.16.b1
@@ -16,6 +20,7 @@ ENV CLASSPATH=.:${JAVA_HOME}/lib
 RUN mkdir -p /bk_job_data/tools && \
     cd /bk_job_data/tools && \
     curl -OL https://github.com/alibaba/arthas/releases/download/arthas-all-4.0.5/arthas-bin.zip && \
+    echo "${ARTHAS_SHA256}  arthas-bin.zip" | sha256sum -c - && \
     dnf install -y unzip && \
     unzip arthas-bin.zip arthas-boot.jar && \
     rm -rf arthas-bin* && \

--- a/support-files/kubernetes/images/backend/tool-set.Dockerfile
+++ b/support-files/kubernetes/images/backend/tool-set.Dockerfile
@@ -1,12 +1,12 @@
-FROM bkjob/jdk17:3.12.3
+FROM bkjob/jdk17:3.12.4
 
 LABEL maintainer="Tencent BlueKing Job"
-LABEL dockerfile.version="3.12.5"
+LABEL dockerfile.version="3.12.6"
 
 ## 安装MySQL与兼容库
-RUN curl -o mysql-8.4.6-linux-glibc2.17-x86_64-minimal.tar.xz https://cdn.mysql.com//Downloads/MySQL-8.4/mysql-8.4.6-linux-glibc2.17-x86_64-minimal.tar.xz \
-    && tar -xvf mysql-8.4.6-linux-glibc2.17-x86_64-minimal.tar.xz \
-    && mv mysql-8.4.6-linux-glibc2.17-x86_64-minimal /usr/local/mysql \
+RUN curl -o mysql-8.4.9-linux-glibc2.17-x86_64-minimal.tar.xz https://cdn.mysql.com/Downloads/MySQL-8.4/mysql-8.4.9-linux-glibc2.17-x86_64-minimal.tar.xz \
+    && tar -xvf mysql-8.4.9-linux-glibc2.17-x86_64-minimal.tar.xz \
+    && mv mysql-8.4.9-linux-glibc2.17-x86_64-minimal /usr/local/mysql \
     && ln -s /usr/local/mysql/bin/mysql /usr/bin/mysql \
     && dnf install -y ncurses-compat-libs \
     && dnf clean all

--- a/support-files/kubernetes/images/backend/tool-set.Dockerfile
+++ b/support-files/kubernetes/images/backend/tool-set.Dockerfile
@@ -1,10 +1,13 @@
 FROM bkjob/jdk17:3.12.4
 
+ARG MYSQL_SHA256=1e9f341e36d4fcdbb3e4d7d3dae6d6b2a42ebe8333e8f276c25e25564ce565c1
+
 LABEL maintainer="Tencent BlueKing Job"
 LABEL dockerfile.version="3.12.6"
 
 ## 安装MySQL与兼容库
 RUN curl -o mysql-8.4.9-linux-glibc2.17-x86_64-minimal.tar.xz https://cdn.mysql.com/Downloads/MySQL-8.4/mysql-8.4.9-linux-glibc2.17-x86_64-minimal.tar.xz \
+    && echo "${MYSQL_SHA256}  mysql-8.4.9-linux-glibc2.17-x86_64-minimal.tar.xz" | sha256sum -c - \
     && tar -xvf mysql-8.4.9-linux-glibc2.17-x86_64-minimal.tar.xz \
     && mv mysql-8.4.9-linux-glibc2.17-x86_64-minimal /usr/local/mysql \
     && ln -s /usr/local/mysql/bin/mysql /usr/bin/mysql \

--- a/support-files/kubernetes/images/build-env/README.md
+++ b/support-files/kubernetes/images/build-env/README.md
@@ -34,17 +34,20 @@ docker build \
   .
 ```
 
-需要调整基础镜像或组件版本时，通过 build-arg 覆盖：
+需要调整基础镜像或组件版本时，通过 build-arg 覆盖；修改组件版本时必须同步更新对应的 SHA-256：
 
 ```bash
 cd support-files/kubernetes/images/build-env
 docker build \
   --build-arg BASE_IMAGE=bkjob/tool-set:3.12.6 \
   --build-arg GIT_VERSION=2.41.3 \
+  --build-arg GIT_SHA256=baa39125deee194b440ac7d0138f6c34f0d87ceb1cb9da5b2becf704f45b0819 \
   --build-arg KONA_JDK8_TAG=8.0.26-GA \
   --build-arg KONA_JDK8_PACKAGE=TencentKona8.0.26.b1_jdk_linux-x86_64_8u492.tar.gz \
+  --build-arg KONA_JDK8_SHA256=9df50dd8e888ac62721ddd18400194f190bd91b8f3a1e1d782f710fc0eab2478 \
   --build-arg NODE_VERSION=24.16.0 \
   --build-arg NVM_VERSION=0.40.3 \
+  --build-arg NVM_SHA256=5f4d6aaa04a177dc93c985e31dbc411ab6b8c6e1e21d8015dbc1372625fcd1d0 \
   -t hub.bktencent.com/blueking/job-build-tool:1.0.1 \
   -f build-tool.Dockerfile \
   .

--- a/support-files/kubernetes/images/build-env/README.md
+++ b/support-files/kubernetes/images/build-env/README.md
@@ -1,35 +1,35 @@
 # bk-job 构建工具镜像
 
-该镜像用于统一 bk-job 前后端编译环境，默认基于 `bkjob/tool-set:3.12.5` 构建。镜像提供构建所需工具和容器内 MySQL 启动能力。
+该镜像用于统一 bk-job 前后端编译环境，默认基于 `bkjob/tool-set:3.12.6` 构建。镜像提供构建所需工具和容器内 MySQL 启动能力。
 
 ## 内置组件
 
-| 组件 | 版本 | 说明 |
-| --- | --- | --- |
-| JDK17 | TencentKona 17.0.16 | 默认 JDK，来自 `bkjob/tool-set:3.12.5` |
-| JDK8 | TencentKona 8.0.26 / jdk8u492 | 通过 `use-jdk8` 切换 |
-| Git | 2.41.3 |  |
-| NodeJS | 24.16.0 | 通过 nvm 安装，版本固定 |
-| nvm | 0.40.3 | 用于切换 NodeJS 版本 |
-| MySQL | 8.4.6 | 来自 `tool-set`，通过 `start-mysql` 启动 |
-| OpenSSL 1.1 兼容库 | 系统仓库版本 | 用于运行 flapdoodle embedded MongoDB 4.4.x |
+| 组件              | 版本                            | 说明                                     |
+|-----------------|-------------------------------|----------------------------------------|
+| JDK17           | TencentKona 17.0.16           | 默认 JDK，来自 `bkjob/tool-set:3.12.6`      |
+| JDK8            | TencentKona 8.0.26 / jdk8u492 | 通过 `use-jdk8` 切换                       |
+| Git             | 2.41.3                        |                                        |
+| NodeJS          | 24.16.0                       | 通过 nvm 安装，版本固定                         |
+| nvm             | 0.40.3                        | 用于切换 NodeJS 版本                         |
+| MySQL           | 8.4.9                         | 来自 `tool-set`，通过 `start-mysql` 启动      |
+| OpenSSL 1.1 兼容库 | 系统仓库版本                        | 用于运行 flapdoodle embedded MongoDB 4.4.x |
 
 ## 构建镜像
 
 目录文件说明：
 
-| 文件 | 说明 |
-| --- | --- |
-| `build-tool.Dockerfile` | 构建工具镜像定义 |
-| `jdk-env.sh` | JDK 环境脚本，复制到 `/etc/profile.d/jdk-env.sh` |
-| `start-mysql.sh` | MySQL 启动脚本，复制到镜像内 `/usr/local/bin/start-mysql` |
+| 文件                      | 说明                                             |
+|-------------------------|------------------------------------------------|
+| `build-tool.Dockerfile` | 构建工具镜像定义                                       |
+| `jdk-env.sh`            | JDK 环境脚本，复制到 `/etc/profile.d/jdk-env.sh`       |
+| `start-mysql.sh`        | MySQL 启动脚本，复制到镜像内 `/usr/local/bin/start-mysql` |
 
 构建镜像：
 
 ```bash
 cd support-files/kubernetes/images/build-env
 docker build \
-  -t hub.bktencent.com/blueking/job-build-tool:1.0.0 \
+  -t hub.bktencent.com/blueking/job-build-tool:1.0.1 \
   -f build-tool.Dockerfile \
   .
 ```
@@ -39,13 +39,13 @@ docker build \
 ```bash
 cd support-files/kubernetes/images/build-env
 docker build \
-  --build-arg BASE_IMAGE=bkjob/tool-set:3.12.5 \
+  --build-arg BASE_IMAGE=bkjob/tool-set:3.12.6 \
   --build-arg GIT_VERSION=2.41.3 \
   --build-arg KONA_JDK8_TAG=8.0.26-GA \
   --build-arg KONA_JDK8_PACKAGE=TencentKona8.0.26.b1_jdk_linux-x86_64_8u492.tar.gz \
   --build-arg NODE_VERSION=24.16.0 \
   --build-arg NVM_VERSION=0.40.3 \
-  -t hub.bktencent.com/blueking/job-build-tool:1.0.0 \
+  -t hub.bktencent.com/blueking/job-build-tool:1.0.1 \
   -f build-tool.Dockerfile \
   .
 ```
@@ -54,14 +54,14 @@ docker build \
 
 容器内 MySQL 默认参数：
 
-| 参数 | 默认值 | 覆盖方式 |
-| --- | --- | --- |
-| 地址 | `127.0.0.1` | 固定监听容器内本机 |
-| 端口 | `3306` | `MYSQL_PORT` |
-| 用户 | `root` | `MYSQL_USER` |
-| 密码 | `root` | `MYSQL_PASSWORD` |
-| 数据目录 | `/data/mysql` | `MYSQL_DATADIR` |
-| 运行目录 | `/tmp/mysql` | `MYSQL_RUN_DIR` |
+| 参数   | 默认值                  | 覆盖方式             |
+|------|----------------------|------------------|
+| 地址   | `127.0.0.1`          | 固定监听容器内本机        |
+| 端口   | `3306`               | `MYSQL_PORT`     |
+| 用户   | `root`               | `MYSQL_USER`     |
+| 密码   | `root`               | `MYSQL_PASSWORD` |
+| 数据目录 | `/bk_job_data/mysql` | `MYSQL_DATADIR`  |
+| 运行目录 | `/tmp/mysql`         | `MYSQL_RUN_DIR`  |
 
 这些变量在容器环境中已有默认值，如需要修改可通过 `docker run -e` 覆盖。
 
@@ -79,7 +79,7 @@ docker run --rm -it \
   -e MYSQL_PORT=3307 \
   -e MYSQL_USER=bkjob \
   -e MYSQL_PASSWORD=bkjob \
-  hub.bktencent.com/blueking/job-build-tool:1.0.0 \
+  hub.bktencent.com/blueking/job-build-tool:1.0.1 \
   bash -l
 ```
 
@@ -93,7 +93,7 @@ cd bk-job
 docker run --rm -it \
   -v "$PWD:/workspace" \
   -w /workspace \
-  hub.bktencent.com/blueking/job-build-tool:1.0.0 \
+  hub.bktencent.com/blueking/job-build-tool:1.0.1 \
   bash -l
 ```
 
@@ -141,7 +141,7 @@ jobs:
   build-backend:
     runs-on: ubuntu-22.04
     container:
-      image: hub.bktencent.com/blueking/job-build-tool:1.0.0
+      image: hub.bktencent.com/blueking/job-build-tool:1.0.1
     steps:
       - uses: actions/checkout@v4
       - name: Init MySQL
@@ -172,7 +172,7 @@ jobs:
   build-frontend:
     runs-on: ubuntu-latest
     container:
-      image: hub.bktencent.com/blueking/job-build-tool:1.0.0
+      image: hub.bktencent.com/blueking/job-build-tool:1.0.1
     steps:
       - uses: actions/checkout@v2
       - name: Build frontend
@@ -206,6 +206,6 @@ java -version
 ## 组件验证
 
 ```bash
-docker run --rm hub.bktencent.com/blueking/job-build-tool:1.0.0 bash -lc \
+docker run --rm hub.bktencent.com/blueking/job-build-tool:1.0.1 bash -lc \
   'java -version && use-jdk8 && java -version && use-jdk17 && node -v && npm -v && nvm --version && git --version && ldconfig -p | grep libcrypto.so.1.1 && start-mysql && /usr/local/mysql/bin/mysqladmin -h127.0.0.1 -P${MYSQL_PORT} -u${MYSQL_USER} -p${MYSQL_PASSWORD} ping'
 ```

--- a/support-files/kubernetes/images/build-env/README.md
+++ b/support-files/kubernetes/images/build-env/README.md
@@ -1,0 +1,211 @@
+# bk-job 构建工具镜像
+
+该镜像用于统一 bk-job 前后端编译环境，默认基于 `bkjob/tool-set:3.12.5` 构建。镜像提供构建所需工具和容器内 MySQL 启动能力。
+
+## 内置组件
+
+| 组件 | 版本 | 说明 |
+| --- | --- | --- |
+| JDK17 | TencentKona 17.0.16 | 默认 JDK，来自 `bkjob/tool-set:3.12.5` |
+| JDK8 | TencentKona 8.0.26 / jdk8u492 | 通过 `use-jdk8` 切换 |
+| Git | 2.41.3 |  |
+| NodeJS | 24.16.0 | 通过 nvm 安装，版本固定 |
+| nvm | 0.40.3 | 用于切换 NodeJS 版本 |
+| MySQL | 8.4.6 | 来自 `tool-set`，通过 `start-mysql` 启动 |
+| OpenSSL 1.1 兼容库 | 系统仓库版本 | 用于运行 flapdoodle embedded MongoDB 4.4.x |
+
+## 构建镜像
+
+目录文件说明：
+
+| 文件 | 说明 |
+| --- | --- |
+| `build-tool.Dockerfile` | 构建工具镜像定义 |
+| `jdk-env.sh` | JDK 环境脚本，复制到 `/etc/profile.d/jdk-env.sh` |
+| `start-mysql.sh` | MySQL 启动脚本，复制到镜像内 `/usr/local/bin/start-mysql` |
+
+构建镜像：
+
+```bash
+cd support-files/kubernetes/images/build-env
+docker build \
+  -t hub.bktencent.com/blueking/job-build-tool:1.0.0 \
+  -f build-tool.Dockerfile \
+  .
+```
+
+需要调整基础镜像或组件版本时，通过 build-arg 覆盖：
+
+```bash
+cd support-files/kubernetes/images/build-env
+docker build \
+  --build-arg BASE_IMAGE=bkjob/tool-set:3.12.5 \
+  --build-arg GIT_VERSION=2.41.3 \
+  --build-arg KONA_JDK8_TAG=8.0.26-GA \
+  --build-arg KONA_JDK8_PACKAGE=TencentKona8.0.26.b1_jdk_linux-x86_64_8u492.tar.gz \
+  --build-arg NODE_VERSION=24.16.0 \
+  --build-arg NVM_VERSION=0.40.3 \
+  -t hub.bktencent.com/blueking/job-build-tool:1.0.0 \
+  -f build-tool.Dockerfile \
+  .
+```
+
+## MySQL
+
+容器内 MySQL 默认参数：
+
+| 参数 | 默认值 | 覆盖方式 |
+| --- | --- | --- |
+| 地址 | `127.0.0.1` | 固定监听容器内本机 |
+| 端口 | `3306` | `MYSQL_PORT` |
+| 用户 | `root` | `MYSQL_USER` |
+| 密码 | `root` | `MYSQL_PASSWORD` |
+| 数据目录 | `/data/mysql` | `MYSQL_DATADIR` |
+| 运行目录 | `/tmp/mysql` | `MYSQL_RUN_DIR` |
+
+这些变量在容器环境中已有默认值，如需要修改可通过 `docker run -e` 覆盖。
+
+启动并验证 MySQL：
+
+```bash
+start-mysql
+/usr/local/mysql/bin/mysqladmin -h127.0.0.1 -P${MYSQL_PORT} -u${MYSQL_USER} -p${MYSQL_PASSWORD} ping
+```
+
+使用时可以通过环境变量覆盖账号、密码等变量：
+
+```bash
+docker run --rm -it \
+  -e MYSQL_PORT=3307 \
+  -e MYSQL_USER=bkjob \
+  -e MYSQL_PASSWORD=bkjob \
+  hub.bktencent.com/blueking/job-build-tool:1.0.0 \
+  bash -l
+```
+
+## 本地使用
+
+在宿主机先拉取 bk-job 源码，然后把源码目录挂载到容器中：
+
+```bash
+git clone https://github.com/TencentBlueKing/bk-job.git
+cd bk-job
+docker run --rm -it \
+  -v "$PWD:/workspace" \
+  -w /workspace \
+  hub.bktencent.com/blueking/job-build-tool:1.0.0 \
+  bash -l
+```
+
+### 后端构建
+
+进入容器后，先启动干净的 MySQL，再导入 `support-files/sql` 下的初始化 SQL，最后按项目现有方式构建后端：
+
+```bash
+start-mysql
+
+cd /workspace/support-files/sql
+export MYSQL_PWD="${MYSQL_PASSWORD}"
+for i in */*.sql; do
+  echo "${i}"
+  /usr/local/mysql/bin/mysql -h127.0.0.1 -P${MYSQL_PORT} -u${MYSQL_USER} < "${i}"
+done
+unset MYSQL_PWD
+
+cd /workspace/src/backend
+./gradlew clean build \
+  -DmysqlURL=127.0.0.1:${MYSQL_PORT} \
+  -DmysqlUser=${MYSQL_USER} \
+  -DmysqlPasswd=${MYSQL_PASSWORD} \
+  -DmavenRepoUrl=<maven_repo_url>
+```
+
+### 前端构建
+
+进入容器后，按项目现有方式构建前端：
+
+```bash
+cd /workspace/src/frontend
+npm i
+npm run build
+```
+
+## GitHub Actions 使用
+
+在 GitHub Actions 中，可以把该镜像作为 job container。`actions/checkout` 会把源码检出到工作目录，后续命令直接基于检出的源码执行。
+
+### 后端构建
+
+```yaml
+jobs:
+  build-backend:
+    runs-on: ubuntu-22.04
+    container:
+      image: hub.bktencent.com/blueking/job-build-tool:1.0.0
+    steps:
+      - uses: actions/checkout@v4
+      - name: Init MySQL
+        working-directory: support-files/sql
+        run: |
+          start-mysql
+          export MYSQL_PWD="${MYSQL_PASSWORD}"
+          for i in */*.sql; do
+            echo "${i}"
+            /usr/local/mysql/bin/mysql -h127.0.0.1 -P${MYSQL_PORT} -u${MYSQL_USER} < "${i}"
+          done
+          unset MYSQL_PWD
+      - name: Build backend
+        working-directory: src/backend
+        run: |
+          ./gradlew clean build \
+            -DmysqlURL=127.0.0.1:${MYSQL_PORT} \
+            -DmysqlUser=${MYSQL_USER} \
+            -DmysqlPasswd=${MYSQL_PASSWORD} \
+            -DmavenRepoUrl="https://mirrors.cloud.tencent.com/nexus/repository/maven-public/" \
+            --info --stacktrace
+```
+
+### 前端构建
+
+```yaml
+jobs:
+  build-frontend:
+    runs-on: ubuntu-latest
+    container:
+      image: hub.bktencent.com/blueking/job-build-tool:1.0.0
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build frontend
+        working-directory: src/frontend
+        run: |
+          npm i --legacy-peer-deps && npm run build
+```
+
+## JDK 切换
+
+默认使用 JDK17：
+
+```bash
+java -version
+```
+
+切换到 JDK8：
+
+```bash
+use-jdk8
+java -version
+```
+
+切回 JDK17：
+
+```bash
+use-jdk17
+java -version
+```
+
+## 组件验证
+
+```bash
+docker run --rm hub.bktencent.com/blueking/job-build-tool:1.0.0 bash -lc \
+  'java -version && use-jdk8 && java -version && use-jdk17 && node -v && npm -v && nvm --version && git --version && ldconfig -p | grep libcrypto.so.1.1 && start-mysql && /usr/local/mysql/bin/mysqladmin -h127.0.0.1 -P${MYSQL_PORT} -u${MYSQL_USER} -p${MYSQL_PASSWORD} ping'
+```

--- a/support-files/kubernetes/images/build-env/build-tool.Dockerfile
+++ b/support-files/kubernetes/images/build-env/build-tool.Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=bkjob/tool-set:3.12.5
+ARG BASE_IMAGE=bkjob/tool-set:3.12.6
 
 # git编译阶段,该阶段会安装gcc/make等编译依赖，不打入最终镜像
 FROM ${BASE_IMAGE} AS git-builder
@@ -34,12 +34,12 @@ ARG NODE_VERSION=24.16.0
 ARG NVM_VERSION=0.40.3
 
 LABEL maintainer="Tencent BlueKing Job" \
-      dockerfile.version="1.0.0"
+      dockerfile.version="1.0.1"
 
-ENV JAVA17_HOME=/data/TencentKona-17.0.16.b1
-ENV KONA_JDK17_HOME=/data/TencentKona-17.0.16.b1
-ENV JAVA8_HOME=/data/TencentKona8
-ENV KONA_JDK8_HOME=/data/TencentKona8
+ENV JAVA17_HOME=/bk_job_data/TencentKona-17.0.16.b1
+ENV KONA_JDK17_HOME=/bk_job_data/TencentKona-17.0.16.b1
+ENV JAVA8_HOME=/bk_job_data/TencentKona8
+ENV KONA_JDK8_HOME=/bk_job_data/TencentKona8
 ENV NVM_DIR=/usr/local/nvm
 ENV NODE_HOME=/usr/local/nvm/versions/node/v${NODE_VERSION}
 ENV PATH=${NODE_HOME}/bin:${PATH}
@@ -47,7 +47,7 @@ ENV BASH_ENV=/etc/profile.d/jdk-env.sh
 ENV MYSQL_PORT=3306
 ENV MYSQL_USER=root
 ENV MYSQL_PASSWORD=root
-ENV MYSQL_DATADIR=/data/mysql
+ENV MYSQL_DATADIR=/bk_job_data/mysql
 ENV MYSQL_RUN_DIR=/tmp/mysql
 
 # 补齐基础镜像缺失的运行依赖：
@@ -65,13 +65,13 @@ COPY --from=git-builder /opt/git /opt/git
 RUN ln -sf /opt/git/bin/git /usr/local/bin/git
 
 # 安装jdk8
-RUN mkdir -p /data && \
+RUN mkdir -p /bk_job_data && \
     cd /tmp && \
     curl -fSL "https://github.com/Tencent/TencentKona-8/releases/download/${KONA_JDK8_TAG}/${KONA_JDK8_PACKAGE}" -o kona8.tar.gz && \
     KONA_DIR="$(tar -tzf kona8.tar.gz | head -1 | cut -d/ -f1)" && \
-    tar -xzf kona8.tar.gz -C /data && \
+    tar -xzf kona8.tar.gz -C /bk_job_data && \
     rm -rf "${JAVA8_HOME}" && \
-    mv "/data/${KONA_DIR}" "${JAVA8_HOME}" && \
+    mv "/bk_job_data/${KONA_DIR}" "${JAVA8_HOME}" && \
     rm -f /tmp/kona8.tar.gz
 
 # 通过nvm安装固定版本nodejs

--- a/support-files/kubernetes/images/build-env/build-tool.Dockerfile
+++ b/support-files/kubernetes/images/build-env/build-tool.Dockerfile
@@ -1,0 +1,91 @@
+ARG BASE_IMAGE=bkjob/tool-set:3.12.5
+
+# git编译阶段,该阶段会安装gcc/make等编译依赖，不打入最终镜像
+FROM ${BASE_IMAGE} AS git-builder
+
+ARG GIT_VERSION=2.41.3
+
+# 构建指定版本的git
+RUN dnf install -y \
+        curl-devel \
+        diffutils \
+        expat-devel \
+        gcc \
+        make \
+        openssl-devel \
+        perl-ExtUtils-MakeMaker \
+        zlib-devel && \
+    cd /tmp && \
+    curl -fSL "https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.xz" -o git.tar.xz && \
+    mkdir git-src && \
+    tar -xJf git.tar.xz -C git-src --strip-components=1 && \
+    cd git-src && \
+    make prefix="/opt/git" NO_GETTEXT=YesPlease NO_TCLTK=YesPlease all && \
+    make prefix="/opt/git" NO_GETTEXT=YesPlease NO_TCLTK=YesPlease install && \
+    rm -rf /tmp/git-src /tmp/git.tar.xz && \
+    dnf clean all
+
+# 最终镜像阶段。重新基于base_image，避免带入git编译阶段的编译依赖
+FROM ${BASE_IMAGE}
+
+ARG KONA_JDK8_TAG=8.0.26-GA
+ARG KONA_JDK8_PACKAGE=TencentKona8.0.26.b1_jdk_linux-x86_64_8u492.tar.gz
+ARG NODE_VERSION=24.16.0
+ARG NVM_VERSION=0.40.3
+
+LABEL maintainer="Tencent BlueKing Job" \
+      dockerfile.version="1.0.0"
+
+ENV JAVA17_HOME=/data/TencentKona-17.0.16.b1
+ENV KONA_JDK17_HOME=/data/TencentKona-17.0.16.b1
+ENV JAVA8_HOME=/data/TencentKona8
+ENV KONA_JDK8_HOME=/data/TencentKona8
+ENV NVM_DIR=/usr/local/nvm
+ENV NODE_HOME=/usr/local/nvm/versions/node/v${NODE_VERSION}
+ENV PATH=${NODE_HOME}/bin:${PATH}
+ENV BASH_ENV=/etc/profile.d/jdk-env.sh
+ENV MYSQL_PORT=3306
+ENV MYSQL_USER=root
+ENV MYSQL_PASSWORD=root
+ENV MYSQL_DATADIR=/data/mysql
+ENV MYSQL_RUN_DIR=/tmp/mysql
+
+# 补齐基础镜像缺失的运行依赖：
+# - nvm安装脚本需要 awk
+# - mysqld需要 libaio/libnuma
+# - embedded MongoDB 4.4.x需要 OpenSSL 1.1 兼容库
+RUN dnf install -y \
+        gawk \
+        libaio \
+        numactl-libs \
+        compat-openssl11 && \
+    dnf clean all
+
+COPY --from=git-builder /opt/git /opt/git
+RUN ln -sf /opt/git/bin/git /usr/local/bin/git
+
+# 安装jdk8
+RUN mkdir -p /data && \
+    cd /tmp && \
+    curl -fSL "https://github.com/Tencent/TencentKona-8/releases/download/${KONA_JDK8_TAG}/${KONA_JDK8_PACKAGE}" -o kona8.tar.gz && \
+    KONA_DIR="$(tar -tzf kona8.tar.gz | head -1 | cut -d/ -f1)" && \
+    tar -xzf kona8.tar.gz -C /data && \
+    rm -rf "${JAVA8_HOME}" && \
+    mv "/data/${KONA_DIR}" "${JAVA8_HOME}" && \
+    rm -f /tmp/kona8.tar.gz
+
+# 通过nvm安装固定版本nodejs
+RUN mkdir -p "${NVM_DIR}" && \
+    cd /tmp && \
+    curl -fSL "https://github.com/nvm-sh/nvm/archive/refs/tags/v${NVM_VERSION}.tar.gz" -o nvm.tar.gz && \
+    tar -xzf nvm.tar.gz -C "${NVM_DIR}" --strip-components=1 && \
+    rm -f /tmp/nvm.tar.gz && \
+    . "${NVM_DIR}/nvm.sh" && \
+    nvm install "${NODE_VERSION}" && \
+    nvm alias default "${NODE_VERSION}" && \
+    nvm cache clear
+
+COPY jdk-env.sh /etc/profile.d/jdk-env.sh
+COPY start-mysql.sh /usr/local/bin/start-mysql
+RUN chmod 644 /etc/profile.d/jdk-env.sh && \
+    chmod +x /usr/local/bin/start-mysql

--- a/support-files/kubernetes/images/build-env/build-tool.Dockerfile
+++ b/support-files/kubernetes/images/build-env/build-tool.Dockerfile
@@ -4,6 +4,7 @@ ARG BASE_IMAGE=bkjob/tool-set:3.12.6
 FROM ${BASE_IMAGE} AS git-builder
 
 ARG GIT_VERSION=2.41.3
+ARG GIT_SHA256=baa39125deee194b440ac7d0138f6c34f0d87ceb1cb9da5b2becf704f45b0819
 
 # 构建指定版本的git
 RUN dnf install -y \
@@ -17,6 +18,7 @@ RUN dnf install -y \
         zlib-devel && \
     cd /tmp && \
     curl -fSL "https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.xz" -o git.tar.xz && \
+    echo "${GIT_SHA256}  git.tar.xz" | sha256sum -c - && \
     mkdir git-src && \
     tar -xJf git.tar.xz -C git-src --strip-components=1 && \
     cd git-src && \
@@ -30,8 +32,10 @@ FROM ${BASE_IMAGE}
 
 ARG KONA_JDK8_TAG=8.0.26-GA
 ARG KONA_JDK8_PACKAGE=TencentKona8.0.26.b1_jdk_linux-x86_64_8u492.tar.gz
+ARG KONA_JDK8_SHA256=9df50dd8e888ac62721ddd18400194f190bd91b8f3a1e1d782f710fc0eab2478
 ARG NODE_VERSION=24.16.0
 ARG NVM_VERSION=0.40.3
+ARG NVM_SHA256=5f4d6aaa04a177dc93c985e31dbc411ab6b8c6e1e21d8015dbc1372625fcd1d0
 
 LABEL maintainer="Tencent BlueKing Job" \
       dockerfile.version="1.0.1"
@@ -68,6 +72,7 @@ RUN ln -sf /opt/git/bin/git /usr/local/bin/git
 RUN mkdir -p /bk_job_data && \
     cd /tmp && \
     curl -fSL "https://github.com/Tencent/TencentKona-8/releases/download/${KONA_JDK8_TAG}/${KONA_JDK8_PACKAGE}" -o kona8.tar.gz && \
+    echo "${KONA_JDK8_SHA256}  kona8.tar.gz" | sha256sum -c - && \
     KONA_DIR="$(tar -tzf kona8.tar.gz | head -1 | cut -d/ -f1)" && \
     tar -xzf kona8.tar.gz -C /bk_job_data && \
     rm -rf "${JAVA8_HOME}" && \
@@ -78,6 +83,7 @@ RUN mkdir -p /bk_job_data && \
 RUN mkdir -p "${NVM_DIR}" && \
     cd /tmp && \
     curl -fSL "https://github.com/nvm-sh/nvm/archive/refs/tags/v${NVM_VERSION}.tar.gz" -o nvm.tar.gz && \
+    echo "${NVM_SHA256}  nvm.tar.gz" | sha256sum -c - && \
     tar -xzf nvm.tar.gz -C "${NVM_DIR}" --strip-components=1 && \
     rm -f /tmp/nvm.tar.gz && \
     . "${NVM_DIR}/nvm.sh" && \

--- a/support-files/kubernetes/images/build-env/jdk-env.sh
+++ b/support-files/kubernetes/images/build-env/jdk-env.sh
@@ -1,13 +1,13 @@
 # 该文件由shell启动时 source，用于初始化默认jdk，并提供jdk切换函数
-export JAVA17_HOME=/data/TencentKona-17.0.16.b1
-export KONA_JDK17_HOME=/data/TencentKona-17.0.16.b1
-export JAVA8_HOME=/data/TencentKona8
-export KONA_JDK8_HOME=/data/TencentKona8
+export JAVA17_HOME=/bk_job_data/TencentKona-17.0.16.b1
+export KONA_JDK17_HOME=/bk_job_data/TencentKona-17.0.16.b1
+export JAVA8_HOME=/bk_job_data/TencentKona8
+export KONA_JDK8_HOME=/bk_job_data/TencentKona8
 export NVM_DIR=/usr/local/nvm
 export MYSQL_PORT=${MYSQL_PORT:-3306}
 export MYSQL_USER=${MYSQL_USER:-root}
 export MYSQL_PASSWORD=${MYSQL_PASSWORD:-root}
-export MYSQL_DATADIR=${MYSQL_DATADIR:-/data/mysql}
+export MYSQL_DATADIR=${MYSQL_DATADIR:-/bk_job_data/mysql}
 export MYSQL_RUN_DIR=${MYSQL_RUN_DIR:-/tmp/mysql}
 
 [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"

--- a/support-files/kubernetes/images/build-env/jdk-env.sh
+++ b/support-files/kubernetes/images/build-env/jdk-env.sh
@@ -21,13 +21,23 @@ export NODE_HOME
 use-jdk17() {
     export JAVA_HOME="$JAVA17_HOME"
     export CLASSPATH=".:$JAVA_HOME/lib"
-    export PATH="$JAVA_HOME/bin:$NODE_HOME/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    PATH=":$PATH:"
+    PATH="${PATH//:$JAVA17_HOME\/bin:/:}"
+    PATH="${PATH//:$JAVA8_HOME\/bin:/:}"
+    PATH="${PATH#:}"
+    PATH="${PATH%:}"
+    export PATH="$JAVA_HOME/bin:$PATH"
 }
 
 use-jdk8() {
     export JAVA_HOME="$JAVA8_HOME"
     export CLASSPATH=".:$JAVA_HOME/lib"
-    export PATH="$JAVA_HOME/bin:$NODE_HOME/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    PATH=":$PATH:"
+    PATH="${PATH//:$JAVA17_HOME\/bin:/:}"
+    PATH="${PATH//:$JAVA8_HOME\/bin:/:}"
+    PATH="${PATH#:}"
+    PATH="${PATH%:}"
+    export PATH="$JAVA_HOME/bin:$PATH"
 }
 
 # 默认使用jdk17，需要jdk8时手动执行use-jdk8

--- a/support-files/kubernetes/images/build-env/jdk-env.sh
+++ b/support-files/kubernetes/images/build-env/jdk-env.sh
@@ -1,0 +1,34 @@
+# 该文件由shell启动时 source，用于初始化默认jdk，并提供jdk切换函数
+export JAVA17_HOME=/data/TencentKona-17.0.16.b1
+export KONA_JDK17_HOME=/data/TencentKona-17.0.16.b1
+export JAVA8_HOME=/data/TencentKona8
+export KONA_JDK8_HOME=/data/TencentKona8
+export NVM_DIR=/usr/local/nvm
+export MYSQL_PORT=${MYSQL_PORT:-3306}
+export MYSQL_USER=${MYSQL_USER:-root}
+export MYSQL_PASSWORD=${MYSQL_PASSWORD:-root}
+export MYSQL_DATADIR=${MYSQL_DATADIR:-/data/mysql}
+export MYSQL_RUN_DIR=${MYSQL_RUN_DIR:-/tmp/mysql}
+
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+
+# nodejs版本由Dockerfile安装，运行时从nvm目录自动识别，避免脚本内重复写版本号
+if [ -z "${NODE_HOME:-}" ] && [ -d "$NVM_DIR/versions/node" ]; then
+    NODE_HOME="$(find "$NVM_DIR/versions/node" -mindepth 1 -maxdepth 1 -type d | sort -V | tail -1)"
+fi
+export NODE_HOME
+
+use-jdk17() {
+    export JAVA_HOME="$JAVA17_HOME"
+    export CLASSPATH=".:$JAVA_HOME/lib"
+    export PATH="$JAVA_HOME/bin:$NODE_HOME/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+}
+
+use-jdk8() {
+    export JAVA_HOME="$JAVA8_HOME"
+    export CLASSPATH=".:$JAVA_HOME/lib"
+    export PATH="$JAVA_HOME/bin:$NODE_HOME/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+}
+
+# 默认使用jdk17，需要jdk8时手动执行use-jdk8
+use-jdk17

--- a/support-files/kubernetes/images/build-env/start-mysql.sh
+++ b/support-files/kubernetes/images/build-env/start-mysql.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="/usr/local/mysql/bin:$PATH"
+
+# 这些参数均可在 docker run 时通过 -e 覆盖。
+MYSQL_DATADIR=${MYSQL_DATADIR:-/data/mysql}
+MYSQL_RUN_DIR=${MYSQL_RUN_DIR:-/tmp/mysql}
+MYSQL_SOCKET=${MYSQL_SOCKET:-${MYSQL_RUN_DIR}/mysql.sock}
+MYSQL_PORT=${MYSQL_PORT:-3306}
+MYSQL_USER=${MYSQL_USER:-root}
+MYSQL_PASSWORD=${MYSQL_PASSWORD:-root}
+MYSQL_LOG=${MYSQL_LOG:-${MYSQL_RUN_DIR}/mysqld.log}
+
+case "${MYSQL_DATADIR}" in
+    /data/*|/tmp/*) ;;
+    *)
+        echo "MYSQL_DATADIR must be under /data or /tmp because start-mysql recreates it: ${MYSQL_DATADIR}" >&2
+        exit 1
+        ;;
+esac
+
+case "${MYSQL_RUN_DIR}" in
+    /tmp/*) ;;
+    *)
+        echo "MYSQL_RUN_DIR must be under /tmp because start-mysql recreates it: ${MYSQL_RUN_DIR}" >&2
+        exit 1
+        ;;
+esac
+
+mkdir -p "${MYSQL_RUN_DIR}"
+
+mysql_ping() {
+    mysqladmin --socket="${MYSQL_SOCKET}" -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" ping >/dev/null 2>&1 \
+        || mysqladmin --socket="${MYSQL_SOCKET}" -uroot ping >/dev/null 2>&1
+}
+
+mysql_shutdown() {
+    mysqladmin --socket="${MYSQL_SOCKET}" -uroot shutdown >/dev/null 2>&1 \
+        || mysqladmin --socket="${MYSQL_SOCKET}" -u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}" shutdown >/dev/null 2>&1 \
+        || true
+}
+
+# 构建场景需要纯净的MySQL，每次执行都停止旧实例并重建数据目录
+if mysql_ping; then
+    mysql_shutdown
+    for i in {1..30}; do
+        if ! mysql_ping; then
+            break
+        fi
+        sleep 1
+    done
+fi
+
+rm -rf "${MYSQL_DATADIR}" "${MYSQL_RUN_DIR}"
+mkdir -p "${MYSQL_DATADIR}" "${MYSQL_RUN_DIR}"
+
+mysqld --initialize-insecure --user=root --datadir="${MYSQL_DATADIR}" --log-error="${MYSQL_RUN_DIR}/initialize.log"
+
+mysqld \
+    --user=root \
+    --datadir="${MYSQL_DATADIR}" \
+    --socket="${MYSQL_SOCKET}" \
+    --port="${MYSQL_PORT}" \
+    --bind-address=127.0.0.1 \
+    --log-error="${MYSQL_LOG}" \
+    --daemonize
+
+# 等待 mysqld 完成启动
+for i in {1..60}; do
+    if mysql_ping; then
+        break
+    fi
+    sleep 1
+done
+
+if mysql --socket="${MYSQL_SOCKET}" -uroot -e "SELECT 1" >/dev/null 2>&1; then
+    MYSQL_ROOT_AUTH=(-uroot)
+else
+    MYSQL_ROOT_AUTH=(-u"${MYSQL_USER}" -p"${MYSQL_PASSWORD}")
+fi
+
+# 设置 root 密码，并确保 MYSQL_USER 可以通过 localhost 访问。
+mysql --socket="${MYSQL_SOCKET}" "${MYSQL_ROOT_AUTH[@]}" <<SQL
+ALTER USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_PASSWORD}';
+CREATE USER IF NOT EXISTS '${MYSQL_USER}'@'localhost' IDENTIFIED BY '${MYSQL_PASSWORD}';
+GRANT ALL PRIVILEGES ON *.* TO '${MYSQL_USER}'@'localhost' WITH GRANT OPTION;
+FLUSH PRIVILEGES;
+SQL
+
+echo "MySQL started: 127.0.0.1:${MYSQL_PORT}, user=${MYSQL_USER}"

--- a/support-files/kubernetes/images/build-env/start-mysql.sh
+++ b/support-files/kubernetes/images/build-env/start-mysql.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 export PATH="/usr/local/mysql/bin:$PATH"
 
 # 这些参数均可在 docker run 时通过 -e 覆盖。
-MYSQL_DATADIR=${MYSQL_DATADIR:-/data/mysql}
+MYSQL_DATADIR=${MYSQL_DATADIR:-/bk_job_data/mysql}
 MYSQL_RUN_DIR=${MYSQL_RUN_DIR:-/tmp/mysql}
 MYSQL_SOCKET=${MYSQL_SOCKET:-${MYSQL_RUN_DIR}/mysql.sock}
 MYSQL_PORT=${MYSQL_PORT:-3306}
@@ -13,9 +13,9 @@ MYSQL_PASSWORD=${MYSQL_PASSWORD:-root}
 MYSQL_LOG=${MYSQL_LOG:-${MYSQL_RUN_DIR}/mysqld.log}
 
 case "${MYSQL_DATADIR}" in
-    /data/*|/tmp/*) ;;
+    /bk_job_data/*|/tmp/*) ;;
     *)
-        echo "MYSQL_DATADIR must be under /data or /tmp because start-mysql recreates it: ${MYSQL_DATADIR}" >&2
+        echo "MYSQL_DATADIR must be under /bk_job_data or /tmp because start-mysql recreates it: ${MYSQL_DATADIR}" >&2
         exit 1
         ;;
 esac

--- a/support-files/kubernetes/images/build.sh
+++ b/support-files/kubernetes/images/build.sh
@@ -514,7 +514,7 @@ generate_version_logs() {
 
     local worker_dir=$(pwd)
     cd "$VERSION_LOGS_DIR"
-    if ! python genBundledVersionLog.py; then
+    if ! python3 genBundledVersionLog.py; then
         log "genBundledVersionLog.py failed"
         cd "$worker_dir"
         return 1


### PR DESCRIPTION
新增统一的编译构建镜像，基于 `bkjob/tool-set:3.12.5` 构建。

主要内容：
- 新增 `build-tool.Dockerfile`，用于构建
- 镜像内补充 JDK8、Git 2.41.3、NodeJS 24.16.0、nvm 等构建依赖
- 提供 `use-jdk8` / `use-jdk17` 切换能力，默认使用 JDK17
- 提供 `start-mysql`，用于构建时启动干净的 MySQL
- 提供MySQL 默认环境变量，方便 GitHub Actions 中直接使用
- 提供使用文档