### PR TITLE
perf: 接口get_job_plan_detail支持返回步骤启用状态 #4420

### DIFF
--- a/ai_agent/user/skills/bk-job/reference/apidocs/get_job_plan_detail.md
+++ b/ai_agent/user/skills/bk-job/reference/apidocs/get_job_plan_detail.md
@@ -96,6 +96,7 @@
                 "id": 1059,
                 "type": 1,
                 "name": "run local script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 1,
                     "script_timeout": 1000,
@@ -109,6 +110,7 @@
                 "id": 1060,
                 "type": 1,
                 "name": "run cite script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 2,
                     "script_id": "aaaaa-bbb-ccc-ddddd",
@@ -123,6 +125,7 @@
                 "id": 1061,
                 "type": 2,
                 "name": "xxx",
+                "enabled": 1,
                 "file_info": {
                     "file_source": [
                         {
@@ -224,10 +227,11 @@
 
 | 字段            | 类型     | 是否一定不为null | 描述                            |
 |---------------|--------|------------|-------------------------------|
-| id            | long   | 是          | 作业步骤ID                        |
-| name          | string | 是          | 作业步骤名称                        |
-| type          | int    | 是          | 步骤类型：1.脚本步骤; 2.文件步骤; 3.人工确认步骤 |
-| script_info   | object | 否          | 脚本信息。当 type=1 时才有这个字段。        |
+| id            | long    | 是          | 作业步骤ID                        |
+| name          | string  | 是          | 作业步骤名称                        |
+| type          | int     | 是          | 步骤类型：1.脚本步骤; 2.文件步骤; 3.人工确认步骤 |
+| enabled       | int     | 是          | 步骤是否启用。可选值: 0 - 未启用，1 - 启用 |
+| script_info   | object  | 否          | 脚本信息。当 type=1 时才有这个字段。        |
 | file_info     | object | 否          | 文件传输步骤信息。当 type=2 时才有这个字段     |
 | approval_info | object | 否          | 人工确认步骤步骤信息。当 type=3 时才有这个字段   |
 

--- a/docs/apidoc/bk-api-gateway/v3/zh/get_job_plan_detail.md
+++ b/docs/apidoc/bk-api-gateway/v3/zh/get_job_plan_detail.md
@@ -96,6 +96,7 @@
                 "id": 1059,
                 "type": 1,
                 "name": "run local script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 1,
                     "script_timeout": 1000,
@@ -109,6 +110,7 @@
                 "id": 1060,
                 "type": 1,
                 "name": "run cite script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 2,
                     "script_id": "aaaaa-bbb-ccc-ddddd",
@@ -123,6 +125,7 @@
                 "id": 1061,
                 "type": 2,
                 "name": "xxx",
+                "enabled": 1,
                 "file_info": {
                     "file_source": [
                         {
@@ -224,10 +227,11 @@
 
 | 字段            | 类型     | 是否一定不为null | 描述                            |
 |---------------|--------|------------|-------------------------------|
-| id            | long   | 是          | 作业步骤ID                        |
-| name          | string | 是          | 作业步骤名称                        |
-| type          | int    | 是          | 步骤类型：1.脚本步骤; 2.文件步骤; 3.人工确认步骤 |
-| script_info   | object | 否          | 脚本信息。当 type=1 时才有这个字段。        |
+| id            | long    | 是          | 作业步骤ID                        |
+| name          | string  | 是          | 作业步骤名称                        |
+| type          | int     | 是          | 步骤类型：1.脚本步骤; 2.文件步骤; 3.人工确认步骤 |
+| enabled       | int     | 是          | 步骤是否启用。可选值: 0 - 未启用，1 - 启用 |
+| script_info   | object  | 否          | 脚本信息。当 type=1 时才有这个字段。        |
 | file_info     | object | 否          | 文件传输步骤信息。当 type=2 时才有这个字段     |
 | approval_info | object | 否          | 人工确认步骤步骤信息。当 type=3 时才有这个字段   |
 

--- a/docs/apidoc/esb/jobv3-confapis/apidocs/en/get_job_plan_detail.md
+++ b/docs/apidoc/esb/jobv3-confapis/apidocs/en/get_job_plan_detail.md
@@ -92,6 +92,7 @@ Check Job Plan details by Job Plan ID
                 "id": 1059,
                 "type": 1,
                 "name": "run local script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 1,
                     "script_timeout": 1000,
@@ -105,6 +106,7 @@ Check Job Plan details by Job Plan ID
                 "id": 1060,
                 "type": 1,
                 "name": "run cite script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 2,
                     "script_id": "aaaaa-bbb-ccc-ddddd",
@@ -119,6 +121,7 @@ Check Job Plan details by Job Plan ID
                 "id": 1061,
                 "type": 2,
                 "name": "xxx",
+                "enabled": 1,
                 "file_info": {
                     "file_source": [
                         {
@@ -224,6 +227,7 @@ Check Job Plan details by Job Plan ID
 | id                 |  long      | Job step ID|
 | name               |  string    | Job step name|
 | type               |  int       | Step Type: 1. Script step; Manual confirmation step|
+| enabled            |  int       | Whether the step is enabled. Optional values: 0 - disabled, 1 - enabled|
 | script_info        |  object    | Script information. This field is only available when type=1. |
 | file_info          |  object    | File transfer step information. This field is only available when type=2|
 

--- a/docs/apidoc/esb/jobv3-confapis/apidocs/zh_hans/get_job_plan_detail.md
+++ b/docs/apidoc/esb/jobv3-confapis/apidocs/zh_hans/get_job_plan_detail.md
@@ -92,6 +92,7 @@
                 "id": 1059,
                 "type": 1,
                 "name": "run local script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 1,
                     "script_timeout": 1000,
@@ -105,6 +106,7 @@
                 "id": 1060,
                 "type": 1,
                 "name": "run cite script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 2,
                     "script_id": "aaaaa-bbb-ccc-ddddd",
@@ -119,6 +121,7 @@
                 "id": 1061,
                 "type": 2,
                 "name": "xxx",
+                "enabled": 1,
                 "file_info": {
                     "file_source": [
                         {
@@ -223,6 +226,7 @@
 | id                 | long      | 作业步骤ID |
 | name               | string    | 作业步骤名称 |
 | type               | int       | 步骤类型：1.脚本步骤; 2.文件步骤; 3.人工确认步骤 |
+| enabled            | int       | 步骤是否启用。可选值: 0 - 未启用，1 - 启用 |
 | script_info        | object    | 脚本信息。当 type=1 时才有这个字段。 |
 | file_info          | object    | 文件传输步骤信息。当 type=2 时才有这个字段 |
 

--- a/src/backend/commons/esb-sdk/src/main/java/com/tencent/bk/job/common/esb/model/job/v3/resp/EsbStepV3DTO.java
+++ b/src/backend/commons/esb-sdk/src/main/java/com/tencent/bk/job/common/esb/model/job/v3/resp/EsbStepV3DTO.java
@@ -42,6 +42,9 @@ public class EsbStepV3DTO {
     @JsonPropertyDescription("Step type")
     private Integer type;
 
+    @JsonPropertyDescription("Whether the step is enabled. 0-disabled, 1-enabled")
+    private Integer enabled;
+
     @JsonProperty("script_info")
     @JsonPropertyDescription("Script step info")
     private EsbScriptStepV3DTO scriptInfo;

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/model/dto/task/TaskStepDTO.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/model/dto/task/TaskStepDTO.java
@@ -156,6 +156,7 @@ public class TaskStepDTO {
         esbStep.setId(taskStep.getId());
         esbStep.setName(taskStep.getName());
         esbStep.setType(taskStep.getType().getValue());
+        esbStep.setEnabled(taskStep.getEnable());
         switch (taskStep.getType()) {
             case SCRIPT:
                 esbStep.setScriptInfo(TaskScriptStepDTO.toEsbScriptInfoV3(taskStep.getScriptStepInfo()));

--- a/src/backend/job-manage/service-job-manage/src/test/java/com/tencent/bk/job/manage/model/dto/task/TaskStepDTOTest.java
+++ b/src/backend/job-manage/service-job-manage/src/test/java/com/tencent/bk/job/manage/model/dto/task/TaskStepDTOTest.java
@@ -1,0 +1,65 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.model.dto.task;
+
+import com.tencent.bk.job.common.esb.model.job.v3.resp.EsbStepV3DTO;
+import com.tencent.bk.job.manage.api.common.constants.task.TaskStepTypeEnum;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TaskStepDTOTest {
+
+    private TaskStepDTO buildScriptStep(Integer enable) {
+        TaskStepDTO step = new TaskStepDTO();
+        step.setId(1L);
+        step.setName("step");
+        step.setType(TaskStepTypeEnum.SCRIPT);
+        step.setEnable(enable);
+        return step;
+    }
+
+    @Test
+    @DisplayName("步骤启用状态映射：enable=1 时 EsbStepV3DTO.enabled 为 1")
+    void toEsbStepV3WhenEnabled() {
+        EsbStepV3DTO esbStep = TaskStepDTO.toEsbStepV3(buildScriptStep(1));
+        assertThat(esbStep.getEnabled()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("步骤启用状态映射：enable=0 时 EsbStepV3DTO.enabled 为 0")
+    void toEsbStepV3WhenDisabled() {
+        EsbStepV3DTO esbStep = TaskStepDTO.toEsbStepV3(buildScriptStep(0));
+        assertThat(esbStep.getEnabled()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("步骤启用状态映射：enable 为 null 时 EsbStepV3DTO.enabled 为 null")
+    void toEsbStepV3WhenEnableNull() {
+        EsbStepV3DTO esbStep = TaskStepDTO.toEsbStepV3(buildScriptStep(null));
+        assertThat(esbStep.getEnabled()).isNull();
+    }
+}

--- a/support-files/bk-api-gateway/v3/apidocs/en/get_job_plan_detail.md.j2
+++ b/support-files/bk-api-gateway/v3/apidocs/en/get_job_plan_detail.md.j2
@@ -86,6 +86,7 @@ Check Job Plan details by Job Plan ID
                 "id": 1059,
                 "type": 1,
                 "name": "run local script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 1,
                     "script_timeout": 1000,
@@ -99,6 +100,7 @@ Check Job Plan details by Job Plan ID
                 "id": 1060,
                 "type": 1,
                 "name": "run cite script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 2,
                     "script_id": "aaaaa-bbb-ccc-ddddd",
@@ -113,6 +115,7 @@ Check Job Plan details by Job Plan ID
                 "id": 1061,
                 "type": 2,
                 "name": "xxx",
+                "enabled": 1,
                 "file_info": {
                     "file_source": [
                         {
@@ -207,10 +210,11 @@ Check Job Plan details by Job Plan ID
 
 | Fields      | Type   | Never null | Description                                                              |
 |-------------|--------|------------|--------------------------------------------------------------------------|
-| id          | long   | yes        | Job step ID                                                              |
-| name        | string | yes        | Job step name                                                            |
-| type        | int    | yes        | Step Type: 1. Script step; Manual confirmation step                      |
-| script_info | object | no         | Script information. This field is only available when type=1.            |
+| id          | long    | yes        | Job step ID                                                              |
+| name        | string  | yes        | Job step name                                                            |
+| type        | int     | yes        | Step Type: 1. Script step; Manual confirmation step                      |
+| enabled     | int     | yes        | Whether the step is enabled. Optional values: 0 - disabled, 1 - enabled |
+| script_info | object  | no         | Script information. This field is only available when type=1.            |
 | file_info   | object | no         | File transfer step information. This field is only available when type=2 |
 
 #### script_info

--- a/support-files/bk-api-gateway/v3/apidocs/en/system_get_job_plan_detail.md.j2
+++ b/support-files/bk-api-gateway/v3/apidocs/en/system_get_job_plan_detail.md.j2
@@ -86,6 +86,7 @@ Check Job Plan details by Job Plan ID
                 "id": 1059,
                 "type": 1,
                 "name": "run local script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 1,
                     "script_timeout": 1000,
@@ -99,6 +100,7 @@ Check Job Plan details by Job Plan ID
                 "id": 1060,
                 "type": 1,
                 "name": "run cite script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 2,
                     "script_id": "aaaaa-bbb-ccc-ddddd",
@@ -113,6 +115,7 @@ Check Job Plan details by Job Plan ID
                 "id": 1061,
                 "type": 2,
                 "name": "xxx",
+                "enabled": 1,
                 "file_info": {
                     "file_source": [
                         {
@@ -207,10 +210,11 @@ Check Job Plan details by Job Plan ID
 
 | Fields      | Type   | Never null | Description                                                              |
 |-------------|--------|------------|--------------------------------------------------------------------------|
-| id          | long   | yes        | Job step ID                                                              |
-| name        | string | yes        | Job step name                                                            |
-| type        | int    | yes        | Step Type: 1. Script step; Manual confirmation step                      |
-| script_info | object | no         | Script information. This field is only available when type=1.            |
+| id          | long    | yes        | Job step ID                                                              |
+| name        | string  | yes        | Job step name                                                            |
+| type        | int     | yes        | Step Type: 1. Script step; Manual confirmation step                      |
+| enabled     | int     | yes        | Whether the step is enabled. Optional values: 0 - disabled, 1 - enabled |
+| script_info | object  | no         | Script information. This field is only available when type=1.            |
 | file_info   | object | no         | File transfer step information. This field is only available when type=2 |
 
 #### script_info

--- a/support-files/bk-api-gateway/v3/apidocs/zh/get_job_plan_detail.md.j2
+++ b/support-files/bk-api-gateway/v3/apidocs/zh/get_job_plan_detail.md.j2
@@ -86,6 +86,7 @@
                 "id": 1059,
                 "type": 1,
                 "name": "run local script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 1,
                     "script_timeout": 1000,
@@ -99,6 +100,7 @@
                 "id": 1060,
                 "type": 1,
                 "name": "run cite script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 2,
                     "script_id": "aaaaa-bbb-ccc-ddddd",
@@ -113,6 +115,7 @@
                 "id": 1061,
                 "type": 2,
                 "name": "xxx",
+                "enabled": 1,
                 "file_info": {
                     "file_source": [
                         {
@@ -207,10 +210,11 @@
 
 | 字段            | 类型     | 是否一定不为null | 描述                            |
 |---------------|--------|------------|-------------------------------|
-| id            | long   | 是          | 作业步骤ID                        |
-| name          | string | 是          | 作业步骤名称                        |
-| type          | int    | 是          | 步骤类型：1.脚本步骤; 2.文件步骤; 3.人工确认步骤 |
-| script_info   | object | 否          | 脚本信息。当 type=1 时才有这个字段。        |
+| id            | long    | 是          | 作业步骤ID                        |
+| name          | string  | 是          | 作业步骤名称                        |
+| type          | int     | 是          | 步骤类型：1.脚本步骤; 2.文件步骤; 3.人工确认步骤 |
+| enabled       | int     | 是          | 步骤是否启用。可选值: 0 - 未启用，1 - 启用 |
+| script_info   | object  | 否          | 脚本信息。当 type=1 时才有这个字段。        |
 | file_info     | object | 否          | 文件传输步骤信息。当 type=2 时才有这个字段     |
 | approval_info | object | 否          | 人工确认步骤步骤信息。当 type=3 时才有这个字段   |
 

--- a/support-files/bk-api-gateway/v3/apidocs/zh/system_get_job_plan_detail.md.j2
+++ b/support-files/bk-api-gateway/v3/apidocs/zh/system_get_job_plan_detail.md.j2
@@ -86,6 +86,7 @@
                 "id": 1059,
                 "type": 1,
                 "name": "run local script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 1,
                     "script_timeout": 1000,
@@ -99,6 +100,7 @@
                 "id": 1060,
                 "type": 1,
                 "name": "run cite script",
+                "enabled": 1,
                 "script_info": {
                     "script_type": 2,
                     "script_id": "aaaaa-bbb-ccc-ddddd",
@@ -113,6 +115,7 @@
                 "id": 1061,
                 "type": 2,
                 "name": "xxx",
+                "enabled": 1,
                 "file_info": {
                     "file_source": [
                         {
@@ -207,10 +210,11 @@
 
 | 字段            | 类型     | 是否一定不为null | 描述                            |
 |---------------|--------|------------|-------------------------------|
-| id            | long   | 是          | 作业步骤ID                        |
-| name          | string | 是          | 作业步骤名称                        |
-| type          | int    | 是          | 步骤类型：1.脚本步骤; 2.文件步骤; 3.人工确认步骤 |
-| script_info   | object | 否          | 脚本信息。当 type=1 时才有这个字段。        |
+| id            | long    | 是          | 作业步骤ID                        |
+| name          | string  | 是          | 作业步骤名称                        |
+| type          | int     | 是          | 步骤类型：1.脚本步骤; 2.文件步骤; 3.人工确认步骤 |
+| enabled       | int     | 是          | 步骤是否启用。可选值: 0 - 未启用，1 - 启用 |
+| script_info   | object  | 否          | 脚本信息。当 type=1 时才有这个字段。        |
 | file_info     | object | 否          | 文件传输步骤信息。当 type=2 时才有这个字段     |
 | approval_info | object | 否          | 人工确认步骤步骤信息。当 type=3 时才有这个字段   |
 

--- a/support-files/bk-api-gateway/v3/resources.yaml
+++ b/support-files/bk-api-gateway/v3/resources.yaml
@@ -1525,6 +1525,9 @@ paths:
                               name:
                                 type: string
                                 description: 作业步骤名称
+                              enabled:
+                                type: integer
+                                description: '步骤是否启用。可选值: 0 - 未启用，1 - 启用'
                             description: 单个步骤信息
                         description: 步骤列表
                       bk_scope_id:

--- a/tests/openapi/src/test/java/com/tencent/bk/job/api/v3/model/EsbStepV3DTO.java
+++ b/tests/openapi/src/test/java/com/tencent/bk/job/api/v3/model/EsbStepV3DTO.java
@@ -37,6 +37,8 @@ public class EsbStepV3DTO {
 
     private Integer type;
 
+    private Integer enabled;
+
     @JsonProperty("script_info")
     private EsbScriptStepV3DTO scriptInfo;
 


### PR DESCRIPTION
1.EsbStepV3DTO 新增 enabled 字段（Integer），表示步骤启用状态（0-未启用，1-启用）。 
2.TaskStepDTO.toEsbStepV3 直接按领域模型整型启用状态填充（enable 为 null 时透传 null，不设默认值），get_job_plan_detail 与 get_job_template_detail 共用此转换均返回该字段。 
3.同步更新权威契约 apidocs（zh/en 及 system 变体）与 resources.yaml，并同步历史文档镜像（docs/apidoc 下 bk-api-gateway 与 esb confapis 的 zh/en，及 ai_agent 技能 reference 副本）。 
4.更新 openapi 测试模型与 TaskStepDTOTest（覆盖 1/0/null 三种映射）。