### PR TITLE
perf: 分发已过期本地文件日志优化 #4409

### DIFF
--- a/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/exception/ArtifactoryExceptionConverter.java
+++ b/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/exception/ArtifactoryExceptionConverter.java
@@ -29,39 +29,41 @@ import com.tencent.bk.job.common.artifactory.constants.ArtifactoryInterfaceConst
 import com.tencent.bk.job.common.artifactory.model.dto.ArtifactoryResp;
 import com.tencent.bk.job.common.constant.ErrorCode;
 import com.tencent.bk.job.common.exception.HttpStatusException;
+import com.tencent.bk.job.common.exception.ServiceException;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 
 /**
- * 制品库接口异常转换器
+ * 制品库接口异常转换器：把 bkrepo 的 HTTP 状态 / 业务错误码统一翻译成类型化异常。
+ * 这里是「业务错误码 -> 异常类型」映射的唯一维护点，调用方应基于返回的异常类型做后续判定。
  */
 public class ArtifactoryExceptionConverter {
 
     /**
-     * 将Http状态等异常转换为ArtifactoryException
+     * 将Http状态等异常转换为类型化的制品库异常。
+     * 只负责构造异常并返回、不抛出，由调用方决定抛出时机。
      *
-     * @param e   原始异常
-     * @param <R> 返回数据类型
-     * @return 转换后的异常
+     * @param e 原始异常
+     * @return 转换后的类型化异常
      */
-    public static <R> R convertException(Exception e) {
+    public static ServiceException convertException(Exception e) {
         if (e instanceof HttpStatusException) {
             HttpStatusException httpStatusException = (HttpStatusException) e;
             int httpStatus = httpStatusException.getHttpStatus();
             // bkrepo 返回 401 表示凭证无效（如用户名/密码或访问令牌错误），
             // 引导用户检查文件源凭证配置；原始 bkrepo 报错信息保留在 cause 中可在日志中查看
             if (httpStatus == HTTP_STATUS_UNAUTHORIZED) {
-                throw new ArtifactoryAuthFailException(e);
+                return new ArtifactoryAuthFailException(e);
             }
             String httpStatusExceptionRespStr = httpStatusException.getRespBodyStr();
             ArtifactoryResp<Object> artifactoryResp = JsonUtils.fromJson(httpStatusExceptionRespStr,
                 new TypeReference<ArtifactoryResp<Object>>() {
                 });
             if (artifactoryResp == null) {
-                // 响应体中没有详细的报错信息，抛出粗粒度接口访问异常
-                throw new ArtifactoryException(e);
+                // 响应体中没有详细的报错信息，返回粗粒度接口访问异常
+                return new ArtifactoryException(e);
             }
             if (artifactoryResp.getCode() == ArtifactoryInterfaceConsts.RESULT_CODE_NODE_NOT_FOUND) {
-                throw new NodeNotFoundException(
+                return new NodeNotFoundException(
                     e,
                     ErrorCode.CAN_NOT_FIND_NODE_IN_ARTIFACTORY,
                     new String[]{
@@ -69,18 +71,18 @@ public class ArtifactoryExceptionConverter {
                     }
                 );
             } else if (artifactoryResp.getCode() == ArtifactoryInterfaceConsts.RESULT_CODE_PROJECT_EXISTED) {
-                // 项目不存在
-                throw new ProjectExistedException(e);
+                // 项目已存在
+                return new ProjectExistedException(e);
             } else if (artifactoryResp.getCode() == ArtifactoryInterfaceConsts.RESULT_CODE_REPO_NOT_FOUND) {
                 // 仓库不存在
-                throw new RepoNotFoundException(e);
+                return new RepoNotFoundException(e);
             } else {
                 // 暂未识别的异常
-                throw new ArtifactoryException(e);
+                return new ArtifactoryException(e);
             }
         } else {
-            // 未收到正常的HTTP响应，抛出粗粒度接口访问异常
-            throw new ArtifactoryException(e);
+            // 未收到正常的HTTP响应，返回粗粒度接口访问异常
+            return new ArtifactoryException(e);
         }
     }
 

--- a/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
+++ b/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.tencent.bk.job.common.artifactory.constants.ArtifactoryInterfaceConsts;
 import com.tencent.bk.job.common.artifactory.constants.MetricsConstants;
 import com.tencent.bk.job.common.artifactory.exception.ArtifactoryExceptionConverter;
+import com.tencent.bk.job.common.artifactory.exception.NodeNotFoundException;
 import com.tencent.bk.job.common.artifactory.model.dto.ArtifactoryResp;
 import com.tencent.bk.job.common.artifactory.model.dto.NodeDTO;
 import com.tencent.bk.job.common.artifactory.model.dto.PageData;
@@ -55,7 +56,6 @@ import com.tencent.bk.job.common.artifactory.model.req.UploadGenericFileReq;
 import com.tencent.bk.job.common.constant.ErrorCode;
 import com.tencent.bk.job.common.constant.HttpMethodEnum;
 import com.tencent.bk.job.common.constant.JobCommonHeaders;
-import com.tencent.bk.job.common.exception.HttpStatusException;
 import com.tencent.bk.job.common.exception.InternalException;
 import com.tencent.bk.job.common.exception.NotImplementedException;
 import com.tencent.bk.job.common.exception.ServiceException;
@@ -357,9 +357,11 @@ public class ArtifactoryClient {
             statusRef.set(MetricsConstants.TAG_VALUE_OK);
             return result;
         } catch (Exception e) {
-            // 命中「可容忍」的业务错误(如节点不存在)时走旁路：按 INFO 记录、不打印堆栈，避免告警误告；
-            // 其它异常按原有级别 + 堆栈打印
-            TolerableArtifactoryError tolerableError = resolveTolerableError(e);
+            // 先由 converter 把原始异常翻译成类型化异常，再据其类型判定是否可容忍：
+            // 命中「可容忍」的业务错误(如节点不存在)时走旁路，按 INFO 记录、不打印堆栈，避免告警误告；
+            // 其它异常按原有级别 + 堆栈打印。
+            ServiceException serviceException = ArtifactoryExceptionConverter.convertException(e);
+            TolerableArtifactoryError tolerableError = TolerableArtifactoryError.resolve(serviceException);
             if (tolerableError != null) {
                 handleTolerableError(tolerableError, method, url, reqStr, statusRef);
             } else {
@@ -374,7 +376,7 @@ public class ArtifactoryClient {
                 log.log(errorLogLevel, msg, e);
                 statusRef.set(MetricsConstants.TAG_VALUE_ERROR);
             }
-            return ArtifactoryExceptionConverter.convertException(e);
+            throw serviceException;
         } finally {
             HttpMetricUtil.clearHttpMetric();
             long end = System.nanoTime();
@@ -398,30 +400,6 @@ public class ArtifactoryClient {
     }
 
     /**
-     * 从异常中解析出命中的「可容忍」制品库业务错误；未命中(需按正常错误处理)时返回 null。
-     * bkrepo 会以 HTTP 4xx + 响应体业务码的形式返回错误，需解析响应体才能识别。
-     */
-    private TolerableArtifactoryError resolveTolerableError(Exception e) {
-        if (!(e instanceof HttpStatusException)) {
-            return null;
-        }
-        String respBodyStr = ((HttpStatusException) e).getRespBodyStr();
-        if (StringUtils.isBlank(respBodyStr)) {
-            return null;
-        }
-        try {
-            ArtifactoryResp<Object> resp = JsonUtils.fromJson(
-                respBodyStr,
-                new TypeReference<ArtifactoryResp<Object>>() {
-                }
-            );
-            return resp == null ? null : TolerableArtifactoryError.valueOfCode(resp.getCode());
-        } catch (Exception parseException) {
-            return null;
-        }
-    }
-
-    /**
      * 可容忍错误的旁路处理：按 INFO 记录且不打印堆栈，避免可预期的正常场景造成告警误告。
      */
     private void handleTolerableError(TolerableArtifactoryError tolerableError,
@@ -440,22 +418,26 @@ public class ArtifactoryClient {
     }
 
     /**
-     * 制品库「可容忍」的业务错误码登记表：这些错误属于可预期的正常场景(如节点不存在)，
-     * 命中后按 INFO 记录而非 ERROR。后续若有其它可容忍错误码，只需在此新增一项，无需改动主流程。
+     * 制品库「可容忍」的业务错误登记表：命中的异常属于可预期的正常场景(如节点不存在)，
+     * 命中后按 INFO 记录而非 ERROR。判定源是 {@link ArtifactoryExceptionConverter} 转换出的类型化异常——
+     * 「业务错误码 -> 异常类型」的映射只在 converter 维护一处，这里只登记「哪些异常类型可容忍」，
+     * 后续新增可容忍场景无需在两处改动错误码。
      */
     private enum TolerableArtifactoryError {
         NODE_NOT_FOUND(
-            ArtifactoryInterfaceConsts.RESULT_CODE_NODE_NOT_FOUND,
+            NodeNotFoundException.class,
             MetricsConstants.TAG_VALUE_CLIENT_ERROR_NODE_NOT_FOUND,
             "Node not found in artifactory"
         );
 
-        private final int code;
+        private final Class<? extends ServiceException> exceptionClass;
         private final String metricTagValue;
         private final String logMessage;
 
-        TolerableArtifactoryError(int code, String metricTagValue, String logMessage) {
-            this.code = code;
+        TolerableArtifactoryError(Class<? extends ServiceException> exceptionClass,
+                                  String metricTagValue,
+                                  String logMessage) {
+            this.exceptionClass = exceptionClass;
             this.metricTagValue = metricTagValue;
             this.logMessage = logMessage;
         }
@@ -468,9 +450,12 @@ public class ArtifactoryClient {
             return logMessage;
         }
 
-        static TolerableArtifactoryError valueOfCode(int code) {
+        /**
+         * 找出与给定异常匹配的可容忍错误；不可容忍时返回 null。
+         */
+        static TolerableArtifactoryError resolve(ServiceException e) {
             for (TolerableArtifactoryError error : values()) {
-                if (error.code == code) {
+                if (error.exceptionClass.isInstance(e)) {
                     return error;
                 }
             }
@@ -861,29 +846,5 @@ public class ArtifactoryClient {
 
     private String getSimplifiedStrForLog(String rawStr) {
         return StringUtil.substring(rawStr, 20000);
-    }
-
-    private <R> R convertException(AtomicReference<String> statusRef, Exception e) {
-        if (e instanceof HttpStatusException) {
-            String httpStatusExceptionRespStr = ((HttpStatusException) e).getRespBodyStr();
-            ArtifactoryResp<Object> artifactoryResp = JsonUtils.fromJson(httpStatusExceptionRespStr,
-                new TypeReference<ArtifactoryResp<Object>>() {
-                });
-            if (artifactoryResp != null
-                && artifactoryResp.getCode() == ArtifactoryInterfaceConsts.RESULT_CODE_NODE_NOT_FOUND) {
-                statusRef.set(MetricsConstants.TAG_VALUE_CLIENT_ERROR_NODE_NOT_FOUND);
-                throw new InternalException(
-                    artifactoryResp.getMessage(),
-                    ErrorCode.CAN_NOT_FIND_NODE_IN_ARTIFACTORY
-                );
-            } else {
-                throw new InternalException(
-                    "Fail to request ARTIFACTORY data",
-                    ErrorCode.ARTIFACTORY_API_DATA_ERROR
-                );
-            }
-        } else {
-            throw new InternalException("Fail to request ARTIFACTORY data", ErrorCode.ARTIFACTORY_API_DATA_ERROR);
-        }
     }
 }

--- a/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
+++ b/src/backend/commons/artifactory-sdk/src/main/java/com/tencent/bk/job/common/artifactory/sdk/ArtifactoryClient.java
@@ -357,16 +357,23 @@ public class ArtifactoryClient {
             statusRef.set(MetricsConstants.TAG_VALUE_OK);
             return result;
         } catch (Exception e) {
-            String msg = MessageFormatter.arrayFormat(
-                "Fail to request ARTIFACTORY data|method={}|url={}|reqStr={}",
-                new String[]{
-                    method,
-                    url,
-                    reqStr
-                }
-            ).getMessage();
-            log.log(errorLogLevel, msg, e);
-            statusRef.set(MetricsConstants.TAG_VALUE_ERROR);
+            // 命中「可容忍」的业务错误(如节点不存在)时走旁路：按 INFO 记录、不打印堆栈，避免告警误告；
+            // 其它异常按原有级别 + 堆栈打印
+            TolerableArtifactoryError tolerableError = resolveTolerableError(e);
+            if (tolerableError != null) {
+                handleTolerableError(tolerableError, method, url, reqStr, statusRef);
+            } else {
+                String msg = MessageFormatter.arrayFormat(
+                    "Fail to request ARTIFACTORY data|method={}|url={}|reqStr={}",
+                    new String[]{
+                        method,
+                        url,
+                        reqStr
+                    }
+                ).getMessage();
+                log.log(errorLogLevel, msg, e);
+                statusRef.set(MetricsConstants.TAG_VALUE_ERROR);
+            }
             return ArtifactoryExceptionConverter.convertException(e);
         } finally {
             HttpMetricUtil.clearHttpMetric();
@@ -388,6 +395,87 @@ public class ArtifactoryClient {
             headerList.add(new BasicHeader(JobCommonHeaders.BK_TENANT_ID, tenantId));
         }
         return headerList;
+    }
+
+    /**
+     * 从异常中解析出命中的「可容忍」制品库业务错误；未命中(需按正常错误处理)时返回 null。
+     * bkrepo 会以 HTTP 4xx + 响应体业务码的形式返回错误，需解析响应体才能识别。
+     */
+    private TolerableArtifactoryError resolveTolerableError(Exception e) {
+        if (!(e instanceof HttpStatusException)) {
+            return null;
+        }
+        String respBodyStr = ((HttpStatusException) e).getRespBodyStr();
+        if (StringUtils.isBlank(respBodyStr)) {
+            return null;
+        }
+        try {
+            ArtifactoryResp<Object> resp = JsonUtils.fromJson(
+                respBodyStr,
+                new TypeReference<ArtifactoryResp<Object>>() {
+                }
+            );
+            return resp == null ? null : TolerableArtifactoryError.valueOfCode(resp.getCode());
+        } catch (Exception parseException) {
+            return null;
+        }
+    }
+
+    /**
+     * 可容忍错误的旁路处理：按 INFO 记录且不打印堆栈，避免可预期的正常场景造成告警误告。
+     */
+    private void handleTolerableError(TolerableArtifactoryError tolerableError,
+                                      String method,
+                                      String url,
+                                      String reqStr,
+                                      AtomicReference<String> statusRef) {
+        log.info(
+            "{}|method={}|url={}|reqStr={}",
+            tolerableError.getLogMessage(),
+            method,
+            url,
+            getSimplifiedStrForLog(reqStr)
+        );
+        statusRef.set(tolerableError.getMetricTagValue());
+    }
+
+    /**
+     * 制品库「可容忍」的业务错误码登记表：这些错误属于可预期的正常场景(如节点不存在)，
+     * 命中后按 INFO 记录而非 ERROR。后续若有其它可容忍错误码，只需在此新增一项，无需改动主流程。
+     */
+    private enum TolerableArtifactoryError {
+        NODE_NOT_FOUND(
+            ArtifactoryInterfaceConsts.RESULT_CODE_NODE_NOT_FOUND,
+            MetricsConstants.TAG_VALUE_CLIENT_ERROR_NODE_NOT_FOUND,
+            "Node not found in artifactory"
+        );
+
+        private final int code;
+        private final String metricTagValue;
+        private final String logMessage;
+
+        TolerableArtifactoryError(int code, String metricTagValue, String logMessage) {
+            this.code = code;
+            this.metricTagValue = metricTagValue;
+            this.logMessage = logMessage;
+        }
+
+        String getMetricTagValue() {
+            return metricTagValue;
+        }
+
+        String getLogMessage() {
+            return logMessage;
+        }
+
+        static TolerableArtifactoryError valueOfCode(int code) {
+            for (TolerableArtifactoryError error : values()) {
+                if (error.code == code) {
+                    return error;
+                }
+            }
+            return null;
+        }
     }
 
     public boolean isAvailable() {

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/ArtifactoryLocalFileService.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/ArtifactoryLocalFileService.java
@@ -5,6 +5,7 @@ import com.tencent.bk.job.common.artifactory.sdk.ArtifactoryClient;
 import com.tencent.bk.job.common.artifactory.sdk.ArtifactoryHelper;
 import com.tencent.bk.job.common.constant.ErrorCode;
 import com.tencent.bk.job.common.exception.InternalException;
+import com.tencent.bk.job.common.exception.NotFoundException;
 import com.tencent.bk.job.common.util.file.PathUtil;
 import com.tencent.bk.job.execute.config.LocalFileConfigForExecute;
 import com.tencent.bk.job.execute.model.FileDetailDTO;
@@ -39,7 +40,7 @@ public class ArtifactoryLocalFileService {
         NodeDTO nodeDTO = getFileNodeAndHandleException(filePath);
         log.debug("nodeDTO={}", nodeDTO);
         if (nodeDTO == null) {
-            throw new InternalException(
+            throw new NotFoundException(
                 "local file not found in artifactory",
                 ErrorCode.LOCAL_FILE_NOT_EXIST_IN_BACKEND,
                 new String[]{filePath, String.valueOf(localFileConfig.getExpireDays())}
@@ -63,8 +64,9 @@ public class ArtifactoryLocalFileService {
             nodeDTO = artifactoryClient.getFileNode(fullPath);
         } catch (InternalException e) {
             if (e.getErrorCode() == ErrorCode.CAN_NOT_FIND_NODE_IN_ARTIFACTORY) {
-                log.error("[TransferLocalFile] transfer fail, local file {} not in artifactory", filePath);
-                throw new InternalException(
+                // 本地文件在制品库中不存在（通常是已过期被清理），属于可预期的业务场景，记录 INFO 即可
+                log.info("[TransferLocalFile] transfer fail, local file {} not in artifactory", filePath);
+                throw new NotFoundException(
                     "local file not found in artifactory",
                     ErrorCode.LOCAL_FILE_NOT_EXIST_IN_BACKEND,
                     new String[]{filePath, String.valueOf(localFileConfig.getExpireDays())}


### PR DESCRIPTION
本次只在制品库客户端（ArtifactoryClient）做「错误容忍」判定，不改通用 HTTP 层（BaseHttpHelper）。

- 容忍判定属业务语义，不该下沉：可容忍的场景是 HTTP 400 且响应体业务码 code=251010(节点不存在)，判断它要解析 bkrepo 响应体。BaseHttpHelper 是所有下游共用的通用客户端，只知道「状态码≥400」，不该理解某个下游的业务码。
- 放上层更精确：只对 code=251010 容忍，其余 400/异常仍按 ERROR+堆栈打印，不会误吞真实错误。
- 主要噪音已消除：造成误告的 3 条带堆栈 ERROR 已全部降为 INFO；仅剩 HTTP 层一条 WARN——它是「请求返回 400」的客观记录，级别低、无堆栈、噪音小。为消这一条去改 BaseHttpHelper 会波及所有 HTTP 调用方，风险远大于收益，故保留；如后续告警策略有需要，可另行为 HTTP 层引入不含业务语义的通用开关，不在本次范围内。