### PR TITLE
fix: 运营分析英文状态下标签仪表盘还是中文 #4408

### DIFF
--- a/src/backend/commons/common-i18n/src/main/resources/i18n/common/message.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/common/message.properties
@@ -115,3 +115,10 @@ resource.host.name=主机
 resource.dynamic_group.name=动态分组
 resource.biz_set.name=业务集
 resource.container.name=容器
+
+common.public.tag.continuousIntegration=持续集成
+common.public.tag.testing=测试专用
+common.public.tag.commonTools=常用工具
+common.public.tag.releaseDeployment=发布部署
+common.public.tag.troubleshooting=故障处理
+common.public.tag.opsRelease=运营发布

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/common/message_en.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/common/message_en.properties
@@ -116,3 +116,10 @@ resource.host.name=host
 resource.dynamic_group.name=group
 resource.biz_set.name=business set
 resource.container.name=container
+
+common.public.tag.continuousIntegration=Continuous Integration
+common.public.tag.testing=Testing
+common.public.tag.commonTools=Common Tools
+common.public.tag.releaseDeployment=Release & Deployment
+common.public.tag.troubleshooting=Troubleshooting
+common.public.tag.opsRelease=Operations Release

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/common/message_en_US.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/common/message_en_US.properties
@@ -116,3 +116,10 @@ resource.host.name=host
 resource.dynamic_group.name=group
 resource.biz_set.name=business set
 resource.container.name=container
+
+common.public.tag.continuousIntegration=Continuous Integration
+common.public.tag.testing=Testing
+common.public.tag.commonTools=Common Tools
+common.public.tag.releaseDeployment=Release & Deployment
+common.public.tag.troubleshooting=Troubleshooting
+common.public.tag.opsRelease=Operations Release

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/common/message_zh.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/common/message_zh.properties
@@ -116,3 +116,10 @@ resource.host.name=主机
 resource.dynamic_group.name=动态分组
 resource.biz_set.name=业务集
 resource.container.name=容器
+
+common.public.tag.continuousIntegration=持续集成
+common.public.tag.testing=测试专用
+common.public.tag.commonTools=常用工具
+common.public.tag.releaseDeployment=发布部署
+common.public.tag.troubleshooting=故障处理
+common.public.tag.opsRelease=运营发布

--- a/src/backend/commons/common-i18n/src/main/resources/i18n/common/message_zh_CN.properties
+++ b/src/backend/commons/common-i18n/src/main/resources/i18n/common/message_zh_CN.properties
@@ -116,3 +116,10 @@ resource.host.name=主机
 resource.dynamic_group.name=动态分组
 resource.biz_set.name=业务集
 resource.container.name=容器
+
+common.public.tag.continuousIntegration=持续集成
+common.public.tag.testing=测试专用
+common.public.tag.commonTools=常用工具
+common.public.tag.releaseDeployment=发布部署
+common.public.tag.troubleshooting=故障处理
+common.public.tag.opsRelease=运营发布

--- a/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/PublicTagI18nUtil.java
+++ b/src/backend/commons/common/src/main/java/com/tencent/bk/job/common/util/PublicTagI18nUtil.java
@@ -1,0 +1,77 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.util;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * 公共内置标签国际化工具
+ */
+public class PublicTagI18nUtil {
+
+    private static final Map<String, String> PUBLIC_TAG_NAME_I18N_KEY_MAP;
+
+    static {
+        Map<String, String> map = new HashMap<>();
+        map.put("持续集成", "common.public.tag.continuousIntegration");
+        map.put("测试专用", "common.public.tag.testing");
+        map.put("常用工具", "common.public.tag.commonTools");
+        map.put("发布部署", "common.public.tag.releaseDeployment");
+        map.put("故障处理", "common.public.tag.troubleshooting");
+        map.put("运营发布", "common.public.tag.opsRelease");
+        PUBLIC_TAG_NAME_I18N_KEY_MAP = Collections.unmodifiableMap(map);
+    }
+
+    public static boolean matchesName(String tagName, String keyword) {
+        if (StringUtils.isBlank(keyword)) {
+            return true;
+        }
+        if (StringUtils.isBlank(tagName)) {
+            return false;
+        }
+        String lowerCaseKeyword = keyword.toLowerCase(Locale.ROOT);
+        return tagName.contains(keyword)
+            || getI18nName(tagName).toLowerCase(Locale.ROOT).contains(lowerCaseKeyword);
+    }
+
+    public static String getI18nName(String tagName) {
+        if (StringUtils.isBlank(tagName)) {
+            return tagName;
+        }
+        String i18nKey = PUBLIC_TAG_NAME_I18N_KEY_MAP.get(tagName);
+        if (i18nKey == null) {
+            return tagName;
+        }
+        return StringUtils.defaultIfBlank(I18nUtil.getI18nMessage(i18nKey), tagName);
+    }
+
+    private PublicTagI18nUtil() {
+    }
+}

