### PR TITLE
fix: 自签名证书场景下，关闭https证书校验后部分调用链不生效 #4502

### DIFF
--- a/src/backend/commons/ai-dev-sdk/src/main/java/com/tencent/bk/job/common/aidev/impl/BkAIDevClient.java
+++ b/src/backend/commons/ai-dev-sdk/src/main/java/com/tencent/bk/job/common/aidev/impl/BkAIDevClient.java
@@ -45,10 +45,8 @@ import com.tencent.bk.job.common.esb.model.BkApiAuthorization;
 import com.tencent.bk.job.common.esb.model.OpenApiRequestInfo;
 import com.tencent.bk.job.common.esb.sdk.BkApiClient;
 import com.tencent.bk.job.common.metrics.CommonMetricNames;
-import com.tencent.bk.job.common.util.http.ExternalSystemEnum;
 import com.tencent.bk.job.common.util.http.HttpHelperFactory;
 import com.tencent.bk.job.common.util.http.HttpMetricUtil;
-import com.tencent.bk.job.common.util.http.JobHttpSslVerifyConfig;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import org.apache.commons.collections4.CollectionUtils;
@@ -67,14 +65,6 @@ public class BkAIDevClient extends BkApiClient implements IBkAIDevClient {
     private final BkApiGatewayProperties.ApiGwConfig bkAIDevConfig;
     private final CustomPaasLoginProperties customPaasLoginProperties;
     private final boolean sslVerifyEnabled;
-
-    public BkAIDevClient(MeterRegistry meterRegistry,
-                         AppProperties appProperties,
-                         CustomPaasLoginProperties customPaasLoginProperties,
-                         BkApiGatewayProperties bkApiGatewayProperties) {
-        this(meterRegistry, appProperties, customPaasLoginProperties, bkApiGatewayProperties,
-            JobHttpSslVerifyConfig.isVerifyEnabled(ExternalSystemEnum.BK_AI_DEV));
-    }
 
     public BkAIDevClient(MeterRegistry meterRegistry,
                          AppProperties appProperties,

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/config/CmdbAutoConfiguration.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/config/CmdbAutoConfiguration.java
@@ -35,6 +35,8 @@ import com.tencent.bk.job.common.esb.config.BkApiGatewayProperties;
 import com.tencent.bk.job.common.esb.config.EsbProperties;
 import com.tencent.bk.job.common.esb.constants.EsbLang;
 import com.tencent.bk.job.common.util.FlowController;
+import com.tencent.bk.job.common.util.http.ExternalSystemEnum;
+import com.tencent.bk.job.common.util.http.JobHttpSslVerifyProperties;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.ObjectProvider;
@@ -98,6 +100,7 @@ public class CmdbAutoConfiguration {
                                        ThreadPoolExecutor cmdbThreadPoolExecutor,
                                        ThreadPoolExecutor cmdbLongTermThreadPoolExecutor,
                                        MeterRegistry meterRegistry,
+                                       JobHttpSslVerifyProperties sslVerifyProperties,
                                        ObjectProvider<FlowController> flowControllerProvider) {
         return new BizCmdbClient(
             appProperties,
@@ -108,7 +111,8 @@ public class CmdbAutoConfiguration {
             cmdbThreadPoolExecutor,
             cmdbLongTermThreadPoolExecutor,
             flowControllerProvider.getIfAvailable(),
-            meterRegistry
+            meterRegistry,
+            sslVerifyProperties.isVerifyEnabled(ExternalSystemEnum.CMDB)
         );
     }
 
@@ -120,6 +124,7 @@ public class CmdbAutoConfiguration {
                                          ThreadPoolExecutor cmdbThreadPoolExecutor,
                                          ThreadPoolExecutor cmdbLongTermThreadPoolExecutor,
                                          MeterRegistry meterRegistry,
+                                         JobHttpSslVerifyProperties sslVerifyProperties,
                                          ObjectProvider<FlowController> flowControllerProvider) {
         return new BizCmdbClient(
             appProperties,
@@ -130,7 +135,8 @@ public class CmdbAutoConfiguration {
             cmdbThreadPoolExecutor,
             cmdbLongTermThreadPoolExecutor,
             flowControllerProvider.getIfAvailable(),
-            meterRegistry
+            meterRegistry,
+            sslVerifyProperties.isVerifyEnabled(ExternalSystemEnum.CMDB)
         );
     }
 
@@ -140,6 +146,7 @@ public class CmdbAutoConfiguration {
                                              BkApiGatewayProperties bkApiGatewayProperties,
                                              CmdbConfig cmdbConfig,
                                              MeterRegistry meterRegistry,
+                                             JobHttpSslVerifyProperties sslVerifyProperties,
                                              ObjectProvider<FlowController> flowControllerProvider) {
         return new BizSetCmdbClient(
             appProperties,
@@ -147,7 +154,8 @@ public class CmdbAutoConfiguration {
             bkApiGatewayProperties,
             cmdbConfig,
             flowControllerProvider.getIfAvailable(),
-            meterRegistry
+            meterRegistry,
+            sslVerifyProperties.isVerifyEnabled(ExternalSystemEnum.CMDB)
         );
     }
 

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BaseCmdbApiClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BaseCmdbApiClient.java
@@ -46,8 +46,6 @@ import com.tencent.bk.job.common.util.FlowController;
 import com.tencent.bk.job.common.util.http.HttpHelper;
 import com.tencent.bk.job.common.util.http.HttpHelperFactory;
 import com.tencent.bk.job.common.util.http.HttpMetricUtil;
-import com.tencent.bk.job.common.util.http.ExternalSystemEnum;
-import com.tencent.bk.job.common.util.http.JobHttpSslVerifyConfig;
 import com.tencent.bk.job.common.util.http.WatchableHttpHelper;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -129,25 +127,6 @@ public class BaseCmdbApiClient {
         interfaceNameMap.put(SEARCH_BUSINESS_SET, "list_business_set");
         interfaceNameMap.put(LIST_KUBE_CONTAINER_BY_TOPO, "list_kube_container_by_topo");
         interfaceNameMap.put(GET_BIZ_KUBE_CACHE_TOPO, "get_biz_kube_cache_topo");
-    }
-
-    protected BaseCmdbApiClient(FlowController flowController,
-                                AppProperties appProperties,
-                                EsbProperties esbProperties,
-                                BkApiGatewayProperties bkApiGatewayProperties,
-                                CmdbConfig cmdbConfig,
-                                MeterRegistry meterRegistry,
-                                String lang) {
-        this(
-            flowController,
-            appProperties,
-            esbProperties,
-            bkApiGatewayProperties,
-            cmdbConfig,
-            meterRegistry,
-            lang,
-            JobHttpSslVerifyConfig.isVerifyEnabled(ExternalSystemEnum.CMDB)
-        );
     }
 
     protected BaseCmdbApiClient(FlowController flowController,

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BaseCmdbApiClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BaseCmdbApiClient.java
@@ -93,6 +93,7 @@ public class BaseCmdbApiClient {
     private static final Map<String, String> interfaceNameMap = new HashMap<>();
 
     protected final String cmdbSupplierAccount;
+    private final boolean sslVerifyEnabled;
     protected final BkApiAuthorization cmdbBkApiAuthorization;
 
     /**
@@ -137,9 +138,27 @@ public class BaseCmdbApiClient {
                                 CmdbConfig cmdbConfig,
                                 MeterRegistry meterRegistry,
                                 String lang) {
-        WatchableHttpHelper httpHelper = HttpHelperFactory.getRetryableHttpHelper(
+        this(
+            flowController,
+            appProperties,
+            esbProperties,
+            bkApiGatewayProperties,
+            cmdbConfig,
+            meterRegistry,
+            lang,
             JobHttpSslVerifyConfig.isVerifyEnabled(ExternalSystemEnum.CMDB)
         );
+    }
+
+    protected BaseCmdbApiClient(FlowController flowController,
+                                AppProperties appProperties,
+                                EsbProperties esbProperties,
+                                BkApiGatewayProperties bkApiGatewayProperties,
+                                CmdbConfig cmdbConfig,
+                                MeterRegistry meterRegistry,
+                                String lang,
+                                boolean sslVerifyEnabled) {
+        WatchableHttpHelper httpHelper = HttpHelperFactory.getRetryableHttpHelper(sslVerifyEnabled);
         this.esbCmdbApiClient = new BkApiClient(meterRegistry,
             CmdbMetricNames.CMDB_API_PREFIX,
             esbProperties.getService().getUrl(),
@@ -157,14 +176,13 @@ public class BaseCmdbApiClient {
         this.globalFlowController = flowController;
         this.cmdbConfig = cmdbConfig;
         this.cmdbSupplierAccount = cmdbConfig.getDefaultSupplierAccount();
+        this.sslVerifyEnabled = sslVerifyEnabled;
         this.cmdbBkApiAuthorization = BkApiAuthorization.appAuthorization(
             appProperties.getCode(), appProperties.getSecret(), "admin");
     }
 
     protected WatchableHttpHelper longRetryableHttpHelper() {
-        return HttpHelperFactory.getLongRetryableHttpHelper(
-            JobHttpSslVerifyConfig.isVerifyEnabled(ExternalSystemEnum.CMDB)
-        );
+        return HttpHelperFactory.getLongRetryableHttpHelper(sslVerifyEnabled);
     }
 
 

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizCmdbClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizCmdbClient.java
@@ -127,6 +127,8 @@ import com.tencent.bk.job.common.util.PageUtil;
 import com.tencent.bk.job.common.util.ThreadUtils;
 import com.tencent.bk.job.common.util.TimeUtil;
 import com.tencent.bk.job.common.util.Utils;
+import com.tencent.bk.job.common.util.http.ExternalSystemEnum;
+import com.tencent.bk.job.common.util.http.JobHttpSslVerifyConfig;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
@@ -189,6 +191,30 @@ public class BizCmdbClient extends BaseCmdbApiClient implements IBizCmdbClient {
                          ThreadPoolExecutor longTermThreadPoolExecutor,
                          FlowController flowController,
                          MeterRegistry meterRegistry) {
+        this(
+            appProperties,
+            esbProperties,
+            bkApiGatewayProperties,
+            cmdbConfig,
+            lang,
+            threadPoolExecutor,
+            longTermThreadPoolExecutor,
+            flowController,
+            meterRegistry,
+            JobHttpSslVerifyConfig.isVerifyEnabled(ExternalSystemEnum.CMDB)
+        );
+    }
+
+    public BizCmdbClient(AppProperties appProperties,
+                         EsbProperties esbProperties,
+                         BkApiGatewayProperties bkApiGatewayProperties,
+                         CmdbConfig cmdbConfig,
+                         String lang,
+                         ThreadPoolExecutor threadPoolExecutor,
+                         ThreadPoolExecutor longTermThreadPoolExecutor,
+                         FlowController flowController,
+                         MeterRegistry meterRegistry,
+                         boolean sslVerifyEnabled) {
         super(
             flowController,
             appProperties,
@@ -196,7 +222,8 @@ public class BizCmdbClient extends BaseCmdbApiClient implements IBizCmdbClient {
             bkApiGatewayProperties,
             cmdbConfig,
             meterRegistry,
-            lang
+            lang,
+            sslVerifyEnabled
         );
         this.threadPoolExecutor = threadPoolExecutor;
         this.longTermThreadPoolExecutor = longTermThreadPoolExecutor;

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizCmdbClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizCmdbClient.java
@@ -127,8 +127,6 @@ import com.tencent.bk.job.common.util.PageUtil;
 import com.tencent.bk.job.common.util.ThreadUtils;
 import com.tencent.bk.job.common.util.TimeUtil;
 import com.tencent.bk.job.common.util.Utils;
-import com.tencent.bk.job.common.util.http.ExternalSystemEnum;
-import com.tencent.bk.job.common.util.http.JobHttpSslVerifyConfig;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
@@ -181,29 +179,6 @@ public class BizCmdbClient extends BaseCmdbApiClient implements IBizCmdbClient {
                       }
                   }
             );
-
-    public BizCmdbClient(AppProperties appProperties,
-                         EsbProperties esbProperties,
-                         BkApiGatewayProperties bkApiGatewayProperties,
-                         CmdbConfig cmdbConfig,
-                         String lang,
-                         ThreadPoolExecutor threadPoolExecutor,
-                         ThreadPoolExecutor longTermThreadPoolExecutor,
-                         FlowController flowController,
-                         MeterRegistry meterRegistry) {
-        this(
-            appProperties,
-            esbProperties,
-            bkApiGatewayProperties,
-            cmdbConfig,
-            lang,
-            threadPoolExecutor,
-            longTermThreadPoolExecutor,
-            flowController,
-            meterRegistry,
-            JobHttpSslVerifyConfig.isVerifyEnabled(ExternalSystemEnum.CMDB)
-        );
-    }
 
     public BizCmdbClient(AppProperties appProperties,
                          EsbProperties esbProperties,

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizSetCmdbClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizSetCmdbClient.java
@@ -52,8 +52,6 @@ import com.tencent.bk.job.common.esb.model.EsbReq;
 import com.tencent.bk.job.common.esb.model.EsbResp;
 import com.tencent.bk.job.common.exception.InternalCmdbException;
 import com.tencent.bk.job.common.util.FlowController;
-import com.tencent.bk.job.common.util.http.ExternalSystemEnum;
-import com.tencent.bk.job.common.util.http.JobHttpSslVerifyConfig;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -72,23 +70,6 @@ import java.util.Set;
 @Slf4j
 public class BizSetCmdbClient extends BaseCmdbApiClient implements IBizSetCmdbClient {
 
-
-    public BizSetCmdbClient(AppProperties appProperties,
-                            EsbProperties esbProperties,
-                            BkApiGatewayProperties bkApiGatewayProperties,
-                            CmdbConfig cmdbConfig,
-                            FlowController flowController,
-                            MeterRegistry meterRegistry) {
-        this(
-            appProperties,
-            esbProperties,
-            bkApiGatewayProperties,
-            cmdbConfig,
-            flowController,
-            meterRegistry,
-            JobHttpSslVerifyConfig.isVerifyEnabled(ExternalSystemEnum.CMDB)
-        );
-    }
 
     public BizSetCmdbClient(AppProperties appProperties,
                             EsbProperties esbProperties,

--- a/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizSetCmdbClient.java
+++ b/src/backend/commons/cmdb-sdk/src/main/java/com/tencent/bk/job/common/cc/sdk/BizSetCmdbClient.java
@@ -52,6 +52,8 @@ import com.tencent.bk.job.common.esb.model.EsbReq;
 import com.tencent.bk.job.common.esb.model.EsbResp;
 import com.tencent.bk.job.common.exception.InternalCmdbException;
 import com.tencent.bk.job.common.util.FlowController;
+import com.tencent.bk.job.common.util.http.ExternalSystemEnum;
+import com.tencent.bk.job.common.util.http.JobHttpSslVerifyConfig;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections4.CollectionUtils;
@@ -77,8 +79,34 @@ public class BizSetCmdbClient extends BaseCmdbApiClient implements IBizSetCmdbCl
                             CmdbConfig cmdbConfig,
                             FlowController flowController,
                             MeterRegistry meterRegistry) {
-        super(flowController, appProperties, esbProperties,
-            bkApiGatewayProperties, cmdbConfig, meterRegistry, null);
+        this(
+            appProperties,
+            esbProperties,
+            bkApiGatewayProperties,
+            cmdbConfig,
+            flowController,
+            meterRegistry,
+            JobHttpSslVerifyConfig.isVerifyEnabled(ExternalSystemEnum.CMDB)
+        );
+    }
+
+    public BizSetCmdbClient(AppProperties appProperties,
+                            EsbProperties esbProperties,
+                            BkApiGatewayProperties bkApiGatewayProperties,
+                            CmdbConfig cmdbConfig,
+                            FlowController flowController,
+                            MeterRegistry meterRegistry,
+                            boolean sslVerifyEnabled) {
+        super(
+            flowController,
+            appProperties,
+            esbProperties,
+            bkApiGatewayProperties,
+            cmdbConfig,
+            meterRegistry,
+            null,
+            sslVerifyEnabled
+        );
     }
 
     /**

--- a/src/backend/commons/common-iam/src/main/java/com/tencent/bk/job/common/iam/http/IamHttpClientServiceImpl.java
+++ b/src/backend/commons/common-iam/src/main/java/com/tencent/bk/job/common/iam/http/IamHttpClientServiceImpl.java
@@ -54,10 +54,6 @@ public class IamHttpClientServiceImpl implements HttpClientService {
     private final HttpHelper httpHelper;
     private final IamConfiguration iamConfiguration;
 
-    public IamHttpClientServiceImpl(IamConfiguration iamConfiguration) {
-        this(iamConfiguration, true);
-    }
-
     public IamHttpClientServiceImpl(IamConfiguration iamConfiguration, boolean sslVerifyEnabled) {
         this.iamConfiguration = iamConfiguration;
         this.httpHelper = HttpHelperFactory.getDefaultHttpHelper(sslVerifyEnabled);

--- a/src/backend/commons/common-iam/src/main/java/com/tencent/bk/job/common/iam/service/impl/AuthServiceImpl.java
+++ b/src/backend/commons/common-iam/src/main/java/com/tencent/bk/job/common/iam/service/impl/AuthServiceImpl.java
@@ -80,14 +80,6 @@ public class AuthServiceImpl extends BasicAuthService implements AuthService {
                            IamConfiguration iamConfiguration,
                            EsbProperties esbProperties,
                            MessageI18nService i18nService,
-                           MeterRegistry meterRegistry) {
-        this(authHelper, iamConfiguration, esbProperties, i18nService, meterRegistry, true);
-    }
-
-    public AuthServiceImpl(AuthHelper authHelper,
-                           IamConfiguration iamConfiguration,
-                           EsbProperties esbProperties,
-                           MessageI18nService i18nService,
                            MeterRegistry meterRegistry,
                            boolean sslVerifyEnabled) {
         this.authHelper = authHelper;

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/GseV2ApiClient.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/GseV2ApiClient.java
@@ -49,10 +49,8 @@ import com.tencent.bk.job.common.gse.v2.model.TransferFileRequest;
 import com.tencent.bk.job.common.gse.v2.model.req.ListAgentStateReq;
 import com.tencent.bk.job.common.gse.v2.model.resp.AgentState;
 import com.tencent.bk.job.common.util.StringUtil;
-import com.tencent.bk.job.common.util.http.ExternalSystemEnum;
 import com.tencent.bk.job.common.util.http.HttpHelperFactory;
 import com.tencent.bk.job.common.util.http.JobHttpRequestRetryHandler;
-import com.tencent.bk.job.common.util.http.JobHttpSslVerifyConfig;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
@@ -75,17 +73,6 @@ public class GseV2ApiClient extends BkApiClient implements IGseClient {
     private static final String URI_ASYNC_TERMINATE_EXECUTE_SCRIPT =
         "/api/v2/task/extensions/async_terminate_execute_script";
     private final BkApiAuthorization gseBkApiAuthorization;
-
-    public GseV2ApiClient(MeterRegistry meterRegistry,
-                          AppProperties appProperties,
-                          BkApiGatewayProperties bkApiGatewayProperties) {
-        this(
-            meterRegistry,
-            appProperties,
-            bkApiGatewayProperties,
-            JobHttpSslVerifyConfig.isVerifyEnabled(ExternalSystemEnum.GSE)
-        );
-    }
 
     public GseV2ApiClient(MeterRegistry meterRegistry,
                           AppProperties appProperties,

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/GseV2ApiClient.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/GseV2ApiClient.java
@@ -49,9 +49,9 @@ import com.tencent.bk.job.common.gse.v2.model.TransferFileRequest;
 import com.tencent.bk.job.common.gse.v2.model.req.ListAgentStateReq;
 import com.tencent.bk.job.common.gse.v2.model.resp.AgentState;
 import com.tencent.bk.job.common.util.StringUtil;
+import com.tencent.bk.job.common.util.http.ExternalSystemEnum;
 import com.tencent.bk.job.common.util.http.HttpHelperFactory;
 import com.tencent.bk.job.common.util.http.JobHttpRequestRetryHandler;
-import com.tencent.bk.job.common.util.http.ExternalSystemEnum;
 import com.tencent.bk.job.common.util.http.JobHttpSslVerifyConfig;
 import com.tencent.bk.job.common.util.json.JsonUtils;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -79,6 +79,18 @@ public class GseV2ApiClient extends BkApiClient implements IGseClient {
     public GseV2ApiClient(MeterRegistry meterRegistry,
                           AppProperties appProperties,
                           BkApiGatewayProperties bkApiGatewayProperties) {
+        this(
+            meterRegistry,
+            appProperties,
+            bkApiGatewayProperties,
+            JobHttpSslVerifyConfig.isVerifyEnabled(ExternalSystemEnum.GSE)
+        );
+    }
+
+    public GseV2ApiClient(MeterRegistry meterRegistry,
+                          AppProperties appProperties,
+                          BkApiGatewayProperties bkApiGatewayProperties,
+                          boolean sslVerifyEnabled) {
         super(meterRegistry,
             GseMetricNames.GSE_V2_API_METRICS_NAME_PREFIX,
             bkApiGatewayProperties.getGse().getUrl(),
@@ -91,7 +103,7 @@ public class GseV2ApiClient extends BkApiClient implements IGseClient {
                 60,
                 true,
                 new JobHttpRequestRetryHandler(),
-                JobHttpSslVerifyConfig.isVerifyEnabled(ExternalSystemEnum.GSE)
+                sslVerifyEnabled
             )
         );
         gseBkApiAuthorization = BkApiAuthorization.appAuthorization(appProperties.getCode(), appProperties.getSecret());

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/GseV2AutoConfiguration.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/GseV2AutoConfiguration.java
@@ -27,6 +27,8 @@ package com.tencent.bk.job.common.gse.v2;
 import com.tencent.bk.job.common.esb.config.AppProperties;
 import com.tencent.bk.job.common.esb.config.BkApiGatewayProperties;
 import com.tencent.bk.job.common.gse.config.GseV2Properties;
+import com.tencent.bk.job.common.util.http.ExternalSystemEnum;
+import com.tencent.bk.job.common.util.http.JobHttpSslVerifyProperties;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -44,9 +46,15 @@ public class GseV2AutoConfiguration {
     @Bean("gseV2ApiClient")
     public GseV2ApiClient gseV2ApiClient(MeterRegistry meterRegistry,
                                          AppProperties appProperties,
-                                         BkApiGatewayProperties bkApiGatewayProperties) {
+                                         BkApiGatewayProperties bkApiGatewayProperties,
+                                         JobHttpSslVerifyProperties sslVerifyProperties) {
         log.info("Init gseV2ApiClient");
-        return new GseV2ApiClient(meterRegistry, appProperties, bkApiGatewayProperties);
+        return new GseV2ApiClient(
+            meterRegistry,
+            appProperties,
+            bkApiGatewayProperties,
+            sslVerifyProperties.isVerifyEnabled(ExternalSystemEnum.GSE)
+        );
     }
 
     @ConditionalOnProperty(name = "gseV2.retry.enabled", havingValue = "true")
@@ -54,13 +62,15 @@ public class GseV2AutoConfiguration {
     public GseV2ApiClient retryableGseV2ApiClient(MeterRegistry meterRegistry,
                                                   AppProperties appProperties,
                                                   BkApiGatewayProperties bkApiGatewayProperties,
-                                                  GseV2Properties gseV2Properties) {
+                                                  GseV2Properties gseV2Properties,
+                                                  JobHttpSslVerifyProperties sslVerifyProperties) {
         log.info("Init retryableGseV2ApiClient");
         return new RetryableGseV2ApiClient(
             meterRegistry,
             appProperties,
             bkApiGatewayProperties,
-            gseV2Properties
+            gseV2Properties,
+            sslVerifyProperties.isVerifyEnabled(ExternalSystemEnum.GSE)
         );
     }
 }

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/RetryableGseV2ApiClient.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/RetryableGseV2ApiClient.java
@@ -34,6 +34,8 @@ import com.tencent.bk.job.common.gse.v2.model.ScriptTaskResult;
 import com.tencent.bk.job.common.gse.v2.model.req.ListAgentStateReq;
 import com.tencent.bk.job.common.gse.v2.model.resp.AgentState;
 import com.tencent.bk.job.common.retry.RetryUtils;
+import com.tencent.bk.job.common.util.http.ExternalSystemEnum;
+import com.tencent.bk.job.common.util.http.JobHttpSslVerifyConfig;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 
@@ -59,7 +61,21 @@ public class RetryableGseV2ApiClient extends GseV2ApiClient {
                                    AppProperties appProperties,
                                    BkApiGatewayProperties bkApiGatewayProperties,
                                    GseV2Properties gseV2Properties) {
-        super(meterRegistry, appProperties, bkApiGatewayProperties);
+        this(
+            meterRegistry,
+            appProperties,
+            bkApiGatewayProperties,
+            gseV2Properties,
+            JobHttpSslVerifyConfig.isVerifyEnabled(ExternalSystemEnum.GSE)
+        );
+    }
+
+    public RetryableGseV2ApiClient(MeterRegistry meterRegistry,
+                                   AppProperties appProperties,
+                                   BkApiGatewayProperties bkApiGatewayProperties,
+                                   GseV2Properties gseV2Properties,
+                                   boolean sslVerifyEnabled) {
+        super(meterRegistry, appProperties, bkApiGatewayProperties, sslVerifyEnabled);
         this.maxAttempts = gseV2Properties.getRetry().getMaxAttempts();
         this.intervalSeconds = gseV2Properties.getRetry().getIntervalSeconds();
     }

--- a/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/RetryableGseV2ApiClient.java
+++ b/src/backend/commons/gse-sdk/src/main/java/com/tencent/bk/job/common/gse/v2/RetryableGseV2ApiClient.java
@@ -34,8 +34,6 @@ import com.tencent.bk.job.common.gse.v2.model.ScriptTaskResult;
 import com.tencent.bk.job.common.gse.v2.model.req.ListAgentStateReq;
 import com.tencent.bk.job.common.gse.v2.model.resp.AgentState;
 import com.tencent.bk.job.common.retry.RetryUtils;
-import com.tencent.bk.job.common.util.http.ExternalSystemEnum;
-import com.tencent.bk.job.common.util.http.JobHttpSslVerifyConfig;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 
@@ -56,19 +54,6 @@ public class RetryableGseV2ApiClient extends GseV2ApiClient {
      * 重试间隔（单位：秒）
      */
     private final Integer intervalSeconds;
-
-    public RetryableGseV2ApiClient(MeterRegistry meterRegistry,
-                                   AppProperties appProperties,
-                                   BkApiGatewayProperties bkApiGatewayProperties,
-                                   GseV2Properties gseV2Properties) {
-        this(
-            meterRegistry,
-            appProperties,
-            bkApiGatewayProperties,
-            gseV2Properties,
-            JobHttpSslVerifyConfig.isVerifyEnabled(ExternalSystemEnum.GSE)
-        );
-    }
 
     public RetryableGseV2ApiClient(MeterRegistry meterRegistry,
                                    AppProperties appProperties,

--- a/src/backend/commons/notice-sdk/src/main/java/com/tencent/bk/job/common/notice/impl/BkNoticeClient.java
+++ b/src/backend/commons/notice-sdk/src/main/java/com/tencent/bk/job/common/notice/impl/BkNoticeClient.java
@@ -41,10 +41,8 @@ import com.tencent.bk.job.common.notice.IBkNoticeClient;
 import com.tencent.bk.job.common.notice.exception.BkNoticeException;
 import com.tencent.bk.job.common.notice.model.AnnouncementDTO;
 import com.tencent.bk.job.common.notice.model.BkNoticeApp;
-import com.tencent.bk.job.common.util.http.ExternalSystemEnum;
 import com.tencent.bk.job.common.util.http.HttpHelperFactory;
 import com.tencent.bk.job.common.util.http.HttpMetricUtil;
-import com.tencent.bk.job.common.util.http.JobHttpSslVerifyConfig;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import org.apache.commons.lang3.StringUtils;
@@ -60,13 +58,6 @@ public class BkNoticeClient extends BkApiClient implements IBkNoticeClient {
 
     private final AppProperties appProperties;
     private final BkApiAuthorization authorization;
-
-    public BkNoticeClient(MeterRegistry meterRegistry,
-                          AppProperties appProperties,
-                          BkApiGatewayProperties bkApiGatewayProperties) {
-        this(meterRegistry, appProperties, bkApiGatewayProperties,
-            JobHttpSslVerifyConfig.isVerifyEnabled(ExternalSystemEnum.BK_NOTICE));
-    }
 
     public BkNoticeClient(MeterRegistry meterRegistry,
                           AppProperties appProperties,

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/cmsi/CmsiApiClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/cmsi/CmsiApiClient.java
@@ -41,10 +41,8 @@ import com.tencent.bk.job.common.model.error.ErrorType;
 import com.tencent.bk.job.common.paas.exception.PaasException;
 import com.tencent.bk.job.common.paas.model.EsbNotifyChannelDTO;
 import com.tencent.bk.job.common.paas.model.PostSendMsgReq;
-import com.tencent.bk.job.common.util.http.ExternalSystemEnum;
 import com.tencent.bk.job.common.util.http.HttpHelperFactory;
 import com.tencent.bk.job.common.util.http.HttpMetricUtil;
-import com.tencent.bk.job.common.util.http.JobHttpSslVerifyConfig;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import lombok.extern.slf4j.Slf4j;
@@ -65,13 +63,6 @@ public class CmsiApiClient extends BkApiClient {
     private static final String API_POST_SEND_MSG = "/api/c/compapi/cmsi/send_msg/";
 
     private final BkApiAuthorization authorization;
-
-    public CmsiApiClient(EsbProperties esbProperties,
-                         AppProperties appProperties,
-                         MeterRegistry meterRegistry) {
-        this(esbProperties, appProperties, meterRegistry,
-            JobHttpSslVerifyConfig.isVerifyEnabled(ExternalSystemEnum.BK_CMSI));
-    }
 
     public CmsiApiClient(EsbProperties esbProperties,
                          AppProperties appProperties,

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/CustomLoginClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/CustomLoginClient.java
@@ -51,10 +51,6 @@ public class CustomLoginClient implements ILoginClient {
     private final String customLoginApiUrl;
     private final HttpHelper httpHelper;
 
-    public CustomLoginClient(String customLoginApiUrl) {
-        this(customLoginApiUrl, true);
-    }
-
     public CustomLoginClient(String customLoginApiUrl, boolean sslVerifyEnabled) {
         if (customLoginApiUrl.endsWith("/")) {
             this.customLoginApiUrl = customLoginApiUrl.substring(0, customLoginApiUrl.length() - 1);

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/StandardLoginClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/login/StandardLoginClient.java
@@ -60,10 +60,6 @@ public class StandardLoginClient extends BkApiClient implements ILoginClient {
 
     private final AppProperties appProperties;
 
-    public StandardLoginClient(EsbProperties esbProperties, AppProperties appProperties, MeterRegistry meterRegistry) {
-        this(esbProperties, appProperties, meterRegistry, true);
-    }
-
     public StandardLoginClient(EsbProperties esbProperties,
                                AppProperties appProperties,
                                MeterRegistry meterRegistry,

--- a/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/user/UserMgrApiClient.java
+++ b/src/backend/commons/paas-sdk/src/main/java/com/tencent/bk/job/common/paas/user/UserMgrApiClient.java
@@ -66,12 +66,6 @@ public class UserMgrApiClient extends BkApiClient {
 
     public UserMgrApiClient(EsbProperties esbProperties,
                             AppProperties appProperties,
-                            MeterRegistry meterRegistry) {
-        this(esbProperties, appProperties, meterRegistry, true);
-    }
-
-    public UserMgrApiClient(EsbProperties esbProperties,
-                            AppProperties appProperties,
                             MeterRegistry meterRegistry,
                             boolean sslVerifyEnabled) {
         super(meterRegistry,


### PR DESCRIPTION
* 原因
CMDB等客户端在 Spring Bean 初始化时通过 JobHttpSslVerifyConfig 静态入口读取证书校验配置，由于 Bean 初始化顺序不确定，客户端可能在静态配置完成赋值前创建，从而读取到默认值true。

* 方案
Spring 自动配置直接从 JobHttpSslVerifyProperties 获取最终配置，并通过构造方法显式传入客户端，消除初始化时序依赖。



