### PR TITLE
fix: 使用多个集群外Agent作为文件分发源时上传源日志查询报错 #4494

### DIFF
--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/third/ThirdFilePrepareTask.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/engine/prepare/third/ThirdFilePrepareTask.java
@@ -25,6 +25,7 @@
 package com.tencent.bk.job.execute.engine.prepare.third;
 
 import com.tencent.bk.job.common.constant.ErrorCode;
+import com.tencent.bk.job.common.exception.DistributeFileFromExternalAgentException;
 import com.tencent.bk.job.common.exception.InternalException;
 import com.tencent.bk.job.common.model.InternalResponse;
 import com.tencent.bk.job.common.model.dto.HostDTO;
@@ -386,11 +387,7 @@ public class ThirdFilePrepareTask implements ContinuousScheduledTask, JobTaskCon
             fileSourceTaskStatusDTO.getIp()
         );
         ExecuteTargetDTO executeTargetDTO = new ExecuteTargetDTO();
-        HostDTO hostDTO = thirdFileDistributeSourceHostProvisioner.getThirdFileDistributeSourceHost(
-            fileSourceTaskStatusDTO.getCloudId(),
-            fileSourceTaskStatusDTO.getIpProtocol(),
-            fileSourceTaskStatusDTO.getIp()
-        );
+        HostDTO hostDTO = resolveDistributeSourceHost(fileSourceTaskStatusDTO);
         if (hostDTO == null) {
             log.error(
                 "[{}]: Cannot find file-worker host info by IP{} (cloudAreaId={}, ip={}), " +
@@ -442,12 +439,8 @@ public class ThirdFilePrepareTask implements ContinuousScheduledTask, JobTaskCon
                            FileSourceTaskStatusDTO fileSourceTaskStatusDTO,
                            List<ThirdFileSourceTaskLogDTO> logDTOList) {
         List<ServiceExecuteObjectLogDTO> serviceExecuteObjectLogDTOList = new ArrayList<>();
+        HostDTO host = resolveDistributeSourceHost(fileSourceTaskStatusDTO);
         for (ThirdFileSourceTaskLogDTO logDTO : logDTOList) {
-            HostDTO host = thirdFileDistributeSourceHostProvisioner.getThirdFileDistributeSourceHost(
-                fileSourceTaskStatusDTO.getCloudId(),
-                fileSourceTaskStatusDTO.getIpProtocol(),
-                fileSourceTaskStatusDTO.getIp()
-            );
             serviceExecuteObjectLogDTOList.add(buildServiceHostLogDTO(host, logDTO));
         }
         logService.writeFileLogsWithTimestamp(
@@ -455,6 +448,38 @@ public class ThirdFilePrepareTask implements ContinuousScheduledTask, JobTaskCon
             serviceExecuteObjectLogDTOList,
             System.currentTimeMillis()
         );
+    }
+
+    private HostDTO resolveDistributeSourceHost(FileSourceTaskStatusDTO fileSourceTaskStatusDTO) {
+        if (thirdFileDistributeSourceHostProvisioner.shouldReuseSelectedSourceHost()) {
+            String fileSourceTaskId = fileSourceTaskStatusDTO.getTaskId();
+            HostDTO selectedSourceHost = findSelectedSourceHost(fileSourceTaskId);
+            if (selectedSourceHost != null) {
+                return selectedSourceHost;
+            }
+            String message = "Selected external agent source host not found, stepInstanceId=" +
+                stepInstance.getId() + ", fileSourceTaskId=" + fileSourceTaskId;
+            throw new DistributeFileFromExternalAgentException(message, ErrorCode.INTERNAL_ERROR);
+        }
+        return thirdFileDistributeSourceHostProvisioner.getThirdFileDistributeSourceHost(
+            fileSourceTaskStatusDTO.getCloudId(),
+            fileSourceTaskStatusDTO.getIpProtocol(),
+            fileSourceTaskStatusDTO.getIp()
+        );
+    }
+
+    private HostDTO findSelectedSourceHost(String fileSourceTaskId) {
+        for (FileSourceDTO fileSourceDTO : fileSourceList) {
+            if (fileSourceDTO == null || !StringUtils.equals(fileSourceTaskId, fileSourceDTO.getFileSourceTaskId())) {
+                continue;
+            }
+            ExecuteTargetDTO servers = fileSourceDTO.getServers();
+            if (servers != null && CollectionUtils.isNotEmpty(servers.getStaticIpList())) {
+                return servers.getStaticIpList().get(0);
+            }
+            break;
+        }
+        return null;
     }
 
     /**

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/ThirdFileDistributeSourceHostProvisioner.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/ThirdFileDistributeSourceHostProvisioner.java
@@ -32,6 +32,13 @@ import com.tencent.bk.job.common.model.dto.HostDTO;
 public interface ThirdFileDistributeSourceHostProvisioner {
 
     /**
+     * 文件准备任务启动时选定的源主机是否应在后续流程中保持不变
+     */
+    default boolean shouldReuseSelectedSourceHost() {
+        return false;
+    }
+
+    /**
      * @return job-file-worker信息 或者 集群外的机器信息
      */
     HostDTO getThirdFileDistributeSourceHost(Long cloudId, String protocol, String ip);

--- a/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/ThirdFileExternalAgentHostProvisioner.java
+++ b/src/backend/job-execute/service-job-execute/src/main/java/com/tencent/bk/job/execute/service/impl/ThirdFileExternalAgentHostProvisioner.java
@@ -42,6 +42,11 @@ public class ThirdFileExternalAgentHostProvisioner implements ThirdFileDistribut
     }
 
     @Override
+    public boolean shouldReuseSelectedSourceHost() {
+        return true;
+    }
+
+    @Override
     public HostDTO getThirdFileDistributeSourceHost(Long cloudId, String protocol, String ip) {
         log.debug("distribute third file from external agent host");
         return externalAgentService.getDistributeSourceHost();


### PR DESCRIPTION
原因：
配置多个集群外 Agent 作为文件分发源时，第三方文件准备链路在不同阶段会重复执行选源，这些阶段可能处于不同线程上下文，无法保证每次都基于相同的 requestId 选中同一台 Agent，导致数据库中保存的文件源主机与上传日志关联的源主机不一致。通过 /fileLog 接口查询日志时无法匹配对应的源执行对象，最终返回内部服务异常。

方案：
外部 Agent 模式下，通过 fileSourceTaskId 找到首次选定的源主机，后续逻辑也是复用该源主机