--- a/src/backend/commons/common/src/test/java/com/tencent/bk/job/common/util/PublicTagI18nUtilTest.java
+++ b/src/backend/commons/common/src/test/java/com/tencent/bk/job/common/util/PublicTagI18nUtilTest.java
@@ -1,0 +1,99 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.common.util;
+
+import com.tencent.bk.job.common.i18n.service.MessageI18nService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PublicTagI18nUtilTest {
+
+    @BeforeEach
+    public void setUp() {
+        ReflectionTestUtils.setField(I18nUtil.class, "i18nService", new TestMessageI18nService());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        ReflectionTestUtils.setField(I18nUtil.class, "i18nService", null);
+    }
+
+    @Test
+    public void getI18nName() {
+        assertEquals("Continuous Integration", PublicTagI18nUtil.getI18nName("持续集成"));
+        assertEquals("业务自定义", PublicTagI18nUtil.getI18nName("业务自定义"));
+        assertEquals("", PublicTagI18nUtil.getI18nName(""));
+    }
+
+    @Test
+    public void matchesName() {
+        assertTrue(PublicTagI18nUtil.matchesName("持续集成", "持续"));
+        assertTrue(PublicTagI18nUtil.matchesName("持续集成", "integration"));
+        assertTrue(PublicTagI18nUtil.matchesName("持续集成", "Integration"));
+        assertFalse(PublicTagI18nUtil.matchesName("持续集成", "deploy"));
+        assertFalse(PublicTagI18nUtil.matchesName(null, "integration"));
+        assertTrue(PublicTagI18nUtil.matchesName("持续集成", null));
+    }
+
+    private static class TestMessageI18nService implements MessageI18nService {
+        private static final Map<String, String> MESSAGE_MAP = Map.of(
+            "common.public.tag.continuousIntegration", "Continuous Integration",
+            "common.public.tag.testing", "Testing",
+            "common.public.tag.commonTools", "Common Tools",
+            "common.public.tag.releaseDeployment", "Release & Deployment",
+            "common.public.tag.troubleshooting", "Troubleshooting",
+            "common.public.tag.opsRelease", "Operations Release"
+        );
+
+        @Override
+        public String getI18n(String msgKey) {
+            return MESSAGE_MAP.getOrDefault(msgKey, "");
+        }
+
+        @Override
+        public String getI18nWithArgs(String msgKey, Object... args) {
+            return getI18n(msgKey);
+        }
+
+        @Override
+        public String getI18n(Locale locale, String msgKey) {
+            return getI18n(msgKey);
+        }
+
+        @Override
+        public String getI18nWithArgs(Locale locale, String msgKey, Object... args) {
+            return getI18n(msgKey);
+        }
+    }
+}

--- a/src/backend/job-analysis/service-job-analysis/src/main/java/com/tencent/bk/job/analysis/service/TagStatisticService.java
+++ b/src/backend/job-analysis/service-job-analysis/src/main/java/com/tencent/bk/job/analysis/service/TagStatisticService.java
@@ -30,6 +30,7 @@ import com.tencent.bk.job.analysis.api.dto.StatisticsDTO;
 import com.tencent.bk.job.analysis.config.StatisticConfig;
 import com.tencent.bk.job.analysis.dao.StatisticsDAO;
 import com.tencent.bk.job.analysis.model.web.CommonDistributionVO;
+import com.tencent.bk.job.common.util.PublicTagI18nUtil;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
@@ -96,7 +97,7 @@ public class TagStatisticService {
         }
         map.clear();
         for (Pair<String, Long> pair : tagList) {
-            map.put(pair.getLeft(), pair.getRight());
+            map.merge(PublicTagI18nUtil.getI18nName(pair.getLeft()), pair.getRight(), Long::sum);
         }
         commonDistributionVO.setLabelAmountMap(map);
         return commonDistributionVO;

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebPublicTagResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebPublicTagResourceImpl.java
@@ -26,6 +26,7 @@ package com.tencent.bk.job.manage.api.web.impl;
 
 import com.tencent.bk.job.common.constant.JobConstants;
 import com.tencent.bk.job.common.model.Response;
