### PR TITLE
fix: restore rewriteBatchedStatements=true in chart JDBC connection properties

### DIFF
--- a/support-files/kubernetes/charts/bk-job/VALUES_LOG.md
+++ b/support-files/kubernetes/charts/bk-job/VALUES_LOG.md
@@ -13,6 +13,29 @@ manageConfig:
     #    account: deploy
 ```
 
+2. JDBC 连接参数默认增加 `rewriteBatchedStatements=true`，恢复批量写入优化；涉及内置/外置 MariaDB、定时任务独立数据库及备份归档数据库配置
+```yaml
+mariadb:
+  connection:
+    properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true
+externalMariaDB:
+  connection:
+    properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true
+crontabConfig:
+  database:
+    connection:
+      properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true
+backupConfig:
+  archive:
+    mariadb:
+      connection:
+        properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true
+    execute:
+      mariadb:
+        connection:
+          properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true
+```
+
 ## 0.9.1
 1. 新增外部系统（GSE、CMDB、IAM、BK-Login、BK-User）重试配置，采用指数退避策略
 ```yaml

--- a/support-files/kubernetes/charts/bk-job/values.yaml
+++ b/support-files/kubernetes/charts/bk-job/values.yaml
@@ -129,7 +129,7 @@ mariadb:
       flush privileges;
   ## JDBC Connection properties
   connection:
-    properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
+    properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true
 
 ## External MariaDB configuration
 ##
@@ -157,7 +157,7 @@ externalMariaDB:
   rootPassword: ""
   ## JDBC Connection properties
   connection:
-    properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
+    properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true
   ## TLS相关配置
   tls:
     ## 是否开启tls认证
@@ -1602,7 +1602,7 @@ crontabConfig:
     host: ""
     port: 3306
     connection:
-      properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
+      properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true
     username: "job"
     password: ""
     maxPoolSize: 100
@@ -1717,7 +1717,7 @@ backupConfig:
       username: "job"
       password: ""
       connection:
-        properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
+        properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true
       ## TLS相关配置
       tls :
         ## 是否开启tls认证
@@ -1747,7 +1747,7 @@ backupConfig:
       # 被归档 DB 的配置
       mariadb:
         connection:
-          properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull
+          properties: ?useUnicode=true&characterEncoding=UTF-8&zeroDateTimeBehavior=convertToNull&rewriteBatchedStatements=true
         dataSourceMode: standalone
         # 垂直分片配置, 需要与 executeConfig 中保持一致
         # verticalSharding:


### PR DESCRIPTION
## Summary
The Helm chart's default JDBC connection properties dropped `rewriteBatchedStatements=true`, the MariaDB batch-insert optimization that PR #2177 originally added for execute-log writes. This restores the parameter in all five chart locations that build a JDBC URL: the bundled MariaDB defaults, `externalMariaDB`, `crontabConfig`, and both `backupConfig` data sources, and records the change in `VALUES_LOG.md` per the chart's convention.

## Why this matters
Issue #4371 reports slow task-log persistence on Kubernetes deployments. Without `rewriteBatchedStatements=true`, the MariaDB driver sends batched inserts one statement at a time, so the optimization the codebase relies on for step-instance log writes silently disappears for anyone deploying from the chart defaults. PR #2177 added the parameter to the application configs, but the chart's `values.yaml` never picked it up, so chart-based deployments regressed.

This PR covers the chart configuration half of the issue. The async-write half discussed in the issue is left to the maintainers since it involves an application-level design decision.

## Testing
Chart values parse and render with the updated properties in both the bundled-MariaDB and external-MariaDB paths (`helm template` over the default and external-DB scenarios).

Refs #4371
