### PR TITLE
perf: 升级网关资源同步使用的apigw-manager版本 #4396

### DIFF
--- a/support-files/kubernetes/charts/bk-job/templates/job-migration/sync-bkapigateway-job.yaml
+++ b/support-files/kubernetes/charts/bk-job/templates/job-migration/sync-bkapigateway-job.yaml
@@ -38,6 +38,8 @@ spec:
           value: {{ .Values.appCode }}
         - name: BK_APP_SECRET
           value: {{ .Values.appSecret }}
+        - name: BK_APP_TENANT_ID
+          value: {{ if .Values.tenant.enabled }}"system"{{ else }}"default"{{ end }}
         - name: BK_API_URL_TMPL
           value: {{ .Values.bkApiGatewayConfig.url }}
         - name: BK_JOB_STAGE_NAME

--- a/support-files/kubernetes/images/migration/bkApiGateway.Dockerfile
+++ b/support-files/kubernetes/images/migration/bkApiGateway.Dockerfile
@@ -1,4 +1,4 @@
-FROM hub.bktencent.com/blueking/apigw-manager:4.0.1
+FROM hub.bktencent.com/blueking/apigw-manager:4.2.4
 
 COPY bin /data/bin
 COPY apidocs /data/apidocs


### PR DESCRIPTION
1. bkApiGateway.Dockerfile 基础镜像 apigw-manager 由 4.0.1 升级至 4.2.4。 
2. sync-bkapigateway-job 按 tenant.enabled 注入 BK_APP_TENANT_ID（多租户 system / 单租户 default）。