+import com.tencent.bk.job.common.util.PublicTagI18nUtil;
 import com.tencent.bk.job.manage.api.web.WebPublicTagResource;
 import com.tencent.bk.job.manage.model.dto.TagDTO;
 import com.tencent.bk.job.manage.model.web.vo.TagVO;
@@ -49,14 +50,16 @@ public class WebPublicTagResourceImpl implements WebPublicTagResource {
 
     @Override
     public Response<List<TagVO>> listTags(String username, String name) {
-        List<TagDTO> tags = tagService.listTags(JobConstants.PUBLIC_APP_ID, name);
+        List<TagDTO> tags = tagService.listTags(JobConstants.PUBLIC_APP_ID, null);
         List<TagVO> tagVOS = new ArrayList<>(tags.size());
         for (TagDTO tag : tags) {
-            TagVO tagVO = new TagVO();
-            tagVO.setId(tag.getId());
-            tagVO.setName(tag.getName());
-            tagVO.setDescription(tag.getDescription());
-            tagVOS.add(tagVO);
+            if (PublicTagI18nUtil.matchesName(tag.getName(), name)) {
+                TagVO tagVO = new TagVO();
+                tagVO.setId(tag.getId());
+                tagVO.setName(TagDTO.getDisplayName(tag));
+                tagVO.setDescription(tag.getDescription());
+                tagVOS.add(tagVO);
+            }
         }
         return Response.buildSuccessResp(tagVOS);
     }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebTagResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/web/impl/WebTagResourceImpl.java
@@ -172,7 +172,7 @@ public class WebTagResourceImpl implements WebTagResource {
         for (TagDTO tag : tags) {
             TagVO tagVO = new TagVO();
             tagVO.setId(tag.getId());
-            tagVO.setName(tag.getName());
+            tagVO.setName(TagDTO.getDisplayName(tag));
             tagVO.setDescription(tag.getDescription());
             tagVOS.add(tagVO);
         }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/model/dto/TagDTO.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/model/dto/TagDTO.java
@@ -24,7 +24,9 @@
 
 package com.tencent.bk.job.manage.model.dto;
 
+import com.tencent.bk.job.common.constant.JobConstants;
 import com.tencent.bk.job.common.model.dto.BasicDTO;
+import com.tencent.bk.job.common.util.PublicTagI18nUtil;
 import com.tencent.bk.job.manage.model.esb.v3.response.EsbTagV3DTO;
 import com.tencent.bk.job.manage.model.inner.ServiceTagDTO;
 import com.tencent.bk.job.manage.model.web.vo.TagVO;
@@ -70,13 +72,20 @@ public class TagDTO extends BasicDTO implements Cloneable {
     public static TagVO toVO(TagDTO tagInfo) {
         TagVO vo = new TagVO();
         vo.setId(tagInfo.getId());
-        vo.setName(tagInfo.getName());
+        vo.setName(getDisplayName(tagInfo));
         vo.setCreator(tagInfo.getCreator());
         vo.setLastModifyUser(tagInfo.getLastModifyUser());
         vo.setDescription(tagInfo.getDescription());
         vo.setCreateTime(tagInfo.getCreateTime());
         vo.setLastModifyTime(tagInfo.getLastModifyTime());
         return vo;
+    }
+
+    public static String getDisplayName(TagDTO tagInfo) {
+        if (tagInfo.getAppId() != null && tagInfo.getAppId().equals(JobConstants.PUBLIC_APP_ID)) {
+            return PublicTagI18nUtil.getI18nName(tagInfo.getName());
+        }
+        return tagInfo.getName();
     }
 
     public static TagDTO fromVO(TagVO tagVO) {

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/model/dto/converter/ScriptConverter.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/model/dto/converter/ScriptConverter.java
@@ -71,7 +71,7 @@ public class ScriptConverter {
         for (TagDTO tagDTO : tags) {
             TagVO tagVO = new TagVO();
             tagVO.setId(tagDTO.getId());
-            tagVO.setName(tagDTO.getName());
+            tagVO.setName(TagDTO.getDisplayName(tagDTO));
             tagVOS.add(tagVO);
         }
         return tagVOS;


### PR DESCRIPTION
实现：内置公共标签名称固定，后端返回标签及统计数据时统一进行国际化转换