### PR TITLE
perf: 升级SpringBoot到3.5.14版本 #4315

### DIFF
--- a/src/backend/build.gradle
+++ b/src/backend/build.gradle
@@ -98,13 +98,13 @@ ext {
     set('jacksonVersion', "2.15.4")
     set('jaxrsVersion', "3.1.0")
     // https://mvnrepository.com/artifact/ch.qos.logback/logback-core
-    set('logbackVersion', "1.5.16")
+    set('logbackVersion', "1.5.34")
     // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
     set('slf4jVersion', "2.0.16")
     // servletVersion 已移除，统一使用 jakarta.servlet (jakartaServletVersion)
     // apache commons
     // https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
-    set('apacheCommonsLang3Version', "3.12.0")
+    set('apacheCommonsLang3Version', "3.20.0")
     // https://mvnrepository.com/artifact/org.apache.commons/commons-collections4
     set('apacheCommonsCollectionVersion', "4.4")
     // https://mvnrepository.com/artifact/org.apache.commons/commons-pool2
@@ -141,11 +141,11 @@ ext {
     set('commonsValidatorVersion', "1.6")
     set('okHttpVersion', "4.12.0")
     set('jcommanderVersion', "1.72")
-    set('kubernetesJavaClientVersion', "19.0.0")
+    set('kubernetesJavaClientVersion', "19.0.3")
     set('springCloudKubernetesVersion', "3.3.2")
     set('cryptoJavaSDKVersion', "1.1.3")
-    // Fix CVE-2019-10086,CVE-2014-0114
-    set('commonsBeanutilsVersion', "1.9.4")
+    // Fix CVE-2025-48734
+    set('commonsBeanutilsVersion', "1.11.0")
     if (System.getProperty("bkjobVersion")) {
         set('bkjobVersion', System.getProperty("bkjobVersion"))
         println "bkjobVersion:" + bkjobVersion
@@ -392,6 +392,8 @@ subprojects {
     configurations {
         all*.exclude group: 'junit', module: 'junit'
         all*.exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+        // 排除commons-logging，会与Spring Boot spring-jcl冲突
+        all*.exclude group: 'commons-logging', module: 'commons-logging'
         // spring-cloud-sleuth-brave 排除已移除（Sleuth 已弃用，使用 Micrometer Tracing）
         all*.exclude group: 'org.springframework.data', module: 'spring-data-redis'
     }

--- a/src/backend/build.gradle
+++ b/src/backend/build.gradle
@@ -27,7 +27,7 @@ import com.dorongold.gradle.tasktree.TaskTreePlugin
 buildscript {
     ext {
         set('springDependencyManagePluginVersion', "1.1.7")
-        set("springBootVersion", "3.4.4")
+        set("springBootVersion", "3.5.14")
         set("gradleJooqVersion", "3.0.0")
     }
 
@@ -59,7 +59,6 @@ buildscript {
     dependencies {
         classpath "io.spring.gradle:dependency-management-plugin:$springDependencyManagePluginVersion"
         classpath "nu.studer:gradle-jooq-plugin:$gradleJooqVersion"
-        classpath 'org.junit.platform:junit-platform-gradle-plugin:1.1.0'
         classpath "gradle.plugin.com.dorongold.plugins:task-tree:1.5"
         classpath "com.vanniktech:gradle-dependency-graph-generator-plugin:0.8.0"
     }
@@ -68,7 +67,7 @@ buildscript {
 plugins {
     id "java-library"
     id "io.spring.dependency-management" version '1.1.7' apply false
-    id 'org.springframework.boot' version '3.4.4' apply false
+    id 'org.springframework.boot' version '3.5.14' apply false
     id "idea"
     id 'nu.studer.jooq' version '9.0'
 }
@@ -87,12 +86,12 @@ ext {
     println("assembly mode: $assemblyMode")
 
     // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies
-    set("springBootVersion", "3.4.4")
+    set("springBootVersion", "3.5.14")
     // https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-dependencies
-    set('springCloudVersion', "2024.0.1")
+    set('springCloudVersion', "2025.0.2")
     // SpringFox 已移除，使用 SpringDoc OpenAPI (springdoc-openapi-starter-webmvc-ui)
-    set('springDocVersion', "2.8.4")
-    set('junitVersion', "5.5.2")
+    set('springDocVersion', "2.8.17")
+    set('junitVersion', "5.12.2")
     // https://mvnrepository.com/artifact/org.projectlombok/lombok
     set('lombokVersion', "1.18.36")
     // https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core
@@ -143,7 +142,7 @@ ext {
     set('okHttpVersion', "4.12.0")
     set('jcommanderVersion', "1.72")
     set('kubernetesJavaClientVersion', "19.0.0")
-    set('springCloudKubernetesVersion', "3.2.1")
+    set('springCloudKubernetesVersion', "3.3.2")
     set('cryptoJavaSDKVersion', "1.1.3")
     // Fix CVE-2019-10086,CVE-2014-0114
     set('commonsBeanutilsVersion', "1.9.4")
@@ -173,7 +172,7 @@ ext {
     // 使用Spring Boot内置的版本号变量，不采用驼峰命名，保持与官方BOM文件一致
     // mysql.version 和 tomcat.version 由 Spring Boot BOM 管理
     // snakeyaml 版本由 Spring Boot BOM 管理
-    set('mysqlConnectorVersion', "8.0.33")
+    // mysqlConnectorVersion 版本由 Spring Boot BOM 管理
 }
 
 group "com.tencent.bk.job"
@@ -377,9 +376,8 @@ subprojects {
             dependency "com.tencent.devops.leaf:leaf-boot-starter:$bkDevOpsLeafVersion"
             dependency "org.apache.zookeeper:zookeeper:$zookeeperVersion"
             dependency "com.squareup.okio:okio:$okioVersion"
-            // reactor-netty, netty, spring-web, amqp-client 版本由 Spring Boot BOM 管理
+            // reactor-netty, netty, spring-web, amqp-client, mysql-connector-j 版本由 Spring Boot BOM 管理
             dependency "org.eclipse.jgit:org.eclipse.jgit:$jgitVersion"
-            dependency "com.mysql:mysql-connector-j:$mysqlConnectorVersion"
         }
     }
     dependencies {
@@ -388,6 +386,7 @@ subprojects {
                 because 'version 1.4 pulled from spring-cloud-starter-openfeign has vulnerabilities(CVE-2023-24998)'
             }
         }
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     }
 
     configurations {

--- a/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/config/JobK8sDiscoveryClientAutoConfiguration.java
+++ b/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/config/JobK8sDiscoveryClientAutoConfiguration.java
@@ -41,7 +41,6 @@ import org.springframework.cloud.client.ConditionalOnDiscoveryEnabled;
 import org.springframework.cloud.client.discovery.simple.SimpleDiscoveryClientAutoConfiguration;
 import org.springframework.cloud.kubernetes.client.KubernetesClientAutoConfiguration;
 import org.springframework.cloud.kubernetes.client.discovery.KubernetesInformerDiscoveryClient;
-import org.springframework.cloud.kubernetes.commons.KubernetesNamespaceProvider;
 import org.springframework.cloud.kubernetes.commons.discovery.KubernetesDiscoveryProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -60,7 +59,6 @@ public class JobK8sDiscoveryClientAutoConfiguration {
 
     @Bean
     public KubernetesInformerDiscoveryClient kubernetesInformerDiscoveryClient(
-        KubernetesNamespaceProvider kubernetesNamespaceProvider,
         SharedInformerFactory sharedInformerFactory,
         @Qualifier("servicesLister") Lister<V1Service> serviceLister,
         @Qualifier("endpointsLister") Lister<V1Endpoints> endpointsLister,
@@ -69,7 +67,6 @@ public class JobK8sDiscoveryClientAutoConfiguration {
         KubernetesDiscoveryProperties properties
     ) {
         return new JobKubernetesInformerDiscoveryClient(
-            kubernetesNamespaceProvider.getNamespace(),
             sharedInformerFactory,
             serviceLister,
             endpointsLister,

--- a/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/config/JobKubernetesInformerDiscoveryClient.java
+++ b/src/backend/commons/common-k8s/src/main/java/com/tencent/bk/job/common/k8s/config/JobKubernetesInformerDiscoveryClient.java
@@ -41,15 +41,13 @@ import java.util.List;
  */
 @Slf4j
 public class JobKubernetesInformerDiscoveryClient extends KubernetesInformerDiscoveryClient {
-    public JobKubernetesInformerDiscoveryClient(String namespace,
-                                                SharedInformerFactory sharedInformerFactory,
+    public JobKubernetesInformerDiscoveryClient(SharedInformerFactory sharedInformerFactory,
                                                 Lister<V1Service> serviceLister,
                                                 Lister<V1Endpoints> endpointsLister,
                                                 SharedInformer<V1Service> serviceInformer,
                                                 SharedInformer<V1Endpoints> endpointsInformer,
                                                 KubernetesDiscoveryProperties properties) {
-        super(namespace, sharedInformerFactory, serviceLister,
-            endpointsLister, serviceInformer, endpointsInformer, properties);
+        super(sharedInformerFactory, serviceLister, endpointsLister, serviceInformer, endpointsInformer, properties);
     }
 
     @Override

--- a/src/backend/commons/common-log/src/main/resources/logback-default.xml
+++ b/src/backend/commons/common-log/src/main/resources/logback-default.xml
@@ -4,9 +4,9 @@
 Default job logback configuration provided for import
 -->
 <included>
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
-    <conversionRule conversionWord="wEx" converterClass="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="wEx" class="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
 
     <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr([%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}]){faint} %clr(%5p [${APP_NAME:-anon-service},%X{traceId:-},%X{spanId:-}]) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>
     <property name="FILE_LOG_PATTERN" value="${FILE_LOG_PATTERN:-[%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}] %5p [${APP_NAME:-anon-service},%X{traceId:-},%X{spanId:-}] ${PID:- } --- [%t] %-40.40logger{39} : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>

--- a/src/backend/commons/common-mysql-sharding/leaf_gen_jooq.gradle
+++ b/src/backend/commons/common-mysql-sharding/leaf_gen_jooq.gradle
@@ -50,7 +50,8 @@ jooq {
 
                     println("mysqlURL=" + mysqlURL)
                     println("mysqlUser=" + mysqlUser)
-                    url = "jdbc:mysql://${mysqlURL}/${databaseName}?useSSL=false&serverTimezone=UTC"
+                    url = "jdbc:mysql://${mysqlURL}/${databaseName}?useSSL=false&serverTimezone=UTC" +
+                            "&allowPublicKeyRetrieval=true"
                     user = mysqlUser
                     password = mysqlPasswd
                 }

--- a/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feign/config/JobFeignLoadBalancerAutoConfiguration.java
+++ b/src/backend/commons/common-service/src/main/java/com/tencent/bk/job/common/service/feign/config/JobFeignLoadBalancerAutoConfiguration.java
@@ -38,8 +38,11 @@ import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
 import org.springframework.cloud.loadbalancer.config.BlockingLoadBalancerClientAutoConfiguration;
 import org.springframework.cloud.loadbalancer.support.LoadBalancerClientFactory;
 import org.springframework.cloud.openfeign.loadbalancer.FeignLoadBalancerAutoConfiguration;
+import org.springframework.cloud.openfeign.loadbalancer.LoadBalancerFeignRequestTransformer;
 import org.springframework.cloud.openfeign.loadbalancer.RetryableFeignBlockingLoadBalancerClient;
 import org.springframework.context.annotation.Bean;
+
+import java.util.List;
 
 /**
  * FeignBlockingLoadBalancerClient相关的自定义Bean配置
@@ -57,13 +60,15 @@ public class JobFeignLoadBalancerAutoConfiguration {
         matchIfMissing = true)
     public Client feignRetryClient(LoadBalancerClient loadBalancerClient,
                                    LoadBalancedRetryFactory loadBalancedRetryFactory,
-                                   LoadBalancerClientFactory loadBalancerClientFactory) {
+                                   LoadBalancerClientFactory loadBalancerClientFactory,
+                                   List<LoadBalancerFeignRequestTransformer> transformers) {
         log.info("feignRetryClient init");
         return new RetryableFeignBlockingLoadBalancerClient(
             new WatchableFeignClient(null, null),
             loadBalancerClient,
             loadBalancedRetryFactory,
-            loadBalancerClientFactory
+            loadBalancerClientFactory,
+            transformers
         );
     }
 }

--- a/src/backend/job-analysis/boot-job-analysis/src/main/resources/application.yml
+++ b/src/backend/job-analysis/boot-job-analysis/src/main/resources/application.yml
@@ -20,35 +20,36 @@ management:
       exposure:
         include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,refresh,busrefresh,bindings
       base-path: /actuator
-    enabled-by-default: false
+    access:
+      default: none
   endpoint:
     health:
-      enabled: true
+      access: unrestricted
       show-details: when_authorized
       probes:
         enabled: true
     configprops:
-      enabled: true
+      access: unrestricted
     env:
-      enabled: true
+      access: unrestricted
     beans:
-      enabled: true
+      access: unrestricted
     conditions:
-      enabled: true
+      access: unrestricted
     loggers:
-      enabled: true
+      access: unrestricted
     metrics:
-      enabled: true
+      access: unrestricted
     mappings:
-      enabled: true
+      access: unrestricted
     prometheus:
-      enabled: true
+      access: unrestricted
     scheduledtasks:
-      enabled: true
+      access: unrestricted
     refresh:
-      enabled: true
+      access: unrestricted
     busrefresh:
-      enabled: true
+      access: unrestricted
 server:
   port: 19807
   shutdown: graceful

--- a/src/backend/job-assemble/src/main/resources/application.yml
+++ b/src/backend/job-assemble/src/main/resources/application.yml
@@ -19,39 +19,40 @@ management:
       exposure:
         include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh,busrefresh,bindings
       base-path: /actuator
-    enabled-by-default: false
+    access:
+      default: none
   endpoint:
     health:
-      enabled: true
+      access: unrestricted
       show-details: when_authorized
       probes:
         enabled: true
     configprops:
-      enabled: true
+      access: unrestricted
     env:
-      enabled: true
+      access: unrestricted
     beans:
-      enabled: true
+      access: unrestricted
     conditions:
-      enabled: true
+      access: unrestricted
     loggers:
-      enabled: true
+      access: unrestricted
     metrics:
-      enabled: true
+      access: unrestricted
     mappings:
-      enabled: true
+      access: unrestricted
     prometheus:
-      enabled: true
+      access: unrestricted
     scheduledtasks:
-      enabled: true
+      access: unrestricted
     info:
-      enabled: true
+      access: unrestricted
     refresh:
-      enabled: true
+      access: unrestricted
     busrefresh:
-      enabled: true
+      access: unrestricted
     bindings:
-      enabled: true
+      access: unrestricted
 
 server:
   port: 19800

--- a/src/backend/job-assemble/src/test/resources/logback-spring.xml
+++ b/src/backend/job-assemble/src/test/resources/logback-spring.xml
@@ -2,9 +2,9 @@
 <configuration scan="true" scanPeriod="30 seconds">
     <contextName>logback</contextName>
 
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
-    <conversionRule conversionWord="wEx" converterClass="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="wEx" class="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
 
     <property name="APP_NAME" value="${APP_NAME:-job-assemble}"/>
     <property name="CONSOLE_LOG_PATTERN" value="${CONSOLE_LOG_PATTERN:-%clr(%d{${LOG_DATEFORMAT_PATTERN:-yyyy-MM-dd HH:mm:ss.SSS}}){faint} %clr(%5p [${APP_NAME:-anon-service},%X{traceId:-},%X{spanId:-}]) %clr(${PID:- }){magenta} %clr(---){faint} %clr([%15.30t]){faint} %clr(%-40.40logger{39}){cyan} %clr(:){faint} %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%wEx}}"/>

--- a/src/backend/job-backup/boot-job-backup/src/main/resources/application.yml
+++ b/src/backend/job-backup/boot-job-backup/src/main/resources/application.yml
@@ -20,37 +20,38 @@ management:
       exposure:
         include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh,busrefresh,bindings
       base-path: /actuator
-    enabled-by-default: false
+    access:
+      default: none
   endpoint:
     health:
-      enabled: true
+      access: unrestricted
       show-details: when_authorized
       probes:
         enabled: true
     configprops:
-      enabled: true
+      access: unrestricted
     env:
-      enabled: true
+      access: unrestricted
     beans:
-      enabled: true
+      access: unrestricted
     conditions:
-      enabled: true
+      access: unrestricted
     loggers:
-      enabled: true
+      access: unrestricted
     metrics:
-      enabled: true
+      access: unrestricted
     mappings:
-      enabled: true
+      access: unrestricted
     prometheus:
-      enabled: true
+      access: unrestricted
     scheduledtasks:
-      enabled: true
+      access: unrestricted
     info:
-      enabled: true
+      access: unrestricted
     refresh:
-      enabled: true
+      access: unrestricted
     busrefresh:
-      enabled: true
+      access: unrestricted
 server:
   port: 19808
   shutdown: graceful

--- a/src/backend/job-config/src/main/resources/application.yml
+++ b/src/backend/job-config/src/main/resources/application.yml
@@ -23,37 +23,38 @@ management:
       exposure:
         include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh,busrefresh,bindings
       base-path: /actuator
-    enabled-by-default: false
+    access:
+      default: none
   endpoint:
     health:
-      enabled: true
+      access: unrestricted
       show-details: when_authorized
       probes:
         enabled: true
     configprops:
-      enabled: true
+      access: unrestricted
     env:
-      enabled: true
+      access: unrestricted
     beans:
-      enabled: true
+      access: unrestricted
     conditions:
-      enabled: true
+      access: unrestricted
     loggers:
-      enabled: true
+      access: unrestricted
     metrics:
-      enabled: true
+      access: unrestricted
     mappings:
-      enabled: true
+      access: unrestricted
     prometheus:
-      enabled: true
+      access: unrestricted
     scheduledtasks:
-      enabled: true
+      access: unrestricted
     info:
-      enabled: true
+      access: unrestricted
     refresh:
-      enabled: true
+      access: unrestricted
     busrefresh:
-      enabled: true
+      access: unrestricted
 server:
   port: 19801
   shutdown: graceful

--- a/src/backend/job-config/src/main/resources/logback-spring.xml
+++ b/src/backend/job-config/src/main/resources/logback-spring.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true" scanPeriod="30 seconds">
     <contextName>logback</contextName>
-    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter" />
-    <conversionRule conversionWord="wex" converterClass="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
-    <conversionRule conversionWord="wEx" converterClass="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="clr" class="org.springframework.boot.logging.logback.ColorConverter" />
+    <conversionRule conversionWord="wex" class="org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter" />
+    <conversionRule conversionWord="wEx" class="org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter" />
 
     <property name="APP_NAME" value="${APP_NAME:-job-config}"/>
     <property name="BK_LOG_DIR" value="${job.log.dir:-/data/bkee/logs/job}"/>

--- a/src/backend/job-crontab/boot-job-crontab/src/main/resources/application.yml
+++ b/src/backend/job-crontab/boot-job-crontab/src/main/resources/application.yml
@@ -20,37 +20,38 @@ management:
       exposure:
         include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh,busrefresh,bindings
       base-path: /actuator
-    enabled-by-default: false
+    access:
+      default: none
   endpoint:
     health:
-      enabled: true
+      access: unrestricted
       show-details: when_authorized
       probes:
         enabled: true
     configprops:
-      enabled: true
+      access: unrestricted
     env:
-      enabled: true
+      access: unrestricted
     beans:
-      enabled: true
+      access: unrestricted
     conditions:
-      enabled: true
+      access: unrestricted
     loggers:
-      enabled: true
+      access: unrestricted
     metrics:
-      enabled: true
+      access: unrestricted
     mappings:
-      enabled: true
+      access: unrestricted
     prometheus:
-      enabled: true
+      access: unrestricted
     scheduledtasks:
-      enabled: true
+      access: unrestricted
     info:
-      enabled: true
+      access: unrestricted
     refresh:
-      enabled: true
+      access: unrestricted
     busrefresh:
-      enabled: true
+      access: unrestricted
 server:
   port: 19805
   shutdown: graceful

--- a/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/config/FeignConfig.java
+++ b/src/backend/job-crontab/service-job-crontab/src/main/java/com/tencent/bk/job/crontab/config/FeignConfig.java
@@ -40,6 +40,7 @@ import org.apache.http.ssl.SSLContexts;
 import org.springframework.cloud.client.loadbalancer.LoadBalancedRetryFactory;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
 import org.springframework.cloud.loadbalancer.support.LoadBalancerClientFactory;
+import org.springframework.cloud.openfeign.loadbalancer.LoadBalancerFeignRequestTransformer;
 import org.springframework.cloud.openfeign.loadbalancer.RetryableFeignBlockingLoadBalancerClient;
 import org.springframework.cloud.openfeign.support.FeignHttpClientProperties;
 import org.springframework.context.annotation.Bean;
@@ -48,6 +49,7 @@ import org.springframework.context.annotation.Configuration;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j
@@ -100,13 +102,15 @@ public class FeignConfig {
                               HttpClientConnectionManager feignClientConnectionManager,
                               LoadBalancerClient loadBalancerClient,
                               LoadBalancedRetryFactory loadBalancedRetryFactory,
-                              LoadBalancerClientFactory loadBalancerClientFactory) {
+                              LoadBalancerClientFactory loadBalancerClientFactory,
+                              List<LoadBalancerFeignRequestTransformer> transformers) {
         ApacheHttpClient delegate = getApacheHttpClient(httpClientProperties, feignClientConnectionManager);
         return new RetryableFeignBlockingLoadBalancerClient(
             delegate,
             loadBalancerClient,
             loadBalancedRetryFactory,
-            loadBalancerClientFactory
+            loadBalancerClientFactory,
+            transformers
         );
     }
 }

--- a/src/backend/job-execute/boot-job-execute/src/main/resources/application.yml
+++ b/src/backend/job-execute/boot-job-execute/src/main/resources/application.yml
@@ -20,39 +20,40 @@ management:
       exposure:
         include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh,busrefresh,bindings
       base-path: /actuator
-    enabled-by-default: false
+    access:
+      default: none
   endpoint:
     health:
-      enabled: true
+      access: unrestricted
       show-details: when_authorized
       probes:
         enabled: true
     configprops:
-      enabled: true
+      access: unrestricted
     env:
-      enabled: true
+      access: unrestricted
     beans:
-      enabled: true
+      access: unrestricted
     conditions:
-      enabled: true
+      access: unrestricted
     loggers:
-      enabled: true
+      access: unrestricted
     metrics:
-      enabled: true
+      access: unrestricted
     mappings:
-      enabled: true
+      access: unrestricted
     prometheus:
-      enabled: true
+      access: unrestricted
     scheduledtasks:
-      enabled: true
+      access: unrestricted
     info:
-      enabled: true
+      access: unrestricted
     refresh:
-      enabled: true
+      access: unrestricted
     busrefresh:
-      enabled: true
+      access: unrestricted
     bindings:
-      enabled: true
+      access: unrestricted
 
 server:
   port: 19804

--- a/src/backend/job-file-gateway/boot-job-file-gateway/src/main/resources/application.yml
+++ b/src/backend/job-file-gateway/boot-job-file-gateway/src/main/resources/application.yml
@@ -20,37 +20,38 @@ management:
       exposure:
         include: shutdown,health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh,busrefresh,bindings
       base-path: /actuator
-    enabled-by-default: false
+    access:
+      default: none
   endpoint:
     shutdown:
-      enabled: true
+      access: unrestricted
     health:
-      enabled: true
+      access: unrestricted
       show-details: when_authorized
     configprops:
-      enabled: true
+      access: unrestricted
     env:
-      enabled: true
+      access: unrestricted
     beans:
-      enabled: true
+      access: unrestricted
     conditions:
-      enabled: true
+      access: unrestricted
     loggers:
-      enabled: true
+      access: unrestricted
     metrics:
-      enabled: true
+      access: unrestricted
     mappings:
-      enabled: true
+      access: unrestricted
     prometheus:
-      enabled: true
+      access: unrestricted
     scheduledtasks:
-      enabled: true
+      access: unrestricted
     info:
-      enabled: true
+      access: unrestricted
     refresh:
-      enabled: true
+      access: unrestricted
     busrefresh:
-      enabled: true
+      access: unrestricted
   metrics:
     tags:
       application: ${spring.application.name}

--- a/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/config/RestTemplateConfig.java
+++ b/src/backend/job-file-gateway/service-job-file-gateway/src/main/java/com/tencent/bk/job/file_gateway/config/RestTemplateConfig.java
@@ -26,7 +26,7 @@ package com.tencent.bk.job.file_gateway.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.OkHttp3ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -34,10 +34,9 @@ public class RestTemplateConfig {
     @Bean
     public RestTemplate restTemplate() {
         RestTemplate restTemplate = new RestTemplate();
-        OkHttp3ClientHttpRequestFactory requestFactory = new OkHttp3ClientHttpRequestFactory();
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
         requestFactory.setConnectTimeout(5000);
         requestFactory.setReadTimeout(15000);
-        requestFactory.setWriteTimeout(15000);
         restTemplate.setRequestFactory(requestFactory);
         return restTemplate;
     }

--- a/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/config/RestTemplateConfig.java
+++ b/src/backend/job-file-worker-sdk/service-job-file-worker-sdk/src/main/java/com/tencent/bk/job/file/worker/config/RestTemplateConfig.java
@@ -26,7 +26,7 @@ package com.tencent.bk.job.file.worker.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.OkHttp3ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -34,10 +34,9 @@ public class RestTemplateConfig {
     @Bean
     public RestTemplate restTemplate() {
         RestTemplate restTemplate = new RestTemplate();
-        OkHttp3ClientHttpRequestFactory requestFactory = new OkHttp3ClientHttpRequestFactory();
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
         requestFactory.setConnectTimeout(5000);
         requestFactory.setReadTimeout(15000);
-        requestFactory.setWriteTimeout(15000);
         restTemplate.setRequestFactory(requestFactory);
         return restTemplate;
     }

--- a/src/backend/job-file-worker/boot-job-file-worker/src/main/resources/application.yml
+++ b/src/backend/job-file-worker/boot-job-file-worker/src/main/resources/application.yml
@@ -15,30 +15,31 @@ management:
       exposure:
         include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info
       base-path: /actuator
-    enabled-by-default: false
+    access:
+      default: none
   endpoint:
     health:
-      enabled: true
+      access: unrestricted
     configprops:
-      enabled: true
+      access: unrestricted
     env:
-      enabled: true
+      access: unrestricted
     beans:
-      enabled: true
+      access: unrestricted
     conditions:
-      enabled: true
+      access: unrestricted
     loggers:
-      enabled: true
+      access: unrestricted
     metrics:
-      enabled: true
+      access: unrestricted
     mappings:
-      enabled: true
+      access: unrestricted
     prometheus:
-      enabled: true
+      access: unrestricted
     scheduledtasks:
-      enabled: true
+      access: unrestricted
     info:
-      enabled: true
+      access: unrestricted
   metrics:
     tags:
       application: ${spring.application.name}

--- a/src/backend/job-gateway/build.gradle
+++ b/src/backend/job-gateway/build.gradle
@@ -42,8 +42,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-autoconfigure")
     implementation 'org.springframework:spring-webflux'
     implementation 'org.springframework.cloud:spring-cloud-starter-bootstrap'
-    implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
-    implementation 'org.springframework.cloud:spring-cloud-gateway-server'
+    implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
     implementation 'redis.clients:jedis'
     implementation 'commons-io:commons-io'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/backend/job-gateway/build.gradle
+++ b/src/backend/job-gateway/build.gradle
@@ -32,6 +32,12 @@ ext {
     }
 }
 version "${jobGatewayVersion}"
+
+configurations.configureEach {
+    // job-gateway是WebFlux/Netty服务，避免公共模块传递引入web Starter后影响WebServer的自动装配顺序，management server被选成Tomcat
+    exclude group: 'org.springframework.boot', module: 'spring-boot-starter-web'
+}
+
 dependencies {
     api project(':commons:common')
     api project(":commons:common-i18n")

--- a/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/config/RestConfig.java
+++ b/src/backend/job-gateway/src/main/java/com/tencent/bk/job/gateway/config/RestConfig.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.gateway.config;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
@@ -32,6 +33,7 @@ import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactoryBuilder;
 import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.apache.hc.core5.util.Timeout;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -55,7 +57,6 @@ public class RestConfig {
         HttpComponentsClientHttpRequestFactory factory = new
             HttpComponentsClientHttpRequestFactory();
         factory.setConnectionRequestTimeout(10000);
-        factory.setConnectTimeout(10000);
         // https
         try {
             SSLContext sslContext = new SSLContextBuilder()
@@ -65,6 +66,9 @@ public class RestConfig {
                 .setSSLSocketFactory(SSLConnectionSocketFactoryBuilder.create()
                     .setSslContext(sslContext)
                     .setHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                    .build())
+                .setDefaultConnectionConfig(ConnectionConfig.custom()
+                    .setConnectTimeout(Timeout.ofMilliseconds(10000))
                     .build())
                 .setMaxConnTotal(200)
                 .build();

--- a/src/backend/job-gateway/src/main/resources/application.yml
+++ b/src/backend/job-gateway/src/main/resources/application.yml
@@ -6,13 +6,16 @@ spring:
     active: default
   # sleuth 配置已移除，迁移至 management.tracing
   cloud:
-    ssl:
-      useInsecureTrustManager: true
     gateway:
-      discovery:
-        locator:
-          enabled: false
-          lower-case-service-id: true
+      server:
+        webflux:
+          httpclient:
+            ssl:
+              use-insecure-trust-manager: true
+          discovery:
+            locator:
+              enabled: false
+              lower-case-service-id: true
 server:
   shutdown: graceful
 management:
@@ -33,37 +36,38 @@ management:
       exposure:
         include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh,busrefresh,bindings
       base-path: /actuator
-    enabled-by-default: false
+    access:
+      default: none
   endpoint:
     health:
-      enabled: true
+      access: unrestricted
       show-details: when_authorized
       probes:
         enabled: true
     configprops:
-      enabled: true
+      access: unrestricted
     env:
-      enabled: true
+      access: unrestricted
     beans:
-      enabled: true
+      access: unrestricted
     conditions:
-      enabled: true
+      access: unrestricted
     loggers:
-      enabled: true
+      access: unrestricted
     metrics:
-      enabled: true
+      access: unrestricted
     mappings:
-      enabled: true
+      access: unrestricted
     prometheus:
-      enabled: true
+      access: unrestricted
     scheduledtasks:
-      enabled: true
+      access: unrestricted
     info:
-      enabled: true
+      access: unrestricted
     refresh:
-      enabled: true
+      access: unrestricted
     busrefresh:
-      enabled: true
+      access: unrestricted
 
 job:
   gateway:

--- a/src/backend/job-logsvr/boot-job-logsvr/src/main/resources/application.yml
+++ b/src/backend/job-logsvr/boot-job-logsvr/src/main/resources/application.yml
@@ -20,37 +20,38 @@ management:
       exposure:
         include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh,busrefresh,bindings
       base-path: /actuator
-    enabled-by-default: false
+    access:
+      default: none
   endpoint:
     health:
-      enabled: true
+      access: unrestricted
       show-details: when_authorized
       probes:
         enabled: true
     configprops:
-      enabled: true
+      access: unrestricted
     env:
-      enabled: true
+      access: unrestricted
     beans:
-      enabled: true
+      access: unrestricted
     conditions:
-      enabled: true
+      access: unrestricted
     loggers:
-      enabled: true
+      access: unrestricted
     metrics:
-      enabled: true
+      access: unrestricted
     mappings:
-      enabled: true
+      access: unrestricted
     prometheus:
-      enabled: true
+      access: unrestricted
     scheduledtasks:
-      enabled: true
+      access: unrestricted
     info:
-      enabled: true
+      access: unrestricted
     refresh:
-      enabled: true
+      access: unrestricted
     busrefresh:
-      enabled: true
+      access: unrestricted
 server:
   port: 19806
   servlet:

--- a/src/backend/job-logsvr/boot-job-logsvr/src/test/resources/application-test.yml
+++ b/src/backend/job-logsvr/boot-job-logsvr/src/test/resources/application-test.yml
@@ -15,7 +15,7 @@ de:
   flapdoodle:
     mongodb:
       embedded:
-        version: 4.0.28
+        version: 7.0.12
 bk-api-gateway:
   gse:
     url: gse.apigw.com

--- a/src/backend/job-logsvr/boot-job-logsvr/src/test/resources/application-test.yml
+++ b/src/backend/job-logsvr/boot-job-logsvr/src/test/resources/application-test.yml
@@ -15,7 +15,7 @@ de:
   flapdoodle:
     mongodb:
       embedded:
-        version: 7.0.12
+        version: 4.4.29
 bk-api-gateway:
   gse:
     url: gse.apigw.com

--- a/src/backend/job-manage/boot-job-manage/src/main/resources/application.yml
+++ b/src/backend/job-manage/boot-job-manage/src/main/resources/application.yml
@@ -22,37 +22,38 @@ management:
       exposure:
         include: health,configprops,env,beans,conditions,loggers,metrics,mappings,prometheus,scheduledtasks,info,refresh,busrefresh,bindings
       base-path: /actuator
-    enabled-by-default: false
+    access:
+      default: none
   endpoint:
     health:
-      enabled: true
+      access: unrestricted
       show-details: when_authorized
       probes:
         enabled: true
     configprops:
-      enabled: true
+      access: unrestricted
     env:
-      enabled: true
+      access: unrestricted
     beans:
-      enabled: true
+      access: unrestricted
     conditions:
-      enabled: true
+      access: unrestricted
     loggers:
-      enabled: true
+      access: unrestricted
     metrics:
-      enabled: true
+      access: unrestricted
     mappings:
-      enabled: true
+      access: unrestricted
     prometheus:
-      enabled: true
+      access: unrestricted
     scheduledtasks:
-      enabled: true
+      access: unrestricted
     info:
-      enabled: true
+      access: unrestricted
     refresh:
-      enabled: true
+      access: unrestricted
     busrefresh:
-      enabled: true
+      access: unrestricted
 server:
   port: 19803
   shutdown: graceful

--- a/src/backend/task_gen_jooq.gradle
+++ b/src/backend/task_gen_jooq.gradle
@@ -66,7 +66,8 @@ jooq {
 
                     println("mysqlURL=" + mysqlURL)
                     println("mysqlUser=" + mysqlUser)
-                    url = "jdbc:mysql://${mysqlURL}/${databaseName}?useSSL=false&serverTimezone=UTC"
+                    url = "jdbc:mysql://${mysqlURL}/${databaseName}?useSSL=false&serverTimezone=UTC" +
+                            "&allowPublicKeyRetrieval=true"
                     user = mysqlUser
                     password = mysqlPasswd
                 }

--- a/support-files/kubernetes/charts/bk-job/templates/job-gateway/configmap.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-gateway/configmap.yaml
@@ -37,434 +37,436 @@ data:
                     {{- end }}
                     virtual-host: {{ include "job.rabbitmq.vhost" . }}
         gateway:
-          discovery:
-            locator:
-              enabled: false
-              lower-case-service-id: true
-          routes:
-            {{- if eq .Values.deploy.mode "standard" }}
-            - id: job-logout
-              uri: lb://job-gateway
-              predicates:
-                - Path= /logout
-              filters:
-                - Logout
-            - id: job-manage-web
-              uri: lb://job-manage
-              predicates:
-                - Path= /job-manage/web/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-                - AddWebLangHeader
-            - id: job-crontab-web
-              uri: lb://job-crontab
-              predicates:
-                - Path= /job-crontab/web/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-                - AddWebLangHeader
-            - id: job-execute-web
-              uri: lb://job-execute
-              predicates:
-                - Path= /job-execute/web/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-                - AddWebLangHeader
-            - id: job-backup-web
-              uri: lb://job-backup
-              predicates:
-                - Path= /job-backup/web/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-                - AddWebLangHeader
-            - id: job-file-gateway-web
-              uri: lb://job-file-gateway
-              predicates:
-                - Path= /job-file-gateway/web/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-                - AddWebLangHeader
-            - id: job-analysis-web
-              uri: lb://job-analysis
-              predicates:
-                - Path= /job-analysis/web/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-                - AddWebLangHeader
+          server:
+            webflux:
+              discovery:
+                locator:
+                  enabled: false
+                  lower-case-service-id: true
+              routes:
+                {{- if eq .Values.deploy.mode "standard" }}
+                - id: job-logout
+                  uri: lb://job-gateway
+                  predicates:
+                    - Path= /logout
+                  filters:
+                    - Logout
+                - id: job-manage-web
+                  uri: lb://job-manage
+                  predicates:
+                    - Path= /job-manage/web/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                    - AddWebLangHeader
+                - id: job-crontab-web
+                  uri: lb://job-crontab
+                  predicates:
+                    - Path= /job-crontab/web/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                    - AddWebLangHeader
+                - id: job-execute-web
+                  uri: lb://job-execute
+                  predicates:
+                    - Path= /job-execute/web/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                    - AddWebLangHeader
+                - id: job-backup-web
+                  uri: lb://job-backup
+                  predicates:
+                    - Path= /job-backup/web/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                    - AddWebLangHeader
+                - id: job-file-gateway-web
+                  uri: lb://job-file-gateway
+                  predicates:
+                    - Path= /job-file-gateway/web/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                    - AddWebLangHeader
+                - id: job-analysis-web
+                  uri: lb://job-analysis
+                  predicates:
+                    - Path= /job-analysis/web/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                    - AddWebLangHeader
 
-            - id: job-file-gateway-remote
-              uri: lb://job-file-gateway
-              predicates:
-                - Path= /job-file-gateway/remote/**
-              filters:
-                - AuthorizeRemote
-                - StripPrefix=1
+                - id: job-file-gateway-remote
+                  uri: lb://job-file-gateway
+                  predicates:
+                    - Path= /job-file-gateway/remote/**
+                  filters:
+                    - AuthorizeRemote
+                    - StripPrefix=1
 
-            - id: job-manage-esb
-              uri: lb://job-manage
-              predicates:
-                - JobEsbV2Path=/api/job/v2/job-manage/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v2/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
+                - id: job-manage-esb
+                  uri: lb://job-manage
+                  predicates:
+                    - JobEsbV2Path=/api/job/v2/job-manage/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v2/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
 
-            - id: job-manage-esb-v3
-              uri: lb://job-manage
-              predicates:
-                - Path=/api/job/v3/job-manage/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v3/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
+                - id: job-manage-esb-v3
+                  uri: lb://job-manage
+                  predicates:
+                    - Path=/api/job/v3/job-manage/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v3/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
 
-            - id: job-crontab-esb
-              uri: lb://job-crontab
-              predicates:
-                - JobEsbV2Path=/api/job/v2/job-crontab/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v2/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
+                - id: job-crontab-esb
+                  uri: lb://job-crontab
+                  predicates:
+                    - JobEsbV2Path=/api/job/v2/job-crontab/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v2/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
 
-            - id: job-crontab-esb-v3
-              uri: lb://job-crontab
-              predicates:
-                - JobEsbV2Path=/api/job/v3/job-crontab/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v3/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
+                - id: job-crontab-esb-v3
+                  uri: lb://job-crontab
+                  predicates:
+                    - JobEsbV2Path=/api/job/v3/job-crontab/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v3/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
 
-            - id: job-execute-esb
-              uri: lb://job-execute
-              predicates:
-                - JobEsbV2Path=/api/job/v2/job-execute/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v2/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
+                - id: job-execute-esb
+                  uri: lb://job-execute
+                  predicates:
+                    - JobEsbV2Path=/api/job/v2/job-execute/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v2/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
 
-            - id: job-execute-esb-v3
-              uri: lb://job-execute
-              predicates:
-                - JobEsbV2Path=/api/job/v3/job-execute/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v3/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
+                - id: job-execute-esb-v3
+                  uri: lb://job-execute
+                  predicates:
+                    - JobEsbV2Path=/api/job/v3/job-execute/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v3/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
 
-            - id: job-file-gateway-esb-v3
-              uri: lb://job-file-gateway
-              predicates:
-                - JobEsbV2Path=/api/job/v3/job-file-gateway/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v3/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
+                - id: job-file-gateway-esb-v3
+                  uri: lb://job-file-gateway
+                  predicates:
+                    - JobEsbV2Path=/api/job/v3/job-file-gateway/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v3/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
 
-            - id: job-execute-esb-v4
-              uri: lb://job-execute
-              predicates:
-                - JobEsbV2Path=/api/job/v4/job-execute/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v4/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
+                - id: job-execute-esb-v4
+                  uri: lb://job-execute
+                  predicates:
+                    - JobEsbV2Path=/api/job/v4/job-execute/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v4/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
 
-            - id: job-manage-esb-v4
-              uri: lb://job-manage
-              predicates:
-                - JobEsbV2Path=/api/job/v4/job-manage/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v4/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
+                - id: job-manage-esb-v4
+                  uri: lb://job-manage
+                  predicates:
+                    - JobEsbV2Path=/api/job/v4/job-manage/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v4/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
 
-            - id: job-file-gateway-esb-v4
-              uri: lb://job-file-gateway
-              predicates:
-                - JobEsbV2Path=/api/job/v4/job-file-gateway/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v4/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
+                - id: job-file-gateway-esb-v4
+                  uri: lb://job-file-gateway
+                  predicates:
+                    - JobEsbV2Path=/api/job/v4/job-file-gateway/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v4/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
 
-            - id: job-crontab-esb-v4
-              uri: lb://job-crontab
-              predicates:
-                - JobEsbV2Path=/api/job/v4/job-crontab/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v4/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
+                - id: job-crontab-esb-v4
+                  uri: lb://job-crontab
+                  predicates:
+                    - JobEsbV2Path=/api/job/v4/job-crontab/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v4/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
 
-            - id: job-analysis-esb-v4
-              uri: lb://job-analysis
-              predicates:
-                - JobEsbV2Path=/api/job/v4/job-analysis/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v4/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
+                - id: job-analysis-esb-v4
+                  uri: lb://job-analysis
+                  predicates:
+                    - JobEsbV2Path=/api/job/v4/job-analysis/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v4/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
 
-            - id: job-esb-v4
-              uri: lb://job-assemble
-              predicates:
-                - Path=/api/job/v4/{module}/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v4/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
+                - id: job-esb-v4
+                  uri: lb://job-assemble
+                  predicates:
+                    - Path=/api/job/v4/{module}/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v4/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
 
-            - id: job-file-gateway-iam
-              uri: lb://job-file-gateway
-              predicates:
-                - Path=/iam/api/v1/resources/file_source
-              filters:
-                - RecordIamAccessLog
-                - CheckTenant
-                - AddEsbLangHeader
+                - id: job-file-gateway-iam
+                  uri: lb://job-file-gateway
+                  predicates:
+                    - Path=/iam/api/v1/resources/file_source
+                  filters:
+                    - RecordIamAccessLog
+                    - CheckTenant
+                    - AddEsbLangHeader
 
-            - id: job-analysis-iam
-              uri: lb://job-analysis
-              predicates:
-                - Path=/iam/api/v1/resources/dashboard_view
-              filters:
-                - RecordIamAccessLog
-                - CheckTenant
-                - AddEsbLangHeader
+                - id: job-analysis-iam
+                  uri: lb://job-analysis
+                  predicates:
+                    - Path=/iam/api/v1/resources/dashboard_view
+                  filters:
+                    - RecordIamAccessLog
+                    - CheckTenant
+                    - AddEsbLangHeader
 
-            - id: job-manage-iam
-              uri: lb://job-manage
-              predicates:
-                - Path=/iam/api/v1/resources/script,/iam/api/v1/resources/task/template,/iam/api/v1/resources/task/plan,/iam/api/v1/resources/account,/iam/api/v1/resources/whitelist,/iam/api/v1/resources/script/public,/iam/api/v1/resources/tag,/iam/api/v1/resources/ticket
-              filters:
-                - RecordIamAccessLog
-                - CheckTenant
-                - AddEsbLangHeader
+                - id: job-manage-iam
+                  uri: lb://job-manage
+                  predicates:
+                    - Path=/iam/api/v1/resources/script,/iam/api/v1/resources/task/template,/iam/api/v1/resources/task/plan,/iam/api/v1/resources/account,/iam/api/v1/resources/whitelist,/iam/api/v1/resources/script/public,/iam/api/v1/resources/tag,/iam/api/v1/resources/ticket
+                  filters:
+                    - RecordIamAccessLog
+                    - CheckTenant
+                    - AddEsbLangHeader
 
-            - id: job-crontab-iam
-              uri: lb://job-crontab
-              predicates:
-                - Path=/iam/api/v1/resources/cron/job
-              filters:
-                - RecordIamAccessLog
-                - CheckTenant
-                - AddEsbLangHeader
+                - id: job-crontab-iam
+                  uri: lb://job-crontab
+                  predicates:
+                    - Path=/iam/api/v1/resources/cron/job
+                  filters:
+                    - RecordIamAccessLog
+                    - CheckTenant
+                    - AddEsbLangHeader
 
-            - id: job-execute-iam
-              uri: lb://job-execute
-              predicates:
-                - Path=/iam/api/v1/resources/execute/record
-              filters:
-                - RecordIamAccessLog
-                - CheckTenant
-                - AddEsbLangHeader
-            {{- if eq (include "job.profileIsDev" .) "true" }}
-            - id: job-execute-swagger
-              uri: lb://job-execute
-              predicates:
-                - Path=/job-execute/swagger-ui/**,/job-execute/swagger-resources/**,/job-execute/v3/api-docs/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-            - id: job-manage-swagger
-              uri: lb://job-manage
-              predicates:
-                - Path=/job-manage/swagger-ui/**,/job-manage/swagger-resources/**,/job-manage/v3/api-docs/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-            - id: job-analysis-swagger
-              uri: lb://job-analysis
-              predicates:
-                - Path=/job-analysis/swagger-ui/**,/job-analysis/swagger-resources/**,/job-analysis/v3/api-docs/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-            - id: job-crontab-swagger
-              uri: lb://job-crontab
-              predicates:
-                - Path=/job-crontab/swagger-ui/**,/job-crontab/swagger-resources/**,/job-crontab/v3/api-docs/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-            - id: job-backup-swagger
-              uri: lb://job-backup
-              predicates:
-                - Path=/job-backup/swagger-ui/**,/job-backup/swagger-resources/**,/job-backup/v3/api-docs/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-            - id: job-file-gateway-swagger
-              uri: lb://job-file-gateway
-              predicates:
-                - Path=/job-file-gateway/swagger-ui/**,/job-file-gateway/swagger-resources/**,/job-file-gateway/v3/api-docs/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-            - id: job-execute-swagger-service-op-esb
-              uri: lb://job-execute
-              predicates:
-                - Path=/job-execute/service/**,/job-execute/op/**,/job-execute/esb/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-            - id: job-manage-swagger-service-op-esb
-              uri: lb://job-manage
-              predicates:
-                - Path=/job-manage/service/**,/job-manage/op/**,/job-manage/esb/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-            - id: job-analysis-swagger-service-op-esb
-              uri: lb://job-analysis
-              predicates:
-                - Path=/job-analysis/service/**,/job-analysis/op/**,/job-analysis/esb/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-            - id: job-crontab-swagger-service-op-esb
-              uri: lb://job-crontab
-              predicates:
-                - Path=/job-crontab/service/**,/job-crontab/op/**,/job-crontab/esb/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-            - id: job-backup-swagger-service-op-esb
-              uri: lb://job-backup
-              predicates:
-                - Path=/job-backup/service/**,/job-backup/op/**,/job-backup/esb/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-            - id: job-file-gateway-swagger-service-op-esb
-              uri: lb://job-file-gateway
-              predicates:
-                - Path=/job-file-gateway/service/**,/job-file-gateway/op/**,/job-file-gateway/esb/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-            {{- end }}
-            {{- else if eq .Values.deploy.mode "lite" }}
-            - id: job-logout
-              uri: lb://job-gateway
-              predicates:
-                - Path= /logout
-              filters:
-                - Logout
-    
-            - id: job-web
-              uri: lb://job-assemble
-              predicates:
-                - Path= /job-manage/web/**,/job-crontab/web/**,/job-execute/web/**,/job-analysis/web/**,/job-backup/web/**,/job-logsvr/web/**,/job-file-gateway/web/**
-              filters:
-                - Authorize
-                - CsrfCheck
-                - StripPrefix=1
-                - AddWebLangHeader
-    
-            - id: job-file-gateway-remote
-              uri: lb://job-assemble
-              predicates:
-                - Path= /job-file-gateway/remote/**
-              filters:
-                - AuthorizeRemote
-                - StripPrefix=1
+                - id: job-execute-iam
+                  uri: lb://job-execute
+                  predicates:
+                    - Path=/iam/api/v1/resources/execute/record
+                  filters:
+                    - RecordIamAccessLog
+                    - CheckTenant
+                    - AddEsbLangHeader
+                {{- if eq (include "job.profileIsDev" .) "true" }}
+                - id: job-execute-swagger
+                  uri: lb://job-execute
+                  predicates:
+                    - Path=/job-execute/swagger-ui/**,/job-execute/swagger-resources/**,/job-execute/v3/api-docs/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                - id: job-manage-swagger
+                  uri: lb://job-manage
+                  predicates:
+                    - Path=/job-manage/swagger-ui/**,/job-manage/swagger-resources/**,/job-manage/v3/api-docs/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                - id: job-analysis-swagger
+                  uri: lb://job-analysis
+                  predicates:
+                    - Path=/job-analysis/swagger-ui/**,/job-analysis/swagger-resources/**,/job-analysis/v3/api-docs/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                - id: job-crontab-swagger
+                  uri: lb://job-crontab
+                  predicates:
+                    - Path=/job-crontab/swagger-ui/**,/job-crontab/swagger-resources/**,/job-crontab/v3/api-docs/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                - id: job-backup-swagger
+                  uri: lb://job-backup
+                  predicates:
+                    - Path=/job-backup/swagger-ui/**,/job-backup/swagger-resources/**,/job-backup/v3/api-docs/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                - id: job-file-gateway-swagger
+                  uri: lb://job-file-gateway
+                  predicates:
+                    - Path=/job-file-gateway/swagger-ui/**,/job-file-gateway/swagger-resources/**,/job-file-gateway/v3/api-docs/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                - id: job-execute-swagger-service-op-esb
+                  uri: lb://job-execute
+                  predicates:
+                    - Path=/job-execute/service/**,/job-execute/op/**,/job-execute/esb/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                - id: job-manage-swagger-service-op-esb
+                  uri: lb://job-manage
+                  predicates:
+                    - Path=/job-manage/service/**,/job-manage/op/**,/job-manage/esb/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                - id: job-analysis-swagger-service-op-esb
+                  uri: lb://job-analysis
+                  predicates:
+                    - Path=/job-analysis/service/**,/job-analysis/op/**,/job-analysis/esb/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                - id: job-crontab-swagger-service-op-esb
+                  uri: lb://job-crontab
+                  predicates:
+                    - Path=/job-crontab/service/**,/job-crontab/op/**,/job-crontab/esb/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                - id: job-backup-swagger-service-op-esb
+                  uri: lb://job-backup
+                  predicates:
+                    - Path=/job-backup/service/**,/job-backup/op/**,/job-backup/esb/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                - id: job-file-gateway-swagger-service-op-esb
+                  uri: lb://job-file-gateway
+                  predicates:
+                    - Path=/job-file-gateway/service/**,/job-file-gateway/op/**,/job-file-gateway/esb/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                {{- end }}
+                {{- else if eq .Values.deploy.mode "lite" }}
+                - id: job-logout
+                  uri: lb://job-gateway
+                  predicates:
+                    - Path= /logout
+                  filters:
+                    - Logout
 
-            - id: job-esb
-              uri: lb://job-assemble
-              predicates:
-                - JobEsbV2Path=/api/job/v2/{module}/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v2/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
-    
-            - id: job-esb-v3
-              uri: lb://job-assemble
-              predicates:
-                - Path=/api/job/v3/{module}/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v3/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
+                - id: job-web
+                  uri: lb://job-assemble
+                  predicates:
+                    - Path= /job-manage/web/**,/job-crontab/web/**,/job-execute/web/**,/job-analysis/web/**,/job-backup/web/**,/job-logsvr/web/**,/job-file-gateway/web/**
+                  filters:
+                    - Authorize
+                    - CsrfCheck
+                    - StripPrefix=1
+                    - AddWebLangHeader
 
-            - id: job-esb-v4
-              uri: lb://job-assemble
-              predicates:
-                - Path=/api/job/v4/{module}/{api_name}
-              filters:
-                - CheckTenant
-                - CheckOpenApiJwt
-                - SetPath=/esb/api/v4/{api_name}
-                - RecordEsbAccessLog
-                - AddEsbLangHeader
-    
-            - id: job-iam
-              uri: lb://job-assemble
-              predicates:
-                - Path=/iam/api/v1/resources/**
-              filters:
-                - RecordIamAccessLog
-                - CheckTenant
-                - AddEsbLangHeader
-            {{- end }}      
+                - id: job-file-gateway-remote
+                  uri: lb://job-assemble
+                  predicates:
+                    - Path= /job-file-gateway/remote/**
+                  filters:
+                    - AuthorizeRemote
+                    - StripPrefix=1
+
+                - id: job-esb
+                  uri: lb://job-assemble
+                  predicates:
+                    - JobEsbV2Path=/api/job/v2/{module}/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v2/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
+
+                - id: job-esb-v3
+                  uri: lb://job-assemble
+                  predicates:
+                    - Path=/api/job/v3/{module}/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v3/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
+
+                - id: job-esb-v4
+                  uri: lb://job-assemble
+                  predicates:
+                    - Path=/api/job/v4/{module}/{api_name}
+                  filters:
+                    - CheckTenant
+                    - CheckOpenApiJwt
+                    - SetPath=/esb/api/v4/{api_name}
+                    - RecordEsbAccessLog
+                    - AddEsbLangHeader
+
+                - id: job-iam
+                  uri: lb://job-assemble
+                  predicates:
+                    - Path=/iam/api/v1/resources/**
+                  filters:
+                    - RecordIamAccessLog
+                    - CheckTenant
+                    - AddEsbLangHeader
+                {{- end }}
     job:
       gateway:
         login-exemption:


### PR DESCRIPTION
1. 核心依赖升级
- Spring Boot：`3.4.4 -> 3.5.14`
- Spring Cloud：`2024.0.1 -> 2025.0.2`
- Spring Cloud Kubernetes：`3.2.1 -> 3.3.2`
- SpringDoc、JUnit 等相关依赖同步升级
- `mysql-connector-j` 改由 Spring Boot BOM 管理

2. 升级后配置适配和兼容处理
- 调整各后端模块 `application.yml`
- 处理 Gateway、Actuator、SSL 等配置迁移
- 适配 Spring Cloud Kubernetes / OpenFeign / HttpClient 相关接口与废弃 API 变更
- JOOQ 生成脚本增加 `allowPublicKeyRetrieval=true`
- `job-logsvr` 测试用 embedded MongoDB 版本升级
- 清理 Logback 新版本告警
- 升级部分相关依赖：`logback`、`commons-lang3`、`kubernetes client`、`commons-beanutils`
- 排除 `commons-logging`，避免与 `spring-jcl` 冲突
- job-gateway访问日志没有management的日志，排除公共模块的web starter