### PR TITLE
perf: 多租户模式下支持自动初始化系统租户 #4452

### DIFF
--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/op/impl/TenantOpResourceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/api/op/impl/TenantOpResourceImpl.java
@@ -25,22 +25,12 @@
 package com.tencent.bk.job.manage.api.op.impl;
 
 import com.tencent.bk.job.common.constant.ErrorCode;
-import com.tencent.bk.job.common.constant.TenantIdConstants;
 import com.tencent.bk.job.common.model.Response;
-import com.tencent.bk.job.common.redis.util.DistributedUniqueTask;
-import com.tencent.bk.job.common.util.ip.IpUtils;
 import com.tencent.bk.job.manage.api.op.TenantOpResource;
-import com.tencent.bk.job.manage.background.ha.BackGroundTaskDaemon;
-import com.tencent.bk.job.manage.background.sync.BizSetSyncService;
-import com.tencent.bk.job.manage.background.sync.BizSyncService;
-import com.tencent.bk.job.manage.background.sync.tenantset.ITenantSetSyncService;
-import com.tencent.bk.job.manage.background.sync.TenantHostSyncService;
 import com.tencent.bk.job.manage.model.op.req.InitTenantReq;
-import com.tencent.bk.job.manage.service.impl.notify.NotifyChannelInitService;
+import com.tencent.bk.job.manage.service.TenantInitService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.util.StopWatch;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -49,49 +39,19 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 public class TenantOpResourceImpl implements TenantOpResource {
-    private static final String machineIp = IpUtils.getFirstMachineIP();
-    private static final String REDIS_KEY_INIT_TENANT_PREFIX = "initTenant-";
-    private final RedisTemplate<String, String> redisTemplate;
-    private final BizSyncService bizSyncService;
-    private final BizSetSyncService bizSetSyncService;
-    private final ITenantSetSyncService tenantSetSyncService;
-    private final TenantHostSyncService tenantHostSyncService;
-    private final NotifyChannelInitService notifyChannelInitService;
-    private final BackGroundTaskDaemon backGroundTaskDaemon;
 
+    private final TenantInitService tenantInitService;
 
     @Autowired
-    public TenantOpResourceImpl(RedisTemplate<String, String> redisTemplate,
-                                BizSyncService bizSyncService,
-                                BizSetSyncService bizSetSyncService,
-                                ITenantSetSyncService tenantSetSyncService,
-                                TenantHostSyncService tenantHostSyncService,
-                                NotifyChannelInitService notifyChannelInitService,
-                                BackGroundTaskDaemon backGroundTaskDaemon) {
-        this.redisTemplate = redisTemplate;
-        this.bizSyncService = bizSyncService;
-        this.bizSetSyncService = bizSetSyncService;
-        this.tenantSetSyncService = tenantSetSyncService;
-        this.tenantHostSyncService = tenantHostSyncService;
-        this.notifyChannelInitService = notifyChannelInitService;
-        this.backGroundTaskDaemon = backGroundTaskDaemon;
+    public TenantOpResourceImpl(TenantInitService tenantInitService) {
+        this.tenantInitService = tenantInitService;
     }
 
     @Override
     public Response<Object> initTenant(InitTenantReq req) {
         String tenantId = req.getTenantId();
-        log.info("initTenantTask(tenantId={}) start", tenantId);
-        StopWatch watch = new StopWatch();
-        Object taskResult = false;
         try {
-            // 分布式唯一性保证
-            taskResult = new DistributedUniqueTask<>(
-                redisTemplate,
-                "InitTenant-" + tenantId,
-                REDIS_KEY_INIT_TENANT_PREFIX + tenantId,
-                machineIp,
-                () -> doInitTenant(tenantId, watch)
-            ).execute();
+            Boolean taskResult = tenantInitService.initTenant(tenantId);
             if (taskResult == null) {
                 // 任务已在其他实例执行
                 return Response.buildCommonFailResp(ErrorCode.INIT_TENANT_TASK_ALREADY_RUNNING, new String[]{tenantId});
@@ -100,48 +60,6 @@ public class TenantOpResourceImpl implements TenantOpResource {
         } catch (Exception e) {
             log.error("initTenantTask failed", e);
             return Response.buildCommonFailResp(ErrorCode.INIT_TENANT_ERROR, new String[]{tenantId});
-        } finally {
-            if (watch.isRunning()) {
-                watch.stop();
-            }
-            if (taskResult != null) {
-                log.info("initTenantTask finished, timeConsuming={}", watch.prettyPrint());
-            }
         }
-    }
-
-    private Object doInitTenant(String tenantId, StopWatch watch) {
-        // 1.同步业务
-        watch.start("syncBizFromCMDB");
-        bizSyncService.syncBizFromCMDB(tenantId);
-        watch.stop();
-
-        // 2.同步业务集
-        watch.start("syncBizSetFromCMDB");
-        bizSetSyncService.syncBizSetFromCMDB(tenantId);
-        watch.stop();
-
-        // 3.同步租户集
-        watch.start("syncTenantSetFromCMDB");
-        tenantSetSyncService.syncTenantSetFromCMDB();
-        watch.stop();
-
-        // 4.同步租户下所有业务的主机
-        watch.start("syncAllBizHostsAtOnce");
-        tenantHostSyncService.syncAllBizHostsAtOnce(tenantId);
-        watch.stop();
-
-        // 5.启动该租户下的CMDB事件监听后台任务
-        watch.start("checkAndResumeTaskForTenant");
-        backGroundTaskDaemon.checkAndResumeTaskForTenant(tenantId);
-        watch.stop();
-
-        // 6.启用默认消息渠道
-        if (!TenantIdConstants.SYSTEM_TENANT_ID.equals(tenantId)) {
-            // system租户初始化时，CMSI不可以，后续采用懒加载
-            notifyChannelInitService.tryToInitDefaultNotifyChannelsWithSingleTenant(tenantId);
-        }
-
-        return true;
     }
 }

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/config/listener/SystemTenantInitListener.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/config/listener/SystemTenantInitListener.java
@@ -1,0 +1,72 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.config.listener;
+
+import com.tencent.bk.job.common.constant.TenantIdConstants;
+import com.tencent.bk.job.common.tenant.ConditionalOnTenantEnabled;
+import com.tencent.bk.job.manage.service.TenantInitResult;
+import com.tencent.bk.job.manage.service.TenantInitService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Profile;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ThreadPoolExecutor;
+
+/**
+ * 多租户模式下自动初始化系统租户，整个软件生命周期内至多成功执行一次。
+ * 失败后不做进程内重试，下一次实例启动时会再次尝试。
+ */
+@Slf4j
+@Component
+@Profile("!test")
+@ConditionalOnTenantEnabled
+public class SystemTenantInitListener implements ApplicationListener<ApplicationReadyEvent> {
+
+    private final TenantInitService tenantInitService;
+    private final ThreadPoolExecutor initRunnerExecutor;
+
+    @Autowired
+    public SystemTenantInitListener(TenantInitService tenantInitService,
+                                    @Qualifier("initRunnerExecutor") ThreadPoolExecutor initRunnerExecutor) {
+        this.tenantInitService = tenantInitService;
+        this.initRunnerExecutor = initRunnerExecutor;
+    }
+
+    @Override
+    public void onApplicationEvent(@NonNull ApplicationReadyEvent event) {
+        // 单次初始化的耗时没有上界，必须异步执行，否则会拖住启动收尾流程导致存活/就绪探针判定实例不健康
+        initRunnerExecutor.submit(this::initSystemTenant);
+    }
+
+    private void initSystemTenant() {
+        TenantInitResult result = tenantInitService.initTenantOnce(TenantIdConstants.SYSTEM_TENANT_ID);
+        log.info("System tenant auto init task finished, result={}", result);
+    }
+}

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/model/dto/TenantInitDoneMark.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/model/dto/TenantInitDoneMark.java
@@ -1,0 +1,50 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 租户初始化完成标记，序列化为JSON后作为Redis标记的value，运维可直接读取排查初始化的执行实例与时间区间
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TenantInitDoneMark {
+    /**
+     * 执行初始化的实例IP
+     */
+    private String machineIp;
+    /**
+     * 初始化开始时间，形如2026-09-09 21:05:30
+     */
+    private String startTime;
+    /**
+     * 初始化结束时间，形如2026-09-09 21:05:30
+     */
+    private String endTime;
+}

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/TenantInitResult.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/TenantInitResult.java
@@ -1,0 +1,51 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.service;
+
+/**
+ * 租户初始化的结果
+ */
+public enum TenantInitResult {
+
+    /**
+     * 完成标记已存在，本次跳过初始化
+     */
+    ALREADY_DONE,
+
+    /**
+     * 本次初始化成功，已写入完成标记
+     */
+    SUCCESS,
+
+    /**
+     * 未获取到分布式锁，本次跳过初始化
+     */
+    RUNNING_ON_OTHER_INSTANCE,
+
+    /**
+     * 本次初始化失败，未写入完成标记
+     */
+    FAILED
+}

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/TenantInitService.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/TenantInitService.java
@@ -1,0 +1,53 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.service;
+
+/**
+ * 租户初始化服务
+ */
+public interface TenantInitService {
+
+    /**
+     * 初始化指定租户，无条件执行，仅通过分布式锁保证多实例互斥。
+     * 供OP接口调用，同时也是自动初始化失败后的人工兜底入口。
+     * <p>
+     * 本方法不写入初始化完成标记，因此通过本方法初始化过的租户，
+     * 在下一次实例启动时仍会被{@link #initTenantOnce}再执行一次（初始化步骤幂等，重复执行安全）。
+     *
+     * @param tenantId 租户ID
+     * @return true：初始化成功；null：已有其他实例正在执行
+     * @throws Exception 初始化过程中的异常，由调用方决定如何转换为响应
+     */
+    Boolean initTenant(String tenantId) throws Exception;
+
+    /**
+     * 初始化指定租户，保证整个软件生命周期内至多成功执行一次，成功后写入永不过期的完成标记。
+     * 供系统租户自动初始化任务调用，内部捕获所有异常，不向外抛出。
+     *
+     * @param tenantId 租户ID
+     * @return 本次初始化的结果
+     */
+    TenantInitResult initTenantOnce(String tenantId);
+}

--- a/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/TenantInitServiceImpl.java
+++ b/src/backend/job-manage/service-job-manage/src/main/java/com/tencent/bk/job/manage/service/impl/TenantInitServiceImpl.java
@@ -1,0 +1,231 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.service.impl;
+
+import com.tencent.bk.job.common.constant.TenantIdConstants;
+import com.tencent.bk.job.common.redis.util.DistributedUniqueTask;
+import com.tencent.bk.job.common.util.date.DateUtils;
+import com.tencent.bk.job.common.util.ip.IpUtils;
+import com.tencent.bk.job.common.util.json.JsonUtils;
+import com.tencent.bk.job.manage.background.ha.BackGroundTaskDaemon;
+import com.tencent.bk.job.manage.background.sync.BizSetSyncService;
+import com.tencent.bk.job.manage.background.sync.BizSyncService;
+import com.tencent.bk.job.manage.background.sync.TenantHostSyncService;
+import com.tencent.bk.job.manage.background.sync.tenantset.ITenantSetSyncService;
+import com.tencent.bk.job.manage.model.dto.TenantInitDoneMark;
+import com.tencent.bk.job.manage.service.TenantInitResult;
+import com.tencent.bk.job.manage.service.TenantInitService;
+import com.tencent.bk.job.manage.service.impl.notify.NotifyChannelInitService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StopWatch;
+
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.Callable;
+
+@Slf4j
+@Service
+public class TenantInitServiceImpl implements TenantInitService {
+
+    private static final String machineIp = IpUtils.getFirstMachineIP();
+    /**
+     * 租户初始化分布式锁的Key前缀，真实的锁Key为job:util:lock:initTenant-{tenantId}。
+     * 该值必须保持稳定，否则升级期间新老版本实例会抢到不同的锁而并发执行初始化。
+     */
+    private static final String REDIS_KEY_INIT_TENANT_PREFIX = "initTenant-";
+    /**
+     * 租户初始化完成标记的Key前缀，标记永不过期，value为{@link TenantInitDoneMark}的JSON串，
+     * 记录执行初始化的实例IP与初始化的开始、结束时间。
+     * 标记仅代表「自动初始化任务成功执行过」：通过OP接口人工初始化不会写入标记，
+     * 因此标记不存在并不等价于租户未初始化，部署验收时需结合业务/主机数据是否非空一并判断。
+     */
+    private static final String REDIS_KEY_TENANT_INIT_DONE_PREFIX = "job:manage:tenant:init:done:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final BizSyncService bizSyncService;
+    private final BizSetSyncService bizSetSyncService;
+    private final ITenantSetSyncService tenantSetSyncService;
+    private final TenantHostSyncService tenantHostSyncService;
+    private final NotifyChannelInitService notifyChannelInitService;
+    private final BackGroundTaskDaemon backGroundTaskDaemon;
+
+    @Autowired
+    public TenantInitServiceImpl(RedisTemplate<String, String> redisTemplate,
+                                 BizSyncService bizSyncService,
+                                 BizSetSyncService bizSetSyncService,
+                                 ITenantSetSyncService tenantSetSyncService,
+                                 TenantHostSyncService tenantHostSyncService,
+                                 NotifyChannelInitService notifyChannelInitService,
+                                 BackGroundTaskDaemon backGroundTaskDaemon) {
+        this.redisTemplate = redisTemplate;
+        this.bizSyncService = bizSyncService;
+        this.bizSetSyncService = bizSetSyncService;
+        this.tenantSetSyncService = tenantSetSyncService;
+        this.tenantHostSyncService = tenantHostSyncService;
+        this.notifyChannelInitService = notifyChannelInitService;
+        this.backGroundTaskDaemon = backGroundTaskDaemon;
+    }
+
+    @Override
+    public Boolean initTenant(String tenantId) throws Exception {
+        log.info("initTenantTask(tenantId={}) start", tenantId);
+        StopWatch watch = new StopWatch();
+        Boolean taskResult = null;
+        try {
+            taskResult = this.<Boolean>newInitTenantTask(tenantId, () -> {
+                doInitTenant(tenantId, watch);
+                return true;
+            }).execute();
+            return taskResult;
+        } finally {
+            logTimeConsuming("initTenantTask", tenantId, watch, taskResult != null);
+        }
+    }
+
+    @Override
+    public TenantInitResult initTenantOnce(String tenantId) {
+        String doneMark = getTenantInitDoneMark(tenantId);
+        if (doneMark != null) {
+            // 先于抢锁判断，避免每次进程启动都去争抢Redis锁
+            log.info("Tenant {} has been initialized before({}), skip init", tenantId, doneMark);
+            return TenantInitResult.ALREADY_DONE;
+        }
+        log.info("initTenantOnceTask(tenantId={}) start", tenantId);
+        StopWatch watch = new StopWatch();
+        TenantInitResult taskResult = null;
+        try {
+            // 异常必须在execute()之外捕获：既保证写标记语句在异常时不可达，又保证execute()内finally的锁释放照常执行
+            taskResult = this.<TenantInitResult>newInitTenantTask(tenantId, () -> {
+                String markInLock = getTenantInitDoneMark(tenantId);
+                if (markInLock != null) {
+                    // 同批启动的其他实例可能已在本实例等待期间完成初始化并释放了锁，故需在锁内复查
+                    log.info("Tenant {} has been initialized by another instance({}), skip init", tenantId,
+                        markInLock);
+                    return TenantInitResult.ALREADY_DONE;
+                }
+                // 开始时间取初始化步骤真正开始执行的时刻，不含抢锁与锁内复查标记的等待耗时
+                long startTimeMillis = System.currentTimeMillis();
+                doInitTenant(tenantId, watch);
+                markTenantInitDone(tenantId, startTimeMillis);
+                return TenantInitResult.SUCCESS;
+            }).execute();
+            if (taskResult == null) {
+                // 加锁失败：可能是其他实例正在执行，也可能是Redis锁层自身出错（HeartBeatRedisLock.lock()
+                // 内部catch了Throwable并同样返回加锁失败），两者不可区分，故用WARN级别
+                log.warn("Lock of init tenant {} not gotten, another instance may be initializing it, "
+                    + "or redis lock error occurred, skip init", tenantId);
+                return TenantInitResult.RUNNING_ON_OTHER_INSTANCE;
+            }
+            return taskResult;
+        } catch (Exception e) {
+            log.error("Failed to init tenant {} automatically, the application keeps running but the tenant is "
+                + "NOT initialized. Retry will happen on next pod restart, or trigger it manually via OP API "
+                + "POST /op/tenant/init with tenantId={}", tenantId, tenantId, e);
+            return TenantInitResult.FAILED;
+        } finally {
+            logTimeConsuming("initTenantOnceTask", tenantId, watch, taskResult == TenantInitResult.SUCCESS);
+        }
+    }
+
+    private <V> DistributedUniqueTask<V> newInitTenantTask(String tenantId, Callable<V> task) {
+        return new DistributedUniqueTask<>(
+            redisTemplate,
+            "InitTenant-" + tenantId,
+            REDIS_KEY_INIT_TENANT_PREFIX + tenantId,
+            machineIp,
+            task
+        );
+    }
+
+    private void doInitTenant(String tenantId, StopWatch watch) {
+        // 1.同步业务
+        watch.start("syncBizFromCMDB");
+        bizSyncService.syncBizFromCMDB(tenantId);
+        watch.stop();
+
+        // 2.同步业务集
+        watch.start("syncBizSetFromCMDB");
+        bizSetSyncService.syncBizSetFromCMDB(tenantId);
+        watch.stop();
+
+        // 3.同步租户集
+        watch.start("syncTenantSetFromCMDB");
+        tenantSetSyncService.syncTenantSetFromCMDB();
+        watch.stop();
+
+        // 4.同步租户下所有业务的主机
+        watch.start("syncAllBizHostsAtOnce");
+        tenantHostSyncService.syncAllBizHostsAtOnce(tenantId);
+        watch.stop();
+
+        // 5.启动该租户下的CMDB事件监听后台任务
+        watch.start("checkAndResumeTaskForTenant");
+        backGroundTaskDaemon.checkAndResumeTaskForTenant(tenantId);
+        watch.stop();
+
+        // 6.启用默认消息渠道
+        if (TenantIdConstants.SYSTEM_TENANT_ID.equals(tenantId)) {
+            // system租户下没有可用的CMSI消息渠道，初始化时跳过，后续由用户在页面上配置或由普通租户初始化时补齐
+            log.info("Skip default notify channel init for system tenant");
+        } else {
+            notifyChannelInitService.tryToInitDefaultNotifyChannelsWithSingleTenant(tenantId);
+        }
+    }
+
+    private String getTenantInitDoneMark(String tenantId) {
+        return redisTemplate.opsForValue().get(buildTenantInitDoneKey(tenantId));
+    }
+
+    private void markTenantInitDone(String tenantId, long startTimeMillis) {
+        String key = buildTenantInitDoneKey(tenantId);
+        TenantInitDoneMark mark = new TenantInitDoneMark(
+            machineIp,
+            formatTime(startTimeMillis),
+            formatTime(System.currentTimeMillis())
+        );
+        String value = JsonUtils.toJson(mark);
+        redisTemplate.opsForValue().set(key, value);
+        log.info("Tenant init done mark written, {}={}", key, value);
+    }
+
+    private String formatTime(long timeMillis) {
+        return DateUtils.formatUnixTimestamp(timeMillis, ChronoUnit.MILLIS);
+    }
+
+    private String buildTenantInitDoneKey(String tenantId) {
+        return REDIS_KEY_TENANT_INIT_DONE_PREFIX + tenantId;
+    }
+
+    private void logTimeConsuming(String taskName, String tenantId, StopWatch watch, boolean executed) {
+        if (watch.isRunning()) {
+            watch.stop();
+        }
+        if (executed) {
+            log.info("{}(tenantId={}) finished, timeConsuming={}", taskName, tenantId, watch.prettyPrint());
+        }
+    }
+}

--- a/src/backend/job-manage/service-job-manage/src/test/java/com/tencent/bk/job/manage/service/impl/TenantInitServiceImplTest.java
+++ b/src/backend/job-manage/service-job-manage/src/test/java/com/tencent/bk/job/manage/service/impl/TenantInitServiceImplTest.java
@@ -1,0 +1,209 @@
+/*
+ * Tencent is pleased to support the open source community by making BK-JOB蓝鲸智云作业平台 available.
+ *
+ * Copyright (C) 2021 Tencent.  All rights reserved.
+ *
+ * BK-JOB蓝鲸智云作业平台 is licensed under the MIT License.
+ *
+ * License for BK-JOB蓝鲸智云作业平台:
+ * --------------------------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+package com.tencent.bk.job.manage.service.impl;
+
+import com.tencent.bk.job.common.constant.TenantIdConstants;
+import com.tencent.bk.job.common.redis.util.LockUtils;
+import com.tencent.bk.job.common.util.json.JsonUtils;
+import com.tencent.bk.job.manage.background.ha.BackGroundTaskDaemon;
+import com.tencent.bk.job.manage.background.sync.BizSetSyncService;
+import com.tencent.bk.job.manage.background.sync.BizSyncService;
+import com.tencent.bk.job.manage.background.sync.TenantHostSyncService;
+import com.tencent.bk.job.manage.background.sync.tenantset.ITenantSetSyncService;
+import com.tencent.bk.job.manage.model.dto.TenantInitDoneMark;
+import com.tencent.bk.job.manage.service.TenantInitResult;
+import com.tencent.bk.job.manage.service.impl.notify.NotifyChannelInitService;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.RedisScript;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@DisplayName("TenantInitServiceImpl 测试")
+class TenantInitServiceImplTest {
+
+    private static final String TENANT_ID = "tenant-001";
+    private static final String INIT_DONE_KEY_PREFIX = "job:manage:tenant:init:done:";
+    private static final String EXISTED_MARK =
+        "{\"machineIp\":\"127.0.0.1\",\"startTime\":\"2026-08-17 17:38:09\",\"endTime\":\"2026-08-17 17:38:11\"}";
+    private static final String DATETIME_REGEX = "\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}";
+
+    private StringRedisTemplate redisTemplate;
+    private ValueOperations<String, String> valueOperations;
+    private BizSyncService bizSyncService;
+    private BizSetSyncService bizSetSyncService;
+    private ITenantSetSyncService tenantSetSyncService;
+    private TenantHostSyncService tenantHostSyncService;
+    private NotifyChannelInitService notifyChannelInitService;
+    private BackGroundTaskDaemon backGroundTaskDaemon;
+    private TenantInitServiceImpl tenantInitService;
+
+    /**
+     * DistributedUniqueTask 经 HeartBeatRedisLock 调用静态的 LockUtils 加锁，需先注入可用的 RedisTemplate，
+     * 否则加锁必然失败，走不到初始化步骤
+     */
+    @BeforeAll
+    static void initLockUtils() {
+        StringRedisTemplate lockRedisTemplate = mock(StringRedisTemplate.class);
+        @SuppressWarnings("unchecked")
+        ValueOperations<String, String> lockValueOperations = mock(ValueOperations.class);
+        when(lockRedisTemplate.opsForValue()).thenReturn(lockValueOperations);
+        when(lockValueOperations.setIfAbsent(anyString(), anyString(), anyLong(), eq(TimeUnit.MILLISECONDS)))
+            .thenReturn(true);
+        LockUtils.init(lockRedisTemplate, RedisScript.of("return 1", Long.class));
+    }
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        redisTemplate = mock(StringRedisTemplate.class);
+        valueOperations = mock(ValueOperations.class);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        bizSyncService = mock(BizSyncService.class);
+        bizSetSyncService = mock(BizSetSyncService.class);
+        tenantSetSyncService = mock(ITenantSetSyncService.class);
+        tenantHostSyncService = mock(TenantHostSyncService.class);
+        notifyChannelInitService = mock(NotifyChannelInitService.class);
+        backGroundTaskDaemon = mock(BackGroundTaskDaemon.class);
+        tenantInitService = new TenantInitServiceImpl(
+            redisTemplate,
+            bizSyncService,
+            bizSetSyncService,
+            tenantSetSyncService,
+            tenantHostSyncService,
+            notifyChannelInitService,
+            backGroundTaskDaemon
+        );
+    }
+
+    @Test
+    @DisplayName("完成标记已存在时跳过初始化，不调用任何下游服务")
+    void initTenantOnceShouldSkipWhenMarkExists() {
+        when(valueOperations.get(INIT_DONE_KEY_PREFIX + TENANT_ID)).thenReturn(EXISTED_MARK);
+
+        TenantInitResult result = tenantInitService.initTenantOnce(TENANT_ID);
+
+        assertThat(result).isEqualTo(TenantInitResult.ALREADY_DONE);
+        verifyNoInteractions(bizSyncService, bizSetSyncService, tenantSetSyncService, tenantHostSyncService,
+            notifyChannelInitService, backGroundTaskDaemon);
+    }
+
+    @Test
+    @DisplayName("完成标记不存在且各步骤均成功时按序执行并写入无过期时间的完成标记")
+    void initTenantOnceShouldWriteMarkAfterAllStepsSucceed() {
+        when(valueOperations.get(INIT_DONE_KEY_PREFIX + TENANT_ID)).thenReturn(null);
+
+        TenantInitResult result = tenantInitService.initTenantOnce(TENANT_ID);
+
+        assertThat(result).isEqualTo(TenantInitResult.SUCCESS);
+        InOrder inOrder = inOrder(bizSyncService, bizSetSyncService, tenantSetSyncService, tenantHostSyncService,
+            backGroundTaskDaemon, notifyChannelInitService);
+        inOrder.verify(bizSyncService).syncBizFromCMDB(TENANT_ID);
+        inOrder.verify(bizSetSyncService).syncBizSetFromCMDB(TENANT_ID);
+        inOrder.verify(tenantSetSyncService).syncTenantSetFromCMDB();
+        inOrder.verify(tenantHostSyncService).syncAllBizHostsAtOnce(TENANT_ID);
+        inOrder.verify(backGroundTaskDaemon).checkAndResumeTaskForTenant(TENANT_ID);
+        inOrder.verify(notifyChannelInitService).tryToInitDefaultNotifyChannelsWithSingleTenant(TENANT_ID);
+        verify(valueOperations).set(eq(INIT_DONE_KEY_PREFIX + TENANT_ID), anyString());
+    }
+
+    @Test
+    @DisplayName("完成标记的value为含machineIp、startTime、endTime的JSON串，时间为可读格式且开始不晚于结束")
+    void initTenantOnceShouldWriteMarkAsJson() {
+        when(valueOperations.get(INIT_DONE_KEY_PREFIX + TENANT_ID)).thenReturn(null);
+
+        tenantInitService.initTenantOnce(TENANT_ID);
+
+        ArgumentCaptor<String> valueCaptor = ArgumentCaptor.forClass(String.class);
+        verify(valueOperations).set(eq(INIT_DONE_KEY_PREFIX + TENANT_ID), valueCaptor.capture());
+        TenantInitDoneMark mark = JsonUtils.fromJson(valueCaptor.getValue(), TenantInitDoneMark.class);
+        assertThat(mark.getMachineIp()).isNotBlank();
+        assertThat(mark.getStartTime()).matches(DATETIME_REGEX);
+        assertThat(mark.getEndTime()).matches(DATETIME_REGEX);
+        assertThat(mark.getStartTime()).isLessThanOrEqualTo(mark.getEndTime());
+    }
+
+    @Test
+    @DisplayName("任一步骤抛异常时返回 FAILED、不写完成标记且不向外抛异常")
+    void initTenantOnceShouldNotWriteMarkWhenStepFailed() {
+        when(valueOperations.get(INIT_DONE_KEY_PREFIX + TENANT_ID)).thenReturn(null);
+        doThrow(new RuntimeException("cmdb unreachable")).when(bizSyncService).syncBizFromCMDB(TENANT_ID);
+
+        TenantInitResult result = tenantInitService.initTenantOnce(TENANT_ID);
+
+        assertThat(result).isEqualTo(TenantInitResult.FAILED);
+        verify(valueOperations, never()).set(anyString(), anyString());
+        verifyNoInteractions(bizSetSyncService, tenantSetSyncService, tenantHostSyncService, backGroundTaskDaemon,
+            notifyChannelInitService);
+    }
+
+    @Test
+    @DisplayName("系统租户跳过默认消息渠道初始化，前 5 个步骤正常执行")
+    void initTenantOnceShouldSkipNotifyChannelForSystemTenant() {
+        String systemTenantId = TenantIdConstants.SYSTEM_TENANT_ID;
+        when(valueOperations.get(INIT_DONE_KEY_PREFIX + systemTenantId)).thenReturn(null);
+
+        TenantInitResult result = tenantInitService.initTenantOnce(systemTenantId);
+
+        assertThat(result).isEqualTo(TenantInitResult.SUCCESS);
+        verify(bizSyncService).syncBizFromCMDB(systemTenantId);
+        verify(bizSetSyncService).syncBizSetFromCMDB(systemTenantId);
+        verify(tenantSetSyncService).syncTenantSetFromCMDB();
+        verify(tenantHostSyncService).syncAllBizHostsAtOnce(systemTenantId);
+        verify(backGroundTaskDaemon).checkAndResumeTaskForTenant(systemTenantId);
+        verifyNoInteractions(notifyChannelInitService);
+    }
+
+    @Test
+    @DisplayName("OP 接口入口无条件执行 6 个步骤且不写完成标记")
+    void initTenantShouldExecuteUnconditionallyWithoutWritingMark() throws Exception {
+        when(valueOperations.get(INIT_DONE_KEY_PREFIX + TENANT_ID)).thenReturn(EXISTED_MARK);
+
+        Boolean result = tenantInitService.initTenant(TENANT_ID);
+
+        assertThat(result).isTrue();
+        verify(bizSyncService).syncBizFromCMDB(TENANT_ID);
+        verify(notifyChannelInitService).tryToInitDefaultNotifyChannelsWithSingleTenant(TENANT_ID);
+        verify(valueOperations, never()).set(anyString(), anyString());
+    }
+}


### PR DESCRIPTION
1.新增TenantInitService，将租户初始化的6个步骤从TenantOpResourceImpl抽取为独立Service，供OP接口与自动初始化任务复用。 
2.新增initTenantOnce，通过永不过期的Redis标记job:manage:tenant:init:done:{tenantId}保证整个软件生命周期内至多成功初始化一次，标记检查在抢锁前后各做一次，仅在6步全部成功后写入；标记value为TenantInitDoneMark序列化出的JSON，含machineIp与初始化的开始、结束时间。
3.新增SystemTenantInitListener，多租户模式下监听ApplicationReadyEvent并异步初始化系统租户，失败只打ERROR日志、不做进程内重试，下次实例启动时自动重试。 
4.TenantOpResourceImpl瘦身为纯委派，对外契约不变。
5.新增TenantInitServiceImplTest，覆盖标记已存在跳过、全部成功写标记、步骤失败不写标记、system租户跳过默认消息渠道、完成标记JSON结构等场景。