### PR TITLE
perf: 升级SpringBoot到3.5.14版本 #4315

### DIFF
--- a/src/backend/job-gateway/build.gradle
+++ b/src/backend/job-gateway/build.gradle
@@ -32,6 +32,12 @@ ext {
     }
 }
 version "${jobGatewayVersion}"
+
+configurations.configureEach {
+    // job-gateway是WebFlux/Netty服务，避免公共模块传递引入web Starter后影响WebServer的自动装配顺序，management server被选成Tomcat
+    exclude group: 'org.springframework.boot', module: 'spring-boot-starter-web'
+}
+
 dependencies {
     api project(':commons:common')
     api project(":commons:common-i18n")


### PR DESCRIPTION
1.job-gateway访问日志没有management的日志，排除公共模块的web